### PR TITLE
feat: add spellcheck job to CI with allowlist for specific words

### DIFF
--- a/.github/spelling/allow.txt
+++ b/.github/spelling/allow.txt
@@ -1,0 +1,3 @@
+Soroban
+XDR
+ERST

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: "1.21"
           cache: true
           cache-dependency-path: go.sum
 
@@ -50,6 +50,31 @@ jobs:
 
       - name: Build
         run: go build -v ./...
+
+  # ============================================
+  # Docs - Spell Check
+  # ============================================
+  docs-spellcheck:
+    name: Docs Spellcheck
+    runs-on: ubuntu-latest
+    # Validation:
+    # - Introduce a typo in any .md file to confirm this job fails.
+    # - Ensure allowlist words (Soroban, XDR, ERST) pass.
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install misspell
+        run: |
+          curl -L https://raw.githubusercontent.com/client9/misspell/master/install-misspell.sh | sh -s -- -b "$HOME/bin"
+          echo "$HOME/bin" >> $GITHUB_PATH
+
+      - name: Run spellcheck
+        run: |
+          set -euo pipefail
+          IGNORE_WORDS=$(paste -sd, .github/spelling/allow.txt)
+          find . -name '*.md' -print0 | xargs -0 misspell -error -i "$IGNORE_WORDS"
 
   # ============================================
   # Rust Simulator - Lint, Build & Test


### PR DESCRIPTION
Closes #115 
This pull request introduces a new documentation spellcheck workflow to the CI pipeline and updates the spelling allowlist to include project-specific terms. The main changes are:

**CI Workflow Enhancements:**

* Added a new `docs-spellcheck` job in `.github/workflows/ci.yml` to automatically check Markdown documentation files for spelling errors using the `misspell` tool. This job uses `.github/spelling/allow.txt` to ignore certain project-specific words.
* Updated the Go setup step in the CI workflow to use double quotes for the `go-version` value for consistency, though the version number remains unchanged.

**Spelling Allowlist Updates:**

* Added `Soroban`, `XDR`, and `ERST` to `.github/spelling/allow.txt` to prevent these project-specific terms from being flagged as spelling errors during documentation spellcheck.