### PR TITLE
feat: Add --network flag to Go CLI for network selection

### DIFF
--- a/internal/cmd/debug.go
+++ b/internal/cmd/debug.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/dotandev/hintents/internal/rpc"
+	"github.com/spf13/cobra"
+)
+
+var debugCmd = &cobra.Command{
+	Use:   "debug <transaction-hash>",
+	Short: "Debug a failed Soroban transaction",
+	Long: `Fetch a transaction envelope from the Stellar network and prepare it for simulation.
+
+Example:
+  erst debug 5c0a1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab
+  erst --network testnet debug <tx-hash>`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		txHash := args[0]
+
+		// Create RPC client with the selected network
+		client := rpc.NewClient(rpc.Network(NetworkFlag))
+
+		fmt.Printf("Debugging transaction: %s\n", txHash)
+		fmt.Printf("Using network: %s\n", NetworkFlag)
+		fmt.Printf("Horizon URL: %s\n", client.Horizon.HorizonURL)
+
+		// Fetch transaction (context would be provided by actual implementation)
+		// txResp, err := client.GetTransaction(context.Background(), txHash)
+		// if err != nil {
+		// 	return err
+		// }
+		// fmt.Printf("Transaction found with envelope XDR size: %d bytes\n", len(txResp.EnvelopeXdr))
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(debugCmd)
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Network types for Stellar
+type Network string
+
+const (
+	Testnet   Network = "testnet"
+	Mainnet   Network = "mainnet"
+	Futurenet Network = "futurenet"
+)
+
+// Global flag variables
+var (
+	NetworkFlag string
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "erst",
+	Short: "Erst - Soroban Error Decoder & Debugger",
+	Long: `Erst is a specialized developer tool for the Stellar network,
+designed to solve the "black box" debugging experience on Soroban.
+
+Use the --network flag to specify which Stellar network to use.`,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// Validate network flag
+		if NetworkFlag != "" {
+			switch Network(NetworkFlag) {
+			case Testnet, Mainnet, Futurenet:
+				// Valid network
+			default:
+				return fmt.Errorf("invalid network: %s. Must be one of: testnet, mainnet, futurenet", NetworkFlag)
+			}
+		}
+		return nil
+	},
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	// Add the --network flag to the root command
+	rootCmd.PersistentFlags().StringVar(
+		&NetworkFlag,
+		"network",
+		string(Mainnet),
+		"Stellar network to use (testnet, mainnet, futurenet)",
+	)
+}

--- a/internal/rpc/client.go
+++ b/internal/rpc/client.go
@@ -3,19 +3,73 @@ package rpc
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/stellar/go/clients/horizonclient"
+)
+
+// Network types for Stellar
+type Network string
+
+const (
+	Testnet   Network = "testnet"
+	Mainnet   Network = "mainnet"
+	Futurenet Network = "futurenet"
+)
+
+// Horizon URLs for each network
+const (
+	TestnetHorizonURL   = "https://horizon-testnet.stellar.org/"
+	MainnetHorizonURL   = "https://horizon.stellar.org/"
+	FuturenetHorizonURL = "https://horizon-futurenet.stellar.org/"
 )
 
 // Client handles interactions with the Stellar Network
 type Client struct {
 	Horizon *horizonclient.Client
+	Network Network
 }
 
-// NewClient creates a new RPC client (defaults to Public Network for now)
-func NewClient() *Client {
+// NewClient creates a new RPC client with the specified network
+// If network is empty, defaults to Mainnet
+func NewClient(net Network) *Client {
+	if net == "" {
+		net = Mainnet
+	}
+
+	var horizonClient *horizonclient.Client
+
+	switch net {
+	case Testnet:
+		horizonClient = horizonclient.DefaultTestNetClient
+	case Futurenet:
+		// Create a futurenet client (not available as default)
+		horizonClient = &horizonclient.Client{
+			HorizonURL: FuturenetHorizonURL,
+			HTTP:       http.DefaultClient,
+		}
+	case Mainnet:
+		fallthrough
+	default:
+		horizonClient = horizonclient.DefaultPublicNetClient
+	}
+
 	return &Client{
-		Horizon: horizonclient.DefaultPublicNetClient,
+		Horizon: horizonClient,
+		Network: net,
+	}
+}
+
+// NewClientWithURL creates a new RPC client with a custom Horizon URL
+func NewClientWithURL(url string, net Network) *Client {
+	horizonClient := &horizonclient.Client{
+		HorizonURL: url,
+		HTTP:       http.DefaultClient,
+	}
+
+	return &Client{
+		Horizon: horizonClient,
+		Network: net,
 	}
 }
 


### PR DESCRIPTION
Closes #25

## Description

Implements the `--network` flag for the Go CLI to support network selection (testnet, mainnet, futurenet).

This resolves #25 by allowing users to specify which Stellar network to target.