### PR TITLE
fix(cli): validate transaction hash format before fetching

### DIFF
--- a/internal/cmd/debug.go
+++ b/internal/cmd/debug.go
@@ -165,8 +165,8 @@ Local WASM Replay Mode:
 			return fmt.Errorf("transaction hash is required when not using --wasm flag")
 		}
 
-		if len(args[0]) != 64 {
-			return fmt.Errorf("error: invalid transaction hash format (expected 64 hex characters, got %d)", len(args[0]))
+		if err := rpc.ValidateTransactionHash(args[0]); err != nil {
+			return fmt.Errorf("error: invalid transaction hash format: %w", err)
 		}
 
 		// Validate network flag

--- a/internal/rpc/validation.go
+++ b/internal/rpc/validation.go
@@ -1,0 +1,20 @@
+package rpc
+
+import (
+	"encoding/hex"
+	"fmt"
+)
+
+// ValidateTransactionHash checks if the provided string is a valid Stellar transaction hash.
+// A valid hash must be exactly 64 characters long and contain only hexadecimal characters.
+// The check is case-insensitive.
+func ValidateTransactionHash(hash string) error {
+	if len(hash) != 64 {
+		return fmt.Errorf("transaction hash must be exactly 64 characters long, got %d", len(hash))
+	}
+	_, err := hex.DecodeString(hash)
+	if err != nil {
+		return fmt.Errorf("transaction hash must contain only valid hexadecimal characters")
+	}
+	return nil
+}

--- a/internal/rpc/validation_test.go
+++ b/internal/rpc/validation_test.go
@@ -1,0 +1,58 @@
+package rpc
+
+import (
+	"testing"
+)
+
+func TestValidateTransactionHash(t *testing.T) {
+	tests := []struct {
+		name    string
+		hash    string
+		wantErr bool
+	}{
+		{
+			name:    "valid lowercase hash",
+			hash:    "5c0a1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab",
+			wantErr: false,
+		},
+		{
+			name:    "valid uppercase hash",
+			hash:    "5C0A1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB",
+			wantErr: false,
+		},
+		{
+			name:    "valid mixed case hash",
+			hash:    "5c0a1234567890ABCDEF1234567890abcdef1234567890ABCDEF1234567890ab",
+			wantErr: false,
+		},
+		{
+			name:    "invalid length - too short",
+			hash:    "123",
+			wantErr: true,
+		},
+		{
+			name:    "invalid length - too long",
+			hash:    "5c0a1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab12",
+			wantErr: true,
+		},
+		{
+			name:    "invalid characters",
+			hash:    "5c0a1234567890abcdef1234567890abcdef1234567890abcdef1234567890gz", // 'g' and 'z' are invalid
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			hash:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateTransactionHash(tt.hash)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateTransactionHash() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description
Adds strict validation to the `debug` command to ensure transaction hashes are correctly formatted (64-character hex strings) before attempting any network operations. This prevents unnecessary RPC calls and provides immediate, helpful feedback for invalid inputs.

### Key Changes
- **Validation Utility**: Implemented a reusable [ValidateTransactionHash](cci:1://file:///c:/Users/owner/Projects/hintents/internal/rpc/validation.go:7:0-19:1) function to enforce length (64 chars) and hex content.
- **CLI Integration**: Updated `erst debug` to validate the `transaction-hash` argument during the pre-run phase, exiting early on failure.
- **Testing**: Added comprehensive unit tests covering valid/invalid cases, different cases (upper/lower), and length edge cases.

### Verification
- [x] Invalid hashes (e.g., "123", "invalid-char") fail immediately with a clear error.
- [x] Valid 64-char hex strings pass validation.
- [x] `go test ./internal/rpc/...` passes.

Closes https://github.com/dotandev/hintents/issues/68