### PR TITLE
refactor(sim): implement builder pattern for simulation requests

### DIFF
--- a/docs/SIMULATION_REQUEST_BUILDER.md
+++ b/docs/SIMULATION_REQUEST_BUILDER.md
@@ -1,0 +1,272 @@
+# SimulationRequest Builder Pattern
+
+This document explains the builder pattern implementation for `SimulationRequest` objects in the erst simulator package.
+
+## Overview
+
+The `SimulationRequestBuilder` provides a fluent, chainable interface for constructing `SimulationRequest` objects. This pattern makes the code more readable, less error-prone, and provides built-in validation.
+
+## Why Use the Builder Pattern?
+
+### Before (Direct Struct Initialization)
+
+```go
+// Error-prone: easy to forget required fields or make mistakes
+req := &simulator.SimulationRequest{
+    EnvelopeXdr:   txResp.EnvelopeXdr,
+    ResultMetaXdr: txResp.ResultMetaXdr,
+    LedgerEntries: nil, // TODO: fetch ledger entries if needed
+}
+```
+
+**Problems:**
+- No validation until runtime
+- Easy to forget required fields
+- No clear indication of what's required vs optional
+- Difficult to read with many fields
+
+### After (Builder Pattern)
+
+```go
+// Clear, validated, and self-documenting
+req, err := simulator.NewSimulationRequestBuilder().
+    WithEnvelopeXDR(txResp.EnvelopeXdr).
+    WithResultMetaXDR(txResp.ResultMetaXdr).
+    Build()
+
+if err != nil {
+    return fmt.Errorf("invalid simulation request: %w", err)
+}
+```
+
+**Benefits:**
+- ✅ Validation at build time
+- ✅ Clear, readable method names
+- ✅ Self-documenting code
+- ✅ Prevents invalid states
+- ✅ Method chaining for fluent API
+
+## Basic Usage
+
+### Creating a Simple Request
+
+```go
+req, err := simulator.NewSimulationRequestBuilder().
+    WithEnvelopeXDR("AAAAAgAAAACE...").
+    WithResultMetaXDR("AAAAAQAAAAA...").
+    Build()
+
+if err != nil {
+    log.Fatalf("Failed to build request: %v", err)
+}
+```
+
+### Adding Ledger Entries
+
+```go
+// Add entries one at a time
+req, err := simulator.NewSimulationRequestBuilder().
+    WithEnvelopeXDR("AAAAAgAAAACE...").
+    WithResultMetaXDR("AAAAAQAAAAA...").
+    WithLedgerEntry("key1", "value1").
+    WithLedgerEntry("key2", "value2").
+    Build()
+```
+
+### Bulk Ledger Entries
+
+```go
+entries := map[string]string{
+    "contract_key_1": "contract_value_1",
+    "contract_key_2": "contract_value_2",
+}
+
+req, err := simulator.NewSimulationRequestBuilder().
+    WithEnvelopeXDR("AAAAAgAAAACE...").
+    WithResultMetaXDR("AAAAAQAAAAA...").
+    WithLedgerEntries(entries).
+    Build()
+```
+
+## API Reference
+
+### Constructor
+
+#### `NewSimulationRequestBuilder() *SimulationRequestBuilder`
+
+Creates a new builder instance with empty fields and an empty ledger entries map.
+
+### Builder Methods (Chainable)
+
+All builder methods return `*SimulationRequestBuilder` for method chaining.
+
+#### `WithEnvelopeXDR(xdr string) *SimulationRequestBuilder`
+
+Sets the XDR encoded TransactionEnvelope. **Required field.**
+
+#### `WithResultMetaXDR(xdr string) *SimulationRequestBuilder`
+
+Sets the XDR encoded TransactionResultMeta. **Required field.**
+
+#### `WithLedgerEntry(key, value string) *SimulationRequestBuilder`
+
+Adds a single ledger entry. Both key and value must be non-empty.
+
+#### `WithLedgerEntries(entries map[string]string) *SimulationRequestBuilder`
+
+Sets multiple ledger entries at once. Replaces any previously set entries. Passing `nil` clears all entries.
+
+#### `Reset() *SimulationRequestBuilder`
+
+Clears all fields and errors, allowing the builder to be reused.
+
+### Terminal Methods
+
+#### `Build() (*SimulationRequest, error)`
+
+Constructs and validates the final `SimulationRequest`. Returns an error if:
+- Required fields are missing (EnvelopeXDR or ResultMetaXDR)
+- Validation errors were collected during building
+- Ledger entry keys or values are empty
+
+#### `MustBuild() *SimulationRequest`
+
+Like `Build()` but panics if there's an error. Use only when you're certain the request is valid (e.g., in tests with known good data).
+
+## Validation
+
+The builder performs validation at multiple stages:
+
+### During Building
+
+- Empty ledger entry keys are rejected
+- Empty ledger entry values are rejected
+- Errors are collected and reported at `Build()` time
+
+### At Build Time
+
+- Envelope XDR is required
+- Result Meta XDR is required
+- All collected errors are checked
+
+### Example Error Handling
+
+```go
+req, err := simulator.NewSimulationRequestBuilder().
+    WithEnvelopeXDR("").  // Invalid: empty
+    WithResultMetaXDR("valid_xdr").
+    Build()
+
+if err != nil {
+    // Error: envelope XDR is required
+    log.Printf("Validation failed: %v", err)
+}
+```
+
+## Advanced Usage
+
+### Reusing a Builder
+
+```go
+builder := simulator.NewSimulationRequestBuilder()
+
+// Build first request
+req1, _ := builder.
+    WithEnvelopeXDR("envelope1").
+    WithResultMetaXDR("result1").
+    Build()
+
+// Reset and build second request
+req2, _ := builder.
+    Reset().
+    WithEnvelopeXDR("envelope2").
+    WithResultMetaXDR("result2").
+    Build()
+```
+
+### Conditional Building
+
+```go
+builder := simulator.NewSimulationRequestBuilder().
+    WithEnvelopeXDR(txResp.EnvelopeXdr).
+    WithResultMetaXDR(txResp.ResultMetaXdr)
+
+// Conditionally add ledger entries
+if needsLedgerEntries {
+    builder.WithLedgerEntries(fetchLedgerEntries())
+}
+
+req, err := builder.Build()
+```
+
+### Using MustBuild in Tests
+
+```go
+func TestSimulation(t *testing.T) {
+    // Safe to use MustBuild with known valid data
+    req := simulator.NewSimulationRequestBuilder().
+        WithEnvelopeXDR("valid_test_envelope").
+        WithResultMetaXDR("valid_test_result").
+        MustBuild()
+    
+    // Test with req...
+}
+```
+
+## Migration Guide
+
+### Migrating Existing Code
+
+**Before:**
+```go
+simReq := &simulator.SimulationRequest{
+    EnvelopeXdr:   txResp.EnvelopeXdr,
+    ResultMetaXdr: txResp.ResultMetaXdr,
+    LedgerEntries: nil,
+}
+```
+
+**After:**
+```go
+simReq, err := simulator.NewSimulationRequestBuilder().
+    WithEnvelopeXDR(txResp.EnvelopeXdr).
+    WithResultMetaXDR(txResp.ResultMetaXdr).
+    Build()
+
+if err != nil {
+    return fmt.Errorf("failed to build simulation request: %w", err)
+}
+```
+
+## Best Practices
+
+1. **Always check errors from `Build()`** - Don't ignore validation errors
+2. **Use `MustBuild()` only in tests** - It panics on error, which is fine for tests but not production code
+3. **Reuse builders when building multiple similar requests** - Use `Reset()` to clear state
+4. **Add ledger entries individually for clarity** - Unless you have a map already prepared
+5. **Let the builder validate** - Don't pre-validate fields yourself
+
+## Testing
+
+The builder includes comprehensive tests covering:
+- Basic usage
+- Method chaining
+- Validation (missing fields, empty values)
+- Error handling
+- Builder reuse with `Reset()`
+- `MustBuild()` panic behavior
+
+Run tests with:
+```bash
+go test ./internal/simulator/... -v
+```
+
+## Future Enhancements
+
+Potential improvements to consider:
+
+- **Validation hooks**: Allow custom validation functions
+- **Default values**: Set sensible defaults for optional fields
+- **Cloning**: Add a `Clone()` method to copy builder state
+- **Partial builds**: Support building incomplete requests for testing
+- **JSON support**: Direct JSON serialization from builder

--- a/internal/simulator/builder.go
+++ b/internal/simulator/builder.go
@@ -1,0 +1,136 @@
+// Copyright 2025 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package simulator
+
+import (
+	"fmt"
+)
+
+// SimulationRequestBuilder provides a fluent interface for building SimulationRequest objects.
+// It uses the builder pattern to make request construction more readable and less error-prone.
+//
+// Example usage:
+//
+//	req, err := NewSimulationRequestBuilder().
+//		WithEnvelopeXDR("AAAAAgAAAA...").
+//		WithResultMetaXDR("AAAAAQAAA...").
+//		WithLedgerEntry("key1", "value1").
+//		Build()
+type SimulationRequestBuilder struct {
+	envelopeXdr   string
+	resultMetaXdr string
+	ledgerEntries map[string]string
+	errors        []string
+}
+
+// NewSimulationRequestBuilder creates a new builder instance.
+func NewSimulationRequestBuilder() *SimulationRequestBuilder {
+	return &SimulationRequestBuilder{
+		ledgerEntries: make(map[string]string),
+		errors:        make([]string, 0),
+	}
+}
+
+// WithEnvelopeXDR sets the XDR encoded TransactionEnvelope.
+// This is a required field for simulation.
+func (b *SimulationRequestBuilder) WithEnvelopeXDR(xdr string) *SimulationRequestBuilder {
+	b.envelopeXdr = xdr
+	return b
+}
+
+// WithResultMetaXDR sets the XDR encoded TransactionResultMeta.
+// This contains historical data needed for replay.
+func (b *SimulationRequestBuilder) WithResultMetaXDR(xdr string) *SimulationRequestBuilder {
+	b.resultMetaXdr = xdr
+	return b
+}
+
+// WithLedgerEntry adds a single ledger entry to the snapshot.
+// The key and value should both be XDR encoded.
+func (b *SimulationRequestBuilder) WithLedgerEntry(key, value string) *SimulationRequestBuilder {
+	if key == "" {
+		b.errors = append(b.errors, "ledger entry key cannot be empty")
+		return b
+	}
+	if value == "" {
+		b.errors = append(b.errors, fmt.Sprintf("ledger entry value for key '%s' cannot be empty", key))
+		return b
+	}
+	b.ledgerEntries[key] = value
+	return b
+}
+
+// WithLedgerEntries sets multiple ledger entries at once.
+// This replaces any previously set ledger entries.
+func (b *SimulationRequestBuilder) WithLedgerEntries(entries map[string]string) *SimulationRequestBuilder {
+	if entries == nil {
+		b.ledgerEntries = make(map[string]string)
+		return b
+	}
+
+	// Validate entries
+	for key, value := range entries {
+		if key == "" {
+			b.errors = append(b.errors, "ledger entry key cannot be empty")
+			continue
+		}
+		if value == "" {
+			b.errors = append(b.errors, fmt.Sprintf("ledger entry value for key '%s' cannot be empty", key))
+			continue
+		}
+	}
+
+	b.ledgerEntries = entries
+	return b
+}
+
+// Build constructs and validates the final SimulationRequest.
+// Returns an error if required fields are missing or validation fails.
+func (b *SimulationRequestBuilder) Build() (*SimulationRequest, error) {
+	// Check for any errors collected during building
+	if len(b.errors) > 0 {
+		return nil, fmt.Errorf("validation errors: %v", b.errors)
+	}
+
+	// Validate required fields
+	if b.envelopeXdr == "" {
+		return nil, fmt.Errorf("envelope XDR is required")
+	}
+
+	if b.resultMetaXdr == "" {
+		return nil, fmt.Errorf("result meta XDR is required")
+	}
+
+	// Build the request
+	req := &SimulationRequest{
+		EnvelopeXdr:   b.envelopeXdr,
+		ResultMetaXdr: b.resultMetaXdr,
+	}
+
+	// Only set ledger entries if there are any
+	if len(b.ledgerEntries) > 0 {
+		req.LedgerEntries = b.ledgerEntries
+	}
+
+	return req, nil
+}
+
+// MustBuild is like Build but panics if there's an error.
+// Use this only when you're certain the request is valid (e.g., in tests with known good data).
+func (b *SimulationRequestBuilder) MustBuild() *SimulationRequest {
+	req, err := b.Build()
+	if err != nil {
+		panic(fmt.Sprintf("failed to build simulation request: %v", err))
+	}
+	return req
+}
+
+// Reset clears all fields and errors, allowing the builder to be reused.
+func (b *SimulationRequestBuilder) Reset() *SimulationRequestBuilder {
+	b.envelopeXdr = ""
+	b.resultMetaXdr = ""
+	b.ledgerEntries = make(map[string]string)
+	b.errors = make([]string, 0)
+	return b
+}

--- a/internal/simulator/builder_test.go
+++ b/internal/simulator/builder_test.go
@@ -1,0 +1,255 @@
+// Copyright 2025 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package simulator
+
+import (
+	"testing"
+)
+
+func TestSimulationRequestBuilder_Basic(t *testing.T) {
+	builder := NewSimulationRequestBuilder()
+
+	req, err := builder.
+		WithEnvelopeXDR("envelope_xdr_data").
+		WithResultMetaXDR("result_meta_xdr_data").
+		Build()
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if req.EnvelopeXdr != "envelope_xdr_data" {
+		t.Errorf("expected EnvelopeXdr to be 'envelope_xdr_data', got: %s", req.EnvelopeXdr)
+	}
+
+	if req.ResultMetaXdr != "result_meta_xdr_data" {
+		t.Errorf("expected ResultMetaXdr to be 'result_meta_xdr_data', got: %s", req.ResultMetaXdr)
+	}
+
+	if req.LedgerEntries != nil {
+		t.Errorf("expected LedgerEntries to be nil, got: %v", req.LedgerEntries)
+	}
+}
+
+func TestSimulationRequestBuilder_WithLedgerEntry(t *testing.T) {
+	builder := NewSimulationRequestBuilder()
+
+	req, err := builder.
+		WithEnvelopeXDR("envelope").
+		WithResultMetaXDR("result").
+		WithLedgerEntry("key1", "value1").
+		WithLedgerEntry("key2", "value2").
+		Build()
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if len(req.LedgerEntries) != 2 {
+		t.Errorf("expected 2 ledger entries, got: %d", len(req.LedgerEntries))
+	}
+
+	if req.LedgerEntries["key1"] != "value1" {
+		t.Errorf("expected ledger entry 'key1' to be 'value1', got: %s", req.LedgerEntries["key1"])
+	}
+
+	if req.LedgerEntries["key2"] != "value2" {
+		t.Errorf("expected ledger entry 'key2' to be 'value2', got: %s", req.LedgerEntries["key2"])
+	}
+}
+
+func TestSimulationRequestBuilder_WithLedgerEntries(t *testing.T) {
+	builder := NewSimulationRequestBuilder()
+
+	entries := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3",
+	}
+
+	req, err := builder.
+		WithEnvelopeXDR("envelope").
+		WithResultMetaXDR("result").
+		WithLedgerEntries(entries).
+		Build()
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if len(req.LedgerEntries) != 3 {
+		t.Errorf("expected 3 ledger entries, got: %d", len(req.LedgerEntries))
+	}
+
+	for key, expectedValue := range entries {
+		if actualValue, ok := req.LedgerEntries[key]; !ok {
+			t.Errorf("expected ledger entry '%s' to exist", key)
+		} else if actualValue != expectedValue {
+			t.Errorf("expected ledger entry '%s' to be '%s', got: %s", key, expectedValue, actualValue)
+		}
+	}
+}
+
+func TestSimulationRequestBuilder_MissingEnvelopeXDR(t *testing.T) {
+	builder := NewSimulationRequestBuilder()
+
+	_, err := builder.
+		WithResultMetaXDR("result").
+		Build()
+
+	if err == nil {
+		t.Fatal("expected error for missing envelope XDR, got nil")
+	}
+
+	expectedError := "envelope XDR is required"
+	if err.Error() != expectedError {
+		t.Errorf("expected error '%s', got: %v", expectedError, err)
+	}
+}
+
+func TestSimulationRequestBuilder_MissingResultMetaXDR(t *testing.T) {
+	builder := NewSimulationRequestBuilder()
+
+	_, err := builder.
+		WithEnvelopeXDR("envelope").
+		Build()
+
+	if err == nil {
+		t.Fatal("expected error for missing result meta XDR, got nil")
+	}
+
+	expectedError := "result meta XDR is required"
+	if err.Error() != expectedError {
+		t.Errorf("expected error '%s', got: %v", expectedError, err)
+	}
+}
+
+func TestSimulationRequestBuilder_EmptyLedgerEntryKey(t *testing.T) {
+	builder := NewSimulationRequestBuilder()
+
+	_, err := builder.
+		WithEnvelopeXDR("envelope").
+		WithResultMetaXDR("result").
+		WithLedgerEntry("", "value").
+		Build()
+
+	if err == nil {
+		t.Fatal("expected error for empty ledger entry key, got nil")
+	}
+}
+
+func TestSimulationRequestBuilder_EmptyLedgerEntryValue(t *testing.T) {
+	builder := NewSimulationRequestBuilder()
+
+	_, err := builder.
+		WithEnvelopeXDR("envelope").
+		WithResultMetaXDR("result").
+		WithLedgerEntry("key", "").
+		Build()
+
+	if err == nil {
+		t.Fatal("expected error for empty ledger entry value, got nil")
+	}
+}
+
+func TestSimulationRequestBuilder_MustBuild_Success(t *testing.T) {
+	builder := NewSimulationRequestBuilder()
+
+	// Should not panic
+	req := builder.
+		WithEnvelopeXDR("envelope").
+		WithResultMetaXDR("result").
+		MustBuild()
+
+	if req == nil {
+		t.Fatal("expected non-nil request")
+	}
+}
+
+func TestSimulationRequestBuilder_MustBuild_Panic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected MustBuild to panic, but it didn't")
+		}
+	}()
+
+	builder := NewSimulationRequestBuilder()
+
+	// Should panic due to missing required fields
+	builder.MustBuild()
+}
+
+func TestSimulationRequestBuilder_Reset(t *testing.T) {
+	builder := NewSimulationRequestBuilder()
+
+	// Build first request
+	req1, err := builder.
+		WithEnvelopeXDR("envelope1").
+		WithResultMetaXDR("result1").
+		WithLedgerEntry("key1", "value1").
+		Build()
+
+	if err != nil {
+		t.Fatalf("expected no error for first build, got: %v", err)
+	}
+
+	if req1.EnvelopeXdr != "envelope1" {
+		t.Errorf("expected first request EnvelopeXdr to be 'envelope1', got: %s", req1.EnvelopeXdr)
+	}
+
+	// Reset and build second request
+	req2, err := builder.
+		Reset().
+		WithEnvelopeXDR("envelope2").
+		WithResultMetaXDR("result2").
+		Build()
+
+	if err != nil {
+		t.Fatalf("expected no error for second build, got: %v", err)
+	}
+
+	if req2.EnvelopeXdr != "envelope2" {
+		t.Errorf("expected second request EnvelopeXdr to be 'envelope2', got: %s", req2.EnvelopeXdr)
+	}
+
+	if req2.LedgerEntries != nil {
+		t.Errorf("expected second request LedgerEntries to be nil after reset, got: %v", req2.LedgerEntries)
+	}
+}
+
+func TestSimulationRequestBuilder_MethodChaining(t *testing.T) {
+	// Test that all methods return the builder for chaining
+	builder := NewSimulationRequestBuilder()
+
+	result := builder.
+		WithEnvelopeXDR("envelope").
+		WithResultMetaXDR("result").
+		WithLedgerEntry("key1", "value1").
+		WithLedgerEntries(map[string]string{"key2": "value2"}).
+		Reset().
+		WithEnvelopeXDR("envelope2").
+		WithResultMetaXDR("result2")
+
+	if result != builder {
+		t.Error("expected method chaining to return the same builder instance")
+	}
+}
+
+func TestSimulationRequestBuilder_NilLedgerEntries(t *testing.T) {
+	builder := NewSimulationRequestBuilder()
+
+	req, err := builder.
+		WithEnvelopeXDR("envelope").
+		WithResultMetaXDR("result").
+		WithLedgerEntries(nil).
+		Build()
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if req.LedgerEntries != nil {
+		t.Errorf("expected LedgerEntries to be nil, got: %v", req.LedgerEntries)
+	}
+}

--- a/internal/simulator/example_test.go
+++ b/internal/simulator/example_test.go
@@ -1,0 +1,107 @@
+// Copyright 2025 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package simulator_test
+
+import (
+	"fmt"
+
+	"github.com/dotandev/hintents/internal/simulator"
+)
+
+// ExampleSimulationRequestBuilder demonstrates basic usage of the builder pattern.
+func ExampleSimulationRequestBuilder() {
+	// Create a simulation request using the builder
+	req, err := simulator.NewSimulationRequestBuilder().
+		WithEnvelopeXDR("AAAAAgAAAACE...").
+		WithResultMetaXDR("AAAAAQAAAAA...").
+		Build()
+
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Request created with envelope XDR length: %d\n", len(req.EnvelopeXdr))
+	// Output: Request created with envelope XDR length: 15
+}
+
+// ExampleSimulationRequestBuilder_withLedgerEntries demonstrates adding ledger entries.
+func ExampleSimulationRequestBuilder_withLedgerEntries() {
+	// Create a simulation request with ledger entries
+	req, err := simulator.NewSimulationRequestBuilder().
+		WithEnvelopeXDR("AAAAAgAAAACE...").
+		WithResultMetaXDR("AAAAAQAAAAA...").
+		WithLedgerEntry("key1", "value1").
+		WithLedgerEntry("key2", "value2").
+		Build()
+
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Request created with %d ledger entries\n", len(req.LedgerEntries))
+	// Output: Request created with 2 ledger entries
+}
+
+// ExampleSimulationRequestBuilder_bulkLedgerEntries demonstrates setting multiple entries at once.
+func ExampleSimulationRequestBuilder_bulkLedgerEntries() {
+	entries := map[string]string{
+		"contract_key_1": "contract_value_1",
+		"contract_key_2": "contract_value_2",
+		"contract_key_3": "contract_value_3",
+	}
+
+	req, err := simulator.NewSimulationRequestBuilder().
+		WithEnvelopeXDR("AAAAAgAAAACE...").
+		WithResultMetaXDR("AAAAAQAAAAA...").
+		WithLedgerEntries(entries).
+		Build()
+
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Request created with %d ledger entries\n", len(req.LedgerEntries))
+	// Output: Request created with 3 ledger entries
+}
+
+// ExampleSimulationRequestBuilder_validation demonstrates validation errors.
+func ExampleSimulationRequestBuilder_validation() {
+	// Try to build without required fields
+	_, err := simulator.NewSimulationRequestBuilder().
+		WithEnvelopeXDR("AAAAAgAAAACE...").
+		Build()
+
+	if err != nil {
+		fmt.Println("Validation error:", err)
+	}
+	// Output: Validation error: result meta XDR is required
+}
+
+// ExampleSimulationRequestBuilder_reuse demonstrates builder reuse with Reset().
+func ExampleSimulationRequestBuilder_reuse() {
+	builder := simulator.NewSimulationRequestBuilder()
+
+	// Build first request
+	req1, _ := builder.
+		WithEnvelopeXDR("envelope1").
+		WithResultMetaXDR("result1").
+		Build()
+
+	fmt.Printf("First request envelope: %s\n", req1.EnvelopeXdr)
+
+	// Reset and build second request
+	req2, _ := builder.
+		Reset().
+		WithEnvelopeXDR("envelope2").
+		WithResultMetaXDR("result2").
+		Build()
+
+	fmt.Printf("Second request envelope: %s\n", req2.EnvelopeXdr)
+	// Output:
+	// First request envelope: envelope1
+	// Second request envelope: envelope2
+}


### PR DESCRIPTION
## Refactor: Implement Builder Pattern for SimulationRequest

Implements a fluent builder pattern for constructing SimulationRequest objects, making the code more readable and preventing invalid states.

Changes:

### Builder implementation: SimulationRequestBuilder with chainable methods

WithEnvelopeXDR() - Set transaction envelope (required)
WithResultMetaXDR() - Set result metadata (required)
WithLedgerEntry() - Add single ledger entry
WithLedgerEntries() - Add multiple ledger entries
Reset() - Clear and reuse builder
Build() - Validate and construct request
MustBuild() - Build or panic (for tests)
Validation: Built-in validation in Build() method

Required fields checked
Empty keys/values rejected
Clear error messages
Tests: Comprehensive test coverage (12 test cases + 5 examples) Documentation: docs/SIMULATION_REQUEST_BUILDER.md with usage guide

Benefits:

Self-documenting code with clear method names
Prevents invalid request states
Method chaining for fluent API
Validation at build time
Easy to extend with new fields
Example Usage:

Before: simReq := &simulator.SimulationRequest{ EnvelopeXdr: txResp.EnvelopeXdr, ResultMetaXdr: txResp.ResultMetaXdr, LedgerEntries: nil, }

After: simReq, err := simulator.NewSimulationRequestBuilder(). WithEnvelopeXDR(txResp.EnvelopeXdr). WithResultMetaXDR(txResp.ResultMetaXdr). Build()

Testing: go test ./internal/simulator/... -v


Closes #118