### PR TITLE
feat(cache): implement TTL expiration for ledger entry cache

### DIFF
--- a/internal/rpc/cache.go
+++ b/internal/rpc/cache.go
@@ -1,7 +1,6 @@
 // Copyright 2025 Erst Users
 // SPDX-License-Identifier: Apache-2.0
 
-
 package rpc
 
 import (
@@ -29,15 +28,18 @@ func HashLedgerKey(key xdr.LedgerKey) (string, error) {
 }
 
 const (
-	CacheDirName = ".erst/cache"
-	FilePerm     = 0600
-	DirPerm      = 0700
+	CacheDirName    = ".erst/cache"
+	FilePerm        = 0600
+	DirPerm         = 0700
+	DefaultCacheTTL = 24 * time.Hour
 )
 
 type CachedEntry struct {
-	Key       string    `json:"key"`
-	Value     string    `json:"value"` // XDR value
-	CreatedAt time.Time `json:"created_at"`
+	Key       string        `json:"key"`
+	Value     string        `json:"value"`
+	CreatedAt time.Time     `json:"created_at"`
+	ExpiresAt time.Time     `json:"expires_at"`
+	TTL       time.Duration `json:"ttl"`
 }
 
 // GetCachePath returns the path to the cache directory, creating it if necessary
@@ -61,7 +63,6 @@ func getCacheKey(key string) string {
 	return hex.EncodeToString(hash[:])
 }
 
-// Get retrieves a value from the cache
 func Get(key string) (string, bool, error) {
 	cachePath, err := GetCachePath()
 	if err != nil {
@@ -70,7 +71,6 @@ func Get(key string) (string, bool, error) {
 
 	filename := filepath.Join(cachePath, getCacheKey(key)+".json")
 
-	// Check if file exists
 	if _, err := os.Stat(filename); os.IsNotExist(err) {
 		return "", false, nil
 	}
@@ -82,25 +82,36 @@ func Get(key string) (string, bool, error) {
 
 	var entry CachedEntry
 	if err := json.Unmarshal(data, &entry); err != nil {
-		// If corrupted, return false (miss) and log warning
 		logger.Logger.Warn("Cache file corrupted", "key", key, "error", err)
+		return "", false, nil
+	}
+
+	if time.Now().After(entry.ExpiresAt) {
+		logger.Logger.Debug("Cache entry expired", "key", key, "expired_at", entry.ExpiresAt)
+		_ = os.Remove(filename)
 		return "", false, nil
 	}
 
 	return entry.Value, true, nil
 }
 
-// Set saves a value to the cache
-func Set(key string, value string) error {
+func SetWithTTL(key string, value string, ttl time.Duration) error {
+	if ttl <= 0 {
+		ttl = DefaultCacheTTL
+	}
+
 	cachePath, err := GetCachePath()
 	if err != nil {
 		return err
 	}
 
+	now := time.Now()
 	entry := CachedEntry{
 		Key:       key,
 		Value:     value,
-		CreatedAt: time.Now(),
+		CreatedAt: now,
+		ExpiresAt: now.Add(ttl),
+		TTL:       ttl,
 	}
 
 	data, err := json.Marshal(entry)
@@ -114,6 +125,10 @@ func Set(key string, value string) error {
 	}
 
 	return nil
+}
+
+func Set(key string, value string) error {
+	return SetWithTTL(key, value, DefaultCacheTTL)
 }
 
 // Invalidate removes a specific key from the cache

--- a/internal/rpc/cache_test.go
+++ b/internal/rpc/cache_test.go
@@ -1,7 +1,6 @@
 // Copyright 2025 Erst Users
 // SPDX-License-Identifier: Apache-2.0
 
-
 package rpc
 
 // cache_test.go - Comprehensive unit tests for LedgerKey cache hashing
@@ -12,6 +11,7 @@ package rpc
 import (
 	"encoding/hex"
 	"testing"
+	"time"
 
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
@@ -872,5 +872,149 @@ func BenchmarkLedgerKeyHashing_AllTypes(b *testing.B) {
 				b.Fatal(err)
 			}
 		}
+	}
+}
+func TestCacheTTL_SetAndGet(t *testing.T) {
+	key := "test-key"
+	value := "test-value"
+	ttl := 1 * time.Hour
+
+	err := SetWithTTL(key, value, ttl)
+	require.NoError(t, err)
+
+	retrieved, found, err := Get(key)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, value, retrieved)
+}
+
+func TestCacheTTL_DefaultTTL(t *testing.T) {
+	key := "default-ttl-key"
+	value := "default-value"
+
+	err := Set(key, value)
+	require.NoError(t, err)
+
+	retrieved, found, err := Get(key)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, value, retrieved)
+}
+
+func TestCacheTTL_Expiration(t *testing.T) {
+	key := "expiring-key"
+	value := "expiring-value"
+	ttl := 100 * time.Millisecond
+
+	err := SetWithTTL(key, value, ttl)
+	require.NoError(t, err)
+
+	retrieved, found, err := Get(key)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, value, retrieved)
+
+	time.Sleep(150 * time.Millisecond)
+
+	_, found, err = Get(key)
+	require.NoError(t, err)
+	require.False(t, found)
+}
+
+func TestCacheTTL_ZeroTTLUsesDefault(t *testing.T) {
+	key := "zero-ttl-key"
+	value := "zero-ttl-value"
+
+	err := SetWithTTL(key, value, 0)
+	require.NoError(t, err)
+
+	retrieved, found, err := Get(key)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, value, retrieved)
+}
+
+func TestCacheTTL_NegativeTTLUsesDefault(t *testing.T) {
+	key := "negative-ttl-key"
+	value := "negative-ttl-value"
+
+	err := SetWithTTL(key, value, -5*time.Second)
+	require.NoError(t, err)
+
+	retrieved, found, err := Get(key)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, value, retrieved)
+}
+
+func TestCacheTTL_MultipleEntriesWithDifferentTTLs(t *testing.T) {
+	key1 := "short-ttl"
+	key2 := "long-ttl"
+	value := "test-value"
+
+	err := SetWithTTL(key1, value, 50*time.Millisecond)
+	require.NoError(t, err)
+
+	err = SetWithTTL(key2, value, 5*time.Second)
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	_, found1, _ := Get(key1)
+	_, found2, _ := Get(key2)
+
+	require.False(t, found1)
+	require.True(t, found2)
+}
+
+func TestCacheTTL_InvalidateAfterExpiry(t *testing.T) {
+	key := "auto-cleanup-key"
+	value := "auto-cleanup-value"
+
+	err := SetWithTTL(key, value, 50*time.Millisecond)
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	_, found, err := Get(key)
+	require.NoError(t, err)
+	require.False(t, found)
+
+	err = Invalidate(key)
+	require.NoError(t, err)
+}
+
+func TestCacheTTL_SetWithCustomTTL(t *testing.T) {
+	key := "custom-ttl"
+	value := "custom-value"
+	customTTL := 200 * time.Millisecond
+
+	err := SetWithTTL(key, value, customTTL)
+	require.NoError(t, err)
+
+	retrieved, found, err := Get(key)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, value, retrieved)
+
+	time.Sleep(250 * time.Millisecond)
+
+	_, found, err = Get(key)
+	require.NoError(t, err)
+	require.False(t, found)
+}
+
+func BenchmarkCacheTTL_Set(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		SetWithTTL("bench-key", "bench-value", 24*time.Hour)
+	}
+}
+
+func BenchmarkCacheTTL_Get(b *testing.B) {
+	SetWithTTL("bench-get", "bench-value", 24*time.Hour)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Get("bench-get")
 	}
 }


### PR DESCRIPTION
Add TTL field to CachedEntry struct with configurable expiration
- Implement SetWithTTL() for entries with custom TTL duration
- Set default TTL to 24 hours for cache entries
- Update Get() to check and respect expiration timestamps
- Automatically remove expired entries during Get() operations
- Add comprehensive TTL test suite with 8 test cases
- All tests pass with -race flag for concurrency safety
- Code formatted with go fmt


Closes #282