### PR TITLE
feat: add structured logging to cli

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "kilocode.kilo-code"
+    ]
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,33 @@
+package logger
+
+import (
+	"io"
+	"log/slog"
+	"os"
+)
+
+// Logger is the global logger instance
+var Logger *slog.Logger
+
+// Level is the current log level
+var Level = new(slog.LevelVar)
+
+// Init initializes the logger with the specified level
+func Init(level slog.Level, output io.Writer) {
+	if output == nil {
+		output = os.Stderr
+	}
+
+	handler := slog.NewJSONHandler(output, &slog.HandlerOptions{
+		Level:     Level,
+		AddSource: true,
+	})
+
+	Logger = slog.New(handler)
+	Level.Set(level)
+}
+
+// SetLevel changes the log level programmatically
+func SetLevel(level slog.Level) {
+	Level.Set(level)
+}

--- a/internal/rpc/client.go
+++ b/internal/rpc/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/dotandev/hintents/internal/logger"
 	"github.com/stellar/go/clients/horizonclient"
 )
 
@@ -28,10 +29,15 @@ type TransactionResponse struct {
 
 // GetTransaction fetches the transaction details and full XDR data
 func (c *Client) GetTransaction(ctx context.Context, hash string) (*TransactionResponse, error) {
+	logger.Logger.Debug("Fetching transaction details", "hash", hash)
+
 	tx, err := c.Horizon.TransactionDetail(hash)
 	if err != nil {
+		logger.Logger.Error("Failed to fetch transaction", "hash", hash, "error", err)
 		return nil, fmt.Errorf("failed to fetch transaction: %w", err)
 	}
+
+	logger.Logger.Info("Transaction fetched successfully", "hash", hash, "envelope_size", len(tx.EnvelopeXdr))
 
 	return &TransactionResponse{
 		EnvelopeXdr:   tx.EnvelopeXdr,


### PR DESCRIPTION
## Description

This PR implements structured logging throughout the CLI using Go 1.21's built-in `log/slog` package, replacing all ad-hoc `fmt.Print*` calls. This improves debuggability, output control, and enables proper log level filtering which closes #42 


## Changes

### Core Implementation
- **New logger package** (`internal/logger/logger.go`): Centralized slog initialization with JSON formatting
- **Root command enhancement** (`cmd/erst/main.go`): 
  - Added persistent `--verbose` / `-v` flag
  - Implements level switching: INFO (default) → DEBUG (when verbose)
  - Flag processed in `PersistentPreRun` before subcommand execution

### Debug Command Updates (`cmd/erst/debug.go`)
- Removed `fmt` package dependency
- **Replaced 4 `fmt.Printf` calls** with structured logger methods:
  - Transaction status → `logger.Info("simulation completed", "status", ...)`
  - Error output → `logger.Error("simulation error", "error_message", ...)`
  - Events/Logs → `logger.Debug("simulation events/logs", ...)`
- **Added DEBUG-level logging** for raw RPC responses (XDR data)

## Key Features

✅ **Structured Logging**: Key-value pairs for machine-readable output  
✅ **Log Levels**: INFO (user-facing), DEBUG (raw RPC, internals), ERROR (failures)  
✅ **Verbose Flag**: `--verbose` or `-v` toggles DEBUG level  
✅ **No External Dependencies**: Uses only Go stdlib `log/slog`  
✅ **Clean Output**: INFO level remains human-readable; DEBUG provides context  

## Testing

```bash
# Default (INFO level only)
go run ./cmd/erst debug <transaction-hash>

# Verbose (shows DEBUG + INFO)
go run ./cmd/erst debug -v <transaction-hash>

# Verify compilation
go build ./cmd/erst/