### PR TITLE
feat(ux): implement watch mode for real-time transaction debugging

### DIFF
--- a/internal/watch/poller.go
+++ b/internal/watch/poller.go
@@ -1,0 +1,90 @@
+// Copyright 2026 dotandev
+// SPDX-License-Identifier: Apache-2.0
+
+package watch
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+type PollerConfig struct {
+	MaxAttempts     int
+	InitialInterval time.Duration
+	MaxInterval     time.Duration
+	TimeoutDuration time.Duration
+}
+
+type Poller struct {
+	config PollerConfig
+}
+
+type PollResult struct {
+	Found bool
+	Data  interface{}
+	Error error
+}
+
+func NewPoller(config PollerConfig) *Poller {
+	if config.MaxAttempts == 0 {
+		config.MaxAttempts = 60
+	}
+	if config.InitialInterval == 0 {
+		config.InitialInterval = 1 * time.Second
+	}
+	if config.MaxInterval == 0 {
+		config.MaxInterval = 10 * time.Second
+	}
+	if config.TimeoutDuration == 0 {
+		config.TimeoutDuration = 30 * time.Second
+	}
+
+	return &Poller{config: config}
+}
+
+func (p *Poller) Poll(ctx context.Context, checkFunc func(ctx context.Context) (interface{}, error), onAttempt func(attempt int)) (*PollResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, p.config.TimeoutDuration)
+	defer cancel()
+
+	interval := p.config.InitialInterval
+	attempt := 0
+
+	for {
+		select {
+		case <-ctx.Done():
+			return &PollResult{Found: false, Error: fmt.Errorf("polling timeout exceeded")}, nil
+		default:
+		}
+
+		attempt++
+
+		if onAttempt != nil {
+			onAttempt(attempt)
+		}
+
+		data, err := checkFunc(ctx)
+		if err == nil && data != nil {
+			return &PollResult{Found: true, Data: data}, nil
+		}
+
+		if attempt >= p.config.MaxAttempts {
+			return &PollResult{Found: false, Error: fmt.Errorf("max attempts exceeded")}, nil
+		}
+
+		select {
+		case <-time.After(interval):
+			interval = p.exponentialBackoff(interval)
+		case <-ctx.Done():
+			return &PollResult{Found: false, Error: ctx.Err()}, nil
+		}
+	}
+}
+
+func (p *Poller) exponentialBackoff(current time.Duration) time.Duration {
+	next := current * 2
+	if next > p.config.MaxInterval {
+		next = p.config.MaxInterval
+	}
+	return next
+}

--- a/internal/watch/spinner.go
+++ b/internal/watch/spinner.go
@@ -1,0 +1,80 @@
+// Copyright 2026 dotandev
+// SPDX-License-Identifier: Apache-2.0
+
+package watch
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+type Spinner struct {
+	frames    []string
+	current   int
+	done      chan struct{}
+	mu        sync.Mutex
+	isRunning bool
+}
+
+func NewSpinner() *Spinner {
+	return &Spinner{
+		frames: []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"},
+		done:   make(chan struct{}),
+	}
+}
+
+func (s *Spinner) Start(message string) {
+	s.mu.Lock()
+	if s.isRunning {
+		s.mu.Unlock()
+		return
+	}
+	s.isRunning = true
+	s.mu.Unlock()
+
+	go func() {
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-s.done:
+				fmt.Print("\r\033[K")
+				return
+			case <-ticker.C:
+				s.mu.Lock()
+				fmt.Printf("\r%s %s", s.frames[s.current], message)
+				s.current = (s.current + 1) % len(s.frames)
+				s.mu.Unlock()
+			}
+		}
+	}()
+}
+
+func (s *Spinner) Stop() {
+	s.mu.Lock()
+	if !s.isRunning {
+		s.mu.Unlock()
+		return
+	}
+	s.isRunning = false
+	s.mu.Unlock()
+
+	select {
+	case s.done <- struct{}{}:
+	default:
+	}
+
+	time.Sleep(50 * time.Millisecond)
+}
+
+func (s *Spinner) StopWithMessage(message string) {
+	s.Stop()
+	fmt.Printf("\r✓ %s\n", message)
+}
+
+func (s *Spinner) StopWithError(message string) {
+	s.Stop()
+	fmt.Printf("\r✗ %s\n", message)
+}

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -1,0 +1,251 @@
+// Copyright 2026 dotandev
+// SPDX-License-Identifier: Apache-2.0
+
+package watch
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestNewPollerDefaults(t *testing.T) {
+	poller := NewPoller(PollerConfig{})
+
+	if poller.config.MaxAttempts != 60 {
+		t.Errorf("expected MaxAttempts 60, got %d", poller.config.MaxAttempts)
+	}
+
+	if poller.config.InitialInterval != 1*time.Second {
+		t.Errorf("expected InitialInterval 1s, got %v", poller.config.InitialInterval)
+	}
+
+	if poller.config.TimeoutDuration != 30*time.Second {
+		t.Errorf("expected TimeoutDuration 30s, got %v", poller.config.TimeoutDuration)
+	}
+}
+
+func TestPollSuccess(t *testing.T) {
+	poller := NewPoller(PollerConfig{
+		MaxAttempts:     5,
+		InitialInterval: 10 * time.Millisecond,
+		TimeoutDuration: 5 * time.Second,
+	})
+
+	attempt := 0
+	checkFunc := func(ctx context.Context) (interface{}, error) {
+		attempt++
+		if attempt >= 3 {
+			return "found", nil
+		}
+		return nil, fmt.Errorf("not found yet")
+	}
+
+	result, err := poller.Poll(context.Background(), checkFunc, nil)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !result.Found {
+		t.Error("expected to find data")
+	}
+
+	if result.Data != "found" {
+		t.Errorf("expected 'found', got %v", result.Data)
+	}
+
+	if attempt != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempt)
+	}
+}
+
+func TestPollTimeout(t *testing.T) {
+	poller := NewPoller(PollerConfig{
+		MaxAttempts:     100,
+		InitialInterval: 100 * time.Millisecond,
+		TimeoutDuration: 200 * time.Millisecond,
+	})
+
+	checkFunc := func(ctx context.Context) (interface{}, error) {
+		return nil, fmt.Errorf("not found")
+	}
+
+	result, err := poller.Poll(context.Background(), checkFunc, nil)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Found {
+		t.Error("expected timeout, but found data")
+	}
+
+	if result.Error == nil {
+		t.Error("expected timeout error")
+	}
+}
+
+func TestPollMaxAttempts(t *testing.T) {
+	poller := NewPoller(PollerConfig{
+		MaxAttempts:     3,
+		InitialInterval: 10 * time.Millisecond,
+		TimeoutDuration: 30 * time.Second,
+	})
+
+	attempt := 0
+	checkFunc := func(ctx context.Context) (interface{}, error) {
+		attempt++
+		return nil, fmt.Errorf("not found")
+	}
+
+	result, err := poller.Poll(context.Background(), checkFunc, nil)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Found {
+		t.Error("expected max attempts exceeded")
+	}
+
+	if attempt != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempt)
+	}
+}
+
+func TestExponentialBackoff(t *testing.T) {
+	poller := NewPoller(PollerConfig{
+		InitialInterval: 1 * time.Second,
+		MaxInterval:     10 * time.Second,
+	})
+
+	tests := []struct {
+		current  time.Duration
+		expected time.Duration
+	}{
+		{1 * time.Second, 2 * time.Second},
+		{2 * time.Second, 4 * time.Second},
+		{4 * time.Second, 8 * time.Second},
+		{8 * time.Second, 10 * time.Second},
+		{10 * time.Second, 10 * time.Second},
+	}
+
+	for _, tt := range tests {
+		result := poller.exponentialBackoff(tt.current)
+		if result != tt.expected {
+			t.Errorf("backoff(%v) = %v, expected %v", tt.current, result, tt.expected)
+		}
+	}
+}
+
+func TestPollWithAttemptCallback(t *testing.T) {
+	poller := NewPoller(PollerConfig{
+		MaxAttempts:     5,
+		InitialInterval: 10 * time.Millisecond,
+		TimeoutDuration: 5 * time.Second,
+	})
+
+	attempts := []int{}
+	checkFunc := func(ctx context.Context) (interface{}, error) {
+		return nil, fmt.Errorf("not found")
+	}
+
+	onAttempt := func(attempt int) {
+		attempts = append(attempts, attempt)
+	}
+
+	poller.Poll(context.Background(), checkFunc, onAttempt)
+
+	if len(attempts) != 5 {
+		t.Errorf("expected 5 attempts, got %d", len(attempts))
+	}
+
+	for i := 0; i < len(attempts); i++ {
+		if attempts[i] != i+1 {
+			t.Errorf("attempt %d: expected %d, got %d", i, i+1, attempts[i])
+		}
+	}
+}
+
+func TestPollContextCancellation(t *testing.T) {
+	poller := NewPoller(PollerConfig{
+		MaxAttempts:     100,
+		InitialInterval: 100 * time.Millisecond,
+		TimeoutDuration: 10 * time.Second,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	checkFunc := func(ctx context.Context) (interface{}, error) {
+		cancel()
+		return nil, fmt.Errorf("not found")
+	}
+
+	result, err := poller.Poll(ctx, checkFunc, nil)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Found {
+		t.Error("expected cancellation")
+	}
+}
+
+func TestNewSpinner(t *testing.T) {
+	spinner := NewSpinner()
+
+	if spinner == nil {
+		t.Error("expected non-nil spinner")
+	}
+
+	if len(spinner.frames) == 0 {
+		t.Error("expected spinner frames")
+	}
+}
+
+func TestSpinnerStartStop(t *testing.T) {
+	spinner := NewSpinner()
+	spinner.Start("Testing...")
+	time.Sleep(50 * time.Millisecond)
+	spinner.Stop()
+}
+
+func TestSpinnerMessages(t *testing.T) {
+	spinner := NewSpinner()
+	spinner.Start("Testing...")
+	time.Sleep(50 * time.Millisecond)
+	spinner.StopWithMessage("Test completed")
+
+	spinner2 := NewSpinner()
+	spinner2.Start("Testing error...")
+	time.Sleep(50 * time.Millisecond)
+	spinner2.StopWithError("Test failed")
+}
+
+func TestSpinnerDoubleStart(t *testing.T) {
+	spinner := NewSpinner()
+	spinner.Start("Testing...")
+	spinner.Start("Testing again...")
+	time.Sleep(50 * time.Millisecond)
+	spinner.Stop()
+}
+
+func BenchmarkPoller(b *testing.B) {
+	poller := NewPoller(PollerConfig{
+		MaxAttempts:     5,
+		InitialInterval: 1 * time.Millisecond,
+		TimeoutDuration: 5 * time.Second,
+	})
+
+	checkFunc := func(ctx context.Context) (interface{}, error) {
+		return "found", nil
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		poller.Poll(context.Background(), checkFunc, nil)
+	}
+}


### PR DESCRIPTION
- Add polling system with exponential backoff for transaction detection
- Implement spinner indicator for visual feedback during polling
- Add --watch flag to automatically poll Horizon until transaction appears
- Add --watch-timeout flag to control polling duration (default 30s)
- Integrate watch mode into debug command for seamless workflow
- Configure exponential backoff: 1s initial, 10s max interval
- Support context cancellation and timeout handling
- Comprehensive test suite with race condition detection

CLoses #85
