### PR TITLE
chore(community): add github issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: "[BUG] "
+labels: bug
+assignees: ''
+---
+
+## Description
+A clear and concise description of what the bug is.
+
+## Expected Behavior
+What should happen?
+
+## Actual Behavior
+What actually happens instead?
+
+## Steps to Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '...'
+3. See error
+
+## Environment
+- OS: [e.g. macOS 12.3, Windows 11]
+- Go Version: [e.g. 1.20]
+- Rust Version (if applicable): [e.g. 1.70]
+
+## Additional Context
+Add any other context about the problem here (logs, error messages, screenshots, etc.).
+
+## Possible Solution
+If you have suggestions on how to fix this, please describe them here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: "[FEATURE] "
+labels: enhancement
+assignees: ''
+---
+
+## Summary
+A clear and concise description of the feature you want to propose.
+
+## Motivation
+Why do you need this feature? What problem does it solve?
+
+## Proposed Solution
+Describe how you imagine this feature working.
+
+## Alternative Solutions
+Have you considered any alternatives? Describe them here.
+
+## Additional Context
+Add any other context, diagrams, or examples about the feature request here.
+
+## Acceptance Criteria
+How would you verify that this feature is working correctly?
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,51 @@
+## Description
+A clear and concise description of what this PR does.
+
+## Related Issue
+Fixes #(issue number) or Relates to #(issue number)
+
+## Type of Change
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+- [ ] Performance improvement
+- [ ] Refactoring
+
+## Changes Made
+Describe the specific changes made in this PR:
+- Change 1
+- Change 2
+- Change 3
+
+## Testing
+Describe the tests you ran and how to reproduce them:
+- [ ] Unit tests added/updated
+- [ ] Integration tests added/updated
+- [ ] Manual testing performed (describe below)
+
+Test steps:
+1. 
+2. 
+3. 
+
+## Documentation
+- [ ] Updated README.md if needed
+- [ ] Updated docs/ if needed
+- [ ] Added/updated code comments for complex logic
+- [ ] CONTRIBUTING.md updated if needed
+
+## Checklist
+- [ ] My code follows the project's code style
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests passed locally with my changes
+
+## Screenshots/Logs (if applicable)
+Add any relevant screenshots or logs here.
+
+## Deployment Notes
+Any special instructions for deploying this change?


### PR DESCRIPTION
# chore(community): add GitHub issue and PR templates

## Description
Standardizes community contributions by adding GitHub Issue and Pull Request templates to the repository.

## Implementation Details
- Added `.github/ISSUE_TEMPLATE/bug_report.md` with sections for "Expected" vs "Actual" behavior.
- Added `.github/ISSUE_TEMPLATE/feature_request.md` for feature proposals.
- Added `.github/pull_request_template.md` including a checklist for tests and documentation.

## Testing
- Verified that the templates appear when creating new issues or PRs in a forked repository.

## Why
Ensures that bug reports, feature requests, and PRs contain all necessary information and follow a consistent format.

This PR closes #92 