### PR TITLE
ux(cli): implement automatic ansi color detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	github.com/gorilla/rpc v1.2.1
+	github.com/mattn/go-isatty v0.0.20
 	github.com/hashicorp/go-version v1.8.0
 	github.com/schollz/progressbar/v3 v3.19.0
 	github.com/spf13/cobra v1.7.0
@@ -30,7 +31,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.17.6 // indirect
 	github.com/manucorporat/sse v0.0.0-20160126180136-ee05b128a739 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/internal/trace/viewer.go
+++ b/internal/trace/viewer.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/dotandev/hintents/internal/visualizer"
 )
 
 // InteractiveViewer provides a terminal-based interactive trace navigation interface
@@ -38,7 +40,7 @@ func NewInteractiveViewer(trace *ExecutionTrace) *InteractiveViewer {
 
 // Start begins the interactive trace viewing session
 func (v *InteractiveViewer) Start() error {
-	fmt.Println("🔍 ERST Interactive Trace Viewer")
+	fmt.Printf("%s ERST Interactive Trace Viewer\n", visualizer.Symbol("magnify"))
 	fmt.Println("=================================")
 	fmt.Printf("Transaction: %s\n", v.trace.TransactionHash)
 	fmt.Printf("Total Steps: %d\n\n", len(v.trace.States))
@@ -105,7 +107,7 @@ func (v *InteractiveViewer) handleCommand(command string) bool {
 	case "h", "help":
 		v.showHelp()
 	case "q", "quit", "exit":
-		fmt.Println("Goodbye! 👋")
+		fmt.Printf("Goodbye! %s\n", visualizer.Symbol("wave"))
 		return true
 	default:
 		fmt.Printf("Unknown command: %s. Type 'help' for available commands.\n", cmd)
@@ -118,11 +120,11 @@ func (v *InteractiveViewer) handleCommand(command string) bool {
 func (v *InteractiveViewer) stepForward() {
 	state, err := v.trace.StepForward()
 	if err != nil {
-		fmt.Printf("❌ %s\n", err)
+		fmt.Printf("%s %s\n", visualizer.Error(), err)
 		return
 	}
 
-	fmt.Printf("➡️  Stepped forward to step %d\n", state.Step)
+	fmt.Printf("%s  Stepped forward to step %d\n", visualizer.Symbol("arrow_r"), state.Step)
 	v.displayCurrentState()
 }
 
@@ -130,11 +132,11 @@ func (v *InteractiveViewer) stepForward() {
 func (v *InteractiveViewer) stepBackward() {
 	state, err := v.trace.StepBackward()
 	if err != nil {
-		fmt.Printf("❌ %s\n", err)
+		fmt.Printf("%s %s\n", visualizer.Error(), err)
 		return
 	}
 
-	fmt.Printf("⬅️  Stepped backward to step %d\n", state.Step)
+	fmt.Printf("%s  Stepped backward to step %d\n", visualizer.Symbol("arrow_l"), state.Step)
 	v.displayCurrentState()
 }
 
@@ -142,17 +144,17 @@ func (v *InteractiveViewer) stepBackward() {
 func (v *InteractiveViewer) jumpToStep(stepStr string) {
 	step, err := strconv.Atoi(stepStr)
 	if err != nil {
-		fmt.Printf("❌ Invalid step number: %s\n", stepStr)
+		fmt.Printf("%s Invalid step number: %s\n", visualizer.Error(), stepStr)
 		return
 	}
 
 	state, err := v.trace.JumpToStep(step)
 	if err != nil {
-		fmt.Printf("❌ %s\n", err)
+		fmt.Printf("%s %s\n", visualizer.Error(), err)
 		return
 	}
 
-	fmt.Printf("🎯 Jumped to step %d\n", state.Step)
+	fmt.Printf("%s Jumped to step %d\n", visualizer.Symbol("target"), state.Step)
 	v.displayCurrentState()
 }
 
@@ -160,11 +162,11 @@ func (v *InteractiveViewer) jumpToStep(stepStr string) {
 func (v *InteractiveViewer) displayCurrentState() {
 	state, err := v.trace.GetCurrentState()
 	if err != nil {
-		fmt.Printf("❌ %s\n", err)
+		fmt.Printf("%s %s\n", visualizer.Error(), err)
 		return
 	}
 
-	fmt.Println("\n📍 Current State")
+	fmt.Printf("\n%s Current State\n", visualizer.Symbol("pin"))
 	fmt.Println("================")
 	fmt.Printf("Step: %d/%d\n", state.Step, len(v.trace.States)-1)
 	fmt.Printf("Time: %s\n", state.Timestamp.Format("15:04:05.000"))
@@ -183,7 +185,7 @@ func (v *InteractiveViewer) displayCurrentState() {
 		fmt.Printf("Return: %v\n", state.ReturnValue)
 	}
 	if state.Error != "" {
-		fmt.Printf("❌ Error: %s\n", state.Error)
+		fmt.Printf("%s Error: %s\n", visualizer.Error(), state.Error)
 	}
 
 	// Show memory/state summary
@@ -199,11 +201,11 @@ func (v *InteractiveViewer) displayCurrentState() {
 func (v *InteractiveViewer) reconstructCurrentState() {
 	state, err := v.trace.ReconstructStateAt(v.trace.CurrentStep)
 	if err != nil {
-		fmt.Printf("❌ Failed to reconstruct state: %s\n", err)
+		fmt.Printf("%s Failed to reconstruct state: %s\n", visualizer.Error(), err)
 		return
 	}
 
-	fmt.Println("\n🔧 Reconstructed State")
+	fmt.Printf("\n%s Reconstructed State\n", visualizer.Symbol("wrench"))
 	fmt.Println("======================")
 	v.displayState(state)
 }
@@ -212,17 +214,17 @@ func (v *InteractiveViewer) reconstructCurrentState() {
 func (v *InteractiveViewer) reconstructState(stepStr string) {
 	step, err := strconv.Atoi(stepStr)
 	if err != nil {
-		fmt.Printf("❌ Invalid step number: %s\n", stepStr)
+		fmt.Printf("%s Invalid step number: %s\n", visualizer.Error(), stepStr)
 		return
 	}
 
 	state, err := v.trace.ReconstructStateAt(step)
 	if err != nil {
-		fmt.Printf("❌ Failed to reconstruct state: %s\n", err)
+		fmt.Printf("%s Failed to reconstruct state: %s\n", visualizer.Error(), err)
 		return
 	}
 
-	fmt.Printf("\n🔧 Reconstructed State at Step %d\n", step)
+	fmt.Printf("\n%s Reconstructed State at Step %d\n", visualizer.Symbol("wrench"), step)
 	fmt.Println("==================================")
 	v.displayState(state)
 }
@@ -259,7 +261,7 @@ func (v *InteractiveViewer) displayState(state *ExecutionState) {
 func (v *InteractiveViewer) showNavigationInfo() {
 	info := v.trace.GetNavigationInfo()
 
-	fmt.Println("\n📊 Navigation Info")
+	fmt.Printf("\n%s Navigation Info\n", visualizer.Symbol("chart"))
 	fmt.Println("==================")
 	fmt.Printf("Total Steps: %d\n", info["total_steps"])
 	fmt.Printf("Current Step: %d\n", info["current_step"])
@@ -279,14 +281,14 @@ func (v *InteractiveViewer) listSteps(countStr string) {
 	start := max(0, current-count/2)
 	end := min(len(v.trace.States)-1, start+count-1)
 
-	fmt.Printf("\n📋 Steps %d-%d\n", start, end)
+	fmt.Printf("\n%s Steps %d-%d\n", visualizer.Symbol("list"), start, end)
 	fmt.Println("===============")
 
 	for i := start; i <= end; i++ {
 		state := &v.trace.States[i]
 		marker := "  "
 		if i == current {
-			marker = "▶️"
+			marker = visualizer.Symbol("play")
 		}
 
 		fmt.Printf("%s %3d: %s", marker, i, state.Operation)
@@ -294,7 +296,7 @@ func (v *InteractiveViewer) listSteps(countStr string) {
 			fmt.Printf(" (%s)", state.Function)
 		}
 		if state.Error != "" {
-			fmt.Printf(" ❌")
+			fmt.Printf(" %s", visualizer.Error())
 		}
 		fmt.Println()
 	}
@@ -302,7 +304,7 @@ func (v *InteractiveViewer) listSteps(countStr string) {
 
 // showHelp displays available commands
 func (v *InteractiveViewer) showHelp() {
-	fmt.Println("\n📖 Available Commands")
+	fmt.Printf("\n%s Available Commands\n", visualizer.Symbol("book"))
 	fmt.Println("=====================")
 	fmt.Println("Navigation:")
 	fmt.Println("  n, next, forward     - Step forward")

--- a/internal/visualizer/color.go
+++ b/internal/visualizer/color.go
@@ -1,0 +1,212 @@
+// Copyright (c) 2026 dotandev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package visualizer
+
+import (
+	"os"
+
+	"github.com/mattn/go-isatty"
+)
+
+// ANSI SGR codes
+const (
+	sgrReset   = "\033[0m"
+	sgrRed     = "\033[31m"
+	sgrGreen   = "\033[32m"
+	sgrYellow  = "\033[33m"
+	sgrBlue    = "\033[34m"
+	sgrMagenta = "\033[35m"
+	sgrCyan    = "\033[36m"
+	sgrDim     = "\033[2m"
+	sgrBold    = "\033[1m"
+)
+
+// ColorEnabled reports whether ANSI color output should be used.
+// Check order (NO_COLOR has highest priority):
+//   - NO_COLOR (https://no-color.org/): if set (any non-empty value), colors are disabled
+//   - FORCE_COLOR: if set (e.g. FORCE_COLOR=1), forces colors even when not a TTY (useful in CI)
+//   - Non-TTY: when stdout is piped or redirected, colors disabled (no garbage in logs)
+//   - TERM=dumb: minimal terminal, no colors
+func ColorEnabled() bool {
+	// NO_COLOR takes precedence over everything
+	if noColor() {
+		return false
+	}
+	// FORCE_COLOR allows colors in pipes/CI (e.g. GitHub Actions with ANSI support)
+	if forceColor() {
+		return true
+	}
+	// Not a real terminal (pipe, redirect, log file)
+	if !isatty.IsTerminal(os.Stdout.Fd()) {
+		return false
+	}
+	// Dumb terminal (e.g. emacs shell)
+	if termDumb() {
+		return false
+	}
+	return true
+}
+
+// noColor returns true if NO_COLOR is set (presence = no color per no-color.org).
+func noColor() bool {
+	_, ok := os.LookupEnv("NO_COLOR")
+	return ok
+}
+
+// forceColor returns true if FORCE_COLOR is set to a non-empty value.
+func forceColor() bool {
+	return os.Getenv("FORCE_COLOR") != ""
+}
+
+// termDumb returns true for minimal terminals that don't support ANSI.
+func termDumb() bool {
+	return os.Getenv("TERM") == "dumb"
+}
+
+// Colorize returns text with ANSI color if enabled, otherwise plain text.
+func Colorize(text string, color string) string {
+	if !ColorEnabled() {
+		return text
+	}
+	return ansiWrap(text, color)
+}
+
+func ansiWrap(text, color string) string {
+	var code string
+	switch color {
+	case "red":
+		code = sgrRed
+	case "green":
+		code = sgrGreen
+	case "yellow":
+		code = sgrYellow
+	case "blue":
+		code = sgrBlue
+	case "magenta":
+		code = sgrMagenta
+	case "cyan":
+		code = sgrCyan
+	case "dim":
+		code = sgrDim
+	case "bold":
+		code = sgrBold
+	default:
+		return text
+	}
+	return code + text + sgrReset
+}
+
+// Success returns a success indicator: colored checkmark if enabled, "[OK]" otherwise.
+func Success() string {
+	if ColorEnabled() {
+		return sgrGreen + "✓" + sgrReset
+	}
+	return "[OK]"
+}
+
+// Warning returns a warning indicator: colored warning sign if enabled, "[!]" otherwise.
+func Warning() string {
+	if ColorEnabled() {
+		return sgrYellow + "⚠" + sgrReset
+	}
+	return "[!]"
+}
+
+// Error returns an error indicator: colored X if enabled, "[X]" otherwise.
+func Error() string {
+	if ColorEnabled() {
+		return sgrRed + "✗" + sgrReset
+	}
+	return "[X]"
+}
+
+// Symbol returns a symbol that may be styled; when colors disabled, returns plain ASCII equivalent.
+func Symbol(name string) string {
+	if ColorEnabled() {
+		switch name {
+		case "check":
+			return "✓"
+		case "cross":
+			return "✗"
+		case "warn":
+			return "⚠"
+		case "arrow_r":
+			return "➡️"
+		case "arrow_l":
+			return "⬅️"
+		case "target":
+			return "🎯"
+		case "pin":
+			return "📍"
+		case "wrench":
+			return "🔧"
+		case "chart":
+			return "📊"
+		case "list":
+			return "📋"
+		case "play":
+			return "▶️"
+		case "book":
+			return "📖"
+		case "wave":
+			return "👋"
+		case "magnify":
+			return "🔍"
+		case "logs":
+			return "📋"
+		case "events":
+			return "📡"
+		default:
+			return name
+		}
+	}
+	// Plain ASCII fallbacks for non-TTY / CI
+	switch name {
+	case "check":
+		return "[OK]"
+	case "cross":
+		return "[X]"
+	case "warn":
+		return "[!]"
+	case "arrow_r":
+		return "->"
+	case "arrow_l":
+		return "<-"
+	case "target":
+		return ">>"
+	case "pin":
+		return "*"
+	case "wrench":
+		return "[*]"
+	case "chart":
+		return "[#]"
+	case "list":
+		return "[.]"
+	case "play":
+		return ">"
+	case "book":
+		return "[?]"
+	case "wave":
+		return ""
+	case "magnify":
+		return "[?]"
+	case "logs":
+		return "[Logs]"
+	case "events":
+		return "[Events]"
+	default:
+		return name
+	}
+}

--- a/internal/visualizer/color_test.go
+++ b/internal/visualizer/color_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 dotandev
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package visualizer
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestNoColorDisablesColors(t *testing.T) {
+	os.Setenv("NO_COLOR", "1")
+	defer os.Unsetenv("NO_COLOR")
+
+	if ColorEnabled() {
+		t.Error("ColorEnabled() should be false when NO_COLOR is set")
+	}
+
+	out := Colorize("hello", "red")
+	if strings.Contains(out, "\033") {
+		t.Errorf("Colorize should not contain ANSI when NO_COLOR set, got: %q", out)
+	}
+	if out != "hello" {
+		t.Errorf("Colorize should return plain text, got: %q", out)
+	}
+}
+
+func TestTermDumbDisablesColors(t *testing.T) {
+	oldTerm := os.Getenv("TERM")
+	defer func() { os.Setenv("TERM", oldTerm) }()
+	os.Unsetenv("NO_COLOR")
+	os.Setenv("TERM", "dumb")
+
+	// TERM=dumb disables - we can't easily test ColorEnabled() without TTY,
+	// but we can verify the logic doesn't panic
+	_ = termDumb()
+	if !termDumb() {
+		t.Error("termDumb() should be true when TERM=dumb")
+	}
+}
+
+func TestSymbolReturnsPlainASCIIWhenDisabled(t *testing.T) {
+	os.Setenv("NO_COLOR", "1")
+	defer os.Unsetenv("NO_COLOR")
+
+	for name, wantPlain := range map[string]string{
+		"check":  "[OK]",
+		"cross":  "[X]",
+		"warn":   "[!]",
+		"arrow_r": "->",
+	} {
+		got := Symbol(name)
+		if got != wantPlain {
+			t.Errorf("Symbol(%q) = %q, want %q (NO_COLOR should force plain ASCII)", name, got, wantPlain)
+		}
+	}
+}
+
+func TestSuccessWarningErrorNoEscapeWhenDisabled(t *testing.T) {
+	os.Setenv("NO_COLOR", "1")
+	defer os.Unsetenv("NO_COLOR")
+
+	for _, s := range []string{Success(), Warning(), Error()} {
+		if strings.Contains(s, "\033") {
+			t.Errorf("Output contains ANSI escape when disabled: %q", s)
+		}
+	}
+}
+
+func TestNoColorOverridesForceColor(t *testing.T) {
+	os.Setenv("NO_COLOR", "1")
+	os.Setenv("FORCE_COLOR", "1")
+	defer func() {
+		os.Unsetenv("NO_COLOR")
+		os.Unsetenv("FORCE_COLOR")
+	}()
+
+	if ColorEnabled() {
+		t.Error("NO_COLOR must take precedence over FORCE_COLOR")
+	}
+	out := Colorize("test", "red")
+	if out != "test" {
+		t.Errorf("NO_COLOR+FORCE_COLOR: expected plain text, got %q", out)
+	}
+}
+
+func TestForceColorEnablesColorsWhenSet(t *testing.T) {
+	os.Unsetenv("NO_COLOR")
+	os.Setenv("FORCE_COLOR", "1")
+	defer os.Unsetenv("FORCE_COLOR")
+
+	// FORCE_COLOR=1 should enable colors (even when piped / not TTY)
+	if !ColorEnabled() {
+		t.Error("ColorEnabled() should be true when FORCE_COLOR=1 and NO_COLOR unset")
+	}
+	out := Colorize("hello", "red")
+	if !strings.Contains(out, "\033") {
+		t.Errorf("FORCE_COLOR=1: Colorize should emit ANSI, got plain: %q", out)
+	}
+}

--- a/scripts/verify_no_ansi.sh
+++ b/scripts/verify_no_ansi.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Verify that erst debug produces no ANSI escape characters when piped
+# Usage: ./scripts/verify_no_ansi.sh
+set -e
+
+cd "$(dirname "$0")/.."
+BIN="./erst"
+
+# Build if needed
+if [ ! -x "$BIN" ] && ! command -v erst &>/dev/null; then
+  echo "Building erst..."
+  go build -o erst ./cmd/erst/
+fi
+if [ -x "$BIN" ]; then
+  : # use ./erst
+elif command -v erst &>/dev/null; then
+  BIN="erst"
+else
+  echo "Error: erst binary not found. Run: go build -o erst ./cmd/erst/"
+  exit 1
+fi
+
+# Use a valid-length hash (64 hex chars) - will fail to fetch but we get initial output
+HASH="0"$(printf '0%.0s' {1..62})
+
+echo "Testing: $BIN debug $HASH 2>&1 | cat"
+OUTPUT=$($BIN debug "$HASH" 2>&1 | cat)
+
+if echo "$OUTPUT" | grep -q $'\033'; then
+  echo "FAIL: Output contains ANSI escape sequences"
+  echo "$OUTPUT" | cat -A
+  exit 1
+fi
+
+echo "PASS: No ANSI escape characters in piped output"
+
+# Also verify NO_COLOR disables colors
+echo ""
+echo "Testing: NO_COLOR=1 $BIN debug $HASH 2>&1 | cat"
+OUTPUT2=$(NO_COLOR=1 $BIN debug "$HASH" 2>&1 | cat)
+if echo "$OUTPUT2" | grep -q $'\033'; then
+  echo "FAIL: NO_COLOR=1 still produced ANSI escape sequences"
+  exit 1
+fi
+echo "PASS: NO_COLOR honored"


### PR DESCRIPTION
## Description
Adds automatic ANSI color/styling detection for the Go CLI so colors are turned off in non-interactive contexts (pipes, redirects, log files, CI, non-TTY).

The change:
- Honors the widely-adopted `NO_COLOR` environment variable standard[](https://no-color.org).
- Automatically disables colors when `os.Stdout` is not a TTY (using `github.com/mattn/go-isatty`).
- Optionally checks `TERM=dumb` for legacy compatibility.
- Ensures clean plain-text output in piped/redirected scenarios while preserving colors in interactive terminals.

## Related Issue
[<!-- Link to the issue this PR addresses -->](https://github.com/dotandev/hintents/issues/136)
Closes #136


## Changes Made
- NO_COLOR (no-color.org): colors are disabled when NO_COLOR is set (any non-empty value)
- FORCE_COLOR: FORCE_COLOR=1 forces colors even when output is not a TTY (e.g. CI)
- TTY check: colors are disabled when stdout is not a terminal (pipes, redirects, log files)
- TERM=dumb: colors are disabled for minimal terminals
- Enforced precedence: NO_COLOR overrides FORCE_COLOR
New unit tests: TestNoColorOverridesForceColor, TestForceColorEnablesColorsWhenSet


## Testing
- go test ./internal/visualizer/... -v — all tests pass
- ./scripts/verify_no_ansi.sh — no ANSI in piped output and NO_COLOR honored
- Manual check: erst debug --demo | cat — no ANSI escape sequences in output

## Checklist
- [x] Documentation updated
- [x] Tests passing
- [x] Code follows project style guidelines
