### PR TITLE
chore: enable unused linter and remove dead code- Enable govet and in…

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,8 @@ linters:
     - errcheck
     - staticcheck
     - unused
+    - govet
+    - ineffassign
 
 linters-settings:
   gocyclo:
@@ -30,7 +32,3 @@ issues:
     - linters:
         - errcheck
       text: "Error return value of `.*(Close|Setenv|Unsetenv).*` is not checked"
-    # Exclude unused for parser.go (kept for future use)
-    - path: internal/rpc/parser\.go
-      linters:
-        - unused

--- a/internal/decoder/xdr_formatter_test.go
+++ b/internal/decoder/xdr_formatter_test.go
@@ -23,6 +23,7 @@ func TestNewXDRFormatter(t *testing.T) {
 			formatter := NewXDRFormatter(tt.format)
 			if formatter == nil {
 				t.Fatal("expected non-nil formatter")
+				return
 			}
 			if formatter.format != tt.format {
 				t.Errorf("expected format %s, got %s", tt.format, formatter.format)

--- a/internal/report/exporter_test.go
+++ b/internal/report/exporter_test.go
@@ -20,6 +20,7 @@ func TestExporterCreation(t *testing.T) {
 
 	if exporter == nil {
 		t.Fatal("expected non-nil exporter")
+		return
 	}
 
 	if exporter.outputDir != tmpDir {

--- a/internal/rpc/builder_simple_test.go
+++ b/internal/rpc/builder_simple_test.go
@@ -14,6 +14,7 @@ func TestBuilderCreateDefaultClient(t *testing.T) {
 	}
 	if client == nil {
 		t.Fatal("expected non-nil client")
+		return
 	}
 	if client.Network != Mainnet {
 		t.Errorf("expected default network Mainnet, got %v", client.Network)
@@ -149,6 +150,7 @@ func TestDeprecatedNewClientDefault(t *testing.T) {
 	client := NewClientDefault(Testnet, "")
 	if client == nil {
 		t.Fatal("expected non-nil client")
+		return
 	}
 	if client.Network != Testnet {
 		t.Errorf("expected network Testnet, got %v", client.Network)
@@ -160,6 +162,7 @@ func TestDeprecatedNewClientWithURLOption(t *testing.T) {
 	client := NewClientWithURLOption(url, Testnet, "")
 	if client == nil {
 		t.Fatal("expected non-nil client")
+		return
 	}
 	if client.HorizonURL != url {
 		t.Errorf("expected HorizonURL %s, got %s", url, client.HorizonURL)
@@ -171,6 +174,7 @@ func TestDeprecatedNewClientWithURLsOption(t *testing.T) {
 	client := NewClientWithURLsOption(urls, Testnet, "")
 	if client == nil {
 		t.Fatal("expected non-nil client")
+		return
 	}
 	if len(client.AltURLs) != len(urls) {
 		t.Errorf("expected %d AltURLs, got %d", len(urls), len(client.AltURLs))
@@ -185,6 +189,7 @@ func TestDeprecatedNewCustomClient(t *testing.T) {
 	}
 	if client == nil {
 		t.Fatal("expected non-nil client")
+		return
 	}
 	if client.Config.Name != config.Name {
 		t.Errorf("expected config name %s, got %s", config.Name, client.Config.Name)

--- a/internal/rpc/builder_test.go
+++ b/internal/rpc/builder_test.go
@@ -268,6 +268,7 @@ func TestDeprecatedNewClient(t *testing.T) {
 	client := NewClientDefault(Testnet, "token")
 	if client == nil {
 		t.Fatal("expected client, got nil")
+		return
 	}
 	if client.Network != Testnet {
 		t.Errorf("expected Testnet network")
@@ -278,6 +279,7 @@ func TestDeprecatedNewClientWithURL(t *testing.T) {
 	client := NewClientWithURLOption(TestnetHorizonURL, Testnet, "token")
 	if client == nil {
 		t.Fatal("expected client, got nil")
+		return
 	}
 	if client.HorizonURL != TestnetHorizonURL {
 		t.Errorf("expected HorizonURL to match")
@@ -289,6 +291,7 @@ func TestDeprecatedNewClientWithURLs(t *testing.T) {
 	client := NewClientWithURLsOption(urls, Testnet, "token")
 	if client == nil {
 		t.Fatal("expected client, got nil")
+		return
 	}
 	if len(client.AltURLs) != len(urls) {
 		t.Errorf("expected %d URLs", len(urls))

--- a/internal/rpc/ledger_test.go
+++ b/internal/rpc/ledger_test.go
@@ -110,6 +110,7 @@ func TestLedgerKeyFromEntry_Account(t *testing.T) {
 	key := ledgerKeyFromEntry(entry)
 	if key == nil {
 		t.Fatal("Expected non-nil key")
+		return
 	}
 
 	if key.Type != xdr.LedgerEntryTypeAccount {
@@ -171,6 +172,7 @@ func TestLedgerKeyFromEntry_ContractCodeLedger(t *testing.T) {
 	key := ledgerKeyFromEntry(entry)
 	if key == nil {
 		t.Fatal("Expected non-nil key")
+		return
 	}
 
 	if key.Type != xdr.LedgerEntryTypeContractCode {

--- a/internal/watch/watch_test.go
+++ b/internal/watch/watch_test.go
@@ -14,6 +14,7 @@ func TestNewPollerDefaults(t *testing.T) {
 	poller := NewPoller(PollerConfig{})
 	if poller == nil {
 		t.Fatal("expected non-nil poller")
+		return
 	}
 
 	if poller.config.MaxAttempts != 60 {
@@ -202,6 +203,7 @@ func TestNewSpinner(t *testing.T) {
 
 	if spinner == nil {
 		t.Fatal("expected non-nil spinner")
+		return
 	}
 
 	if len(spinner.frames) == 0 {


### PR DESCRIPTION
I enabled unused linter and remove dead code

- Enable govet and ineffassign linters for enhanced dead code detection
- Remove parser.go exclusion from unused linter (functions are legitimately used)
- Fix SA5011 staticcheck warnings (possible nil pointer dereferences) in test files
  by adding return after t.Fatal in nil checks
- All golangci-lint checks pass with zero warnings

Closes #116 