### PR TITLE
feat(ui): Render nested budget consumption inline

### DIFF
--- a/docs/BUDGET_METRICS.md
+++ b/docs/BUDGET_METRICS.md
@@ -1,0 +1,137 @@
+# Budget Consumption Metrics in Trace Tree
+
+## Overview
+
+The trace tree now displays inline CPU and memory delta metrics beside each function call node, providing immediate visibility into resource consumption at each step of contract execution.
+
+## Features
+
+### Inline Budget Display
+
+Each trace node can now track and display:
+- **CPU Delta**: Number of CPU instructions consumed by that specific operation
+- **Memory Delta**: Number of memory bytes consumed by that specific operation
+
+### Visual Representation
+
+Budget metrics are displayed inline in the trace tree:
+
+```
+0: contract_init (initialize)
+1: contract_call (mint) [CPU: 125.00K, Mem: 2.00KB]
+2: contract_call (transfer) [CPU: 180.00K, Mem: 3.00KB]
+3: balance_check (get_balance) [CPU: 75.00K, Mem: 1.00KB]
+```
+
+### Format Specifications
+
+**CPU Instructions:**
+- Values >= 1,000,000: Displayed as `X.XXM` (e.g., `1.25M`)
+- Values >= 1,000: Displayed as `X.XXK` (e.g., `125.00K`)
+- Values < 1,000: Displayed as raw number
+
+**Memory Bytes:**
+- Values >= 1,048,576: Displayed as `X.XXMB` (e.g., `2.50MB`)
+- Values >= 1,024: Displayed as `X.XXKB` (e.g., `3.00KB`)
+- Values < 1,024: Displayed as `XB` (e.g., `512B`)
+
+## Data Structure
+
+### Go (TraceNode)
+
+```go
+type TraceNode struct {
+    // ... existing fields ...
+    CPUDelta    *uint64  // CPU instructions consumed (nil if not tracked)
+    MemoryDelta *uint64  // Memory bytes consumed (nil if not tracked)
+}
+```
+
+### TypeScript (TraceStep)
+
+```typescript
+export interface TraceStep {
+    // ... existing fields ...
+    cpu_delta?: number;      // CPU instructions consumed
+    memory_delta?: number;   // Memory bytes consumed
+}
+```
+
+## Usage
+
+### In VSCode Extension
+
+Budget metrics are automatically displayed in the trace tree view when available:
+
+```typescript
+export class TraceItem extends vscode.TreeItem {
+    constructor(public readonly step: TraceStep) {
+        // Budget info is formatted and displayed in description
+        const budgetParts: string[] = [];
+        if (step.cpu_delta !== undefined && step.cpu_delta > 0) {
+            budgetParts.push(`CPU: ${this.formatNumber(step.cpu_delta)}`);
+        }
+        if (step.memory_delta !== undefined && step.memory_delta > 0) {
+            budgetParts.push(`Mem: ${this.formatBytes(step.memory_delta)}`);
+        }
+        const budgetInfo = budgetParts.length > 0 ? ` [${budgetParts.join(', ')}]` : '';
+        this.description = step.error ? `Error: ${step.error}` : budgetInfo;
+    }
+}
+```
+
+### In Mock Traces
+
+Sample budget metrics can be added to test traces:
+
+```go
+call := NewTraceNode("call-1", "contract_call")
+cpuDelta := uint64(150000)
+memDelta := uint64(2048)
+call.CPUDelta = &cpuDelta
+call.MemoryDelta = &memDelta
+```
+
+## Benefits
+
+1. **Immediate Visibility**: See resource consumption at a glance without drilling into details
+2. **Performance Analysis**: Quickly identify expensive operations in the call tree
+3. **Budget Planning**: Understand cumulative costs across nested function calls
+4. **Optimization**: Spot optimization opportunities by comparing delta values
+
+## Implementation Details
+
+### Optional Fields
+
+Budget metrics are optional (`*uint64` in Go, `number?` in TypeScript) to:
+- Support traces without budget tracking
+- Allow backward compatibility
+- Reduce memory overhead for nodes that don't need tracking
+
+### Zero Values
+
+A value of `0` is treated as "no consumption" and not displayed, keeping the UI clean for operations with negligible resource usage.
+
+### Nested Consumption
+
+Budget deltas represent the consumption of that specific node only, not cumulative consumption including children. This allows developers to:
+- See exact costs per operation
+- Calculate total costs by summing deltas
+- Identify which level of nesting contributes most to consumption
+
+## Testing
+
+Tests are provided in `internal/trace/budget_test.go`:
+
+```bash
+go test ./internal/trace/... -v -run TestBudget
+```
+
+## Future Enhancements
+
+Potential improvements:
+- Cumulative budget display (node + all children)
+- Percentage of total budget consumed
+- Budget limit warnings
+- Color coding for high consumption nodes
+- Budget comparison between different executions

--- a/erst_extension/src/erstClient.ts
+++ b/erst_extension/src/erstClient.ts
@@ -12,6 +12,8 @@ export interface TraceStep {
     error?: string;
     host_state?: any;
     memory?: any;
+    cpu_delta?: number;
+    memory_delta?: number;
 }
 
 export interface Trace {

--- a/erst_extension/src/traceTreeView.ts
+++ b/erst_extension/src/traceTreeView.ts
@@ -43,8 +43,18 @@ export class TraceItem extends vscode.TreeItem {
             vscode.TreeItemCollapsibleState.None
         );
 
-        this.tooltip = `${this.label}`;
-        this.description = step.error ? `Error: ${step.error}` : '';
+        // Build budget metrics display
+        const budgetParts: string[] = [];
+        if (step.cpu_delta !== undefined && step.cpu_delta > 0) {
+            budgetParts.push(`CPU: ${this.formatNumber(step.cpu_delta)}`);
+        }
+        if (step.memory_delta !== undefined && step.memory_delta > 0) {
+            budgetParts.push(`Mem: ${this.formatBytes(step.memory_delta)}`);
+        }
+        const budgetInfo = budgetParts.length > 0 ? ` [${budgetParts.join(', ')}]` : '';
+
+        this.tooltip = `${this.label}${budgetInfo}`;
+        this.description = step.error ? `Error: ${step.error}` : budgetInfo;
         this.contextValue = 'traceStep';
 
         if (step.error) {
@@ -52,5 +62,23 @@ export class TraceItem extends vscode.TreeItem {
         } else {
             this.iconPath = new vscode.ThemeIcon('pass', new vscode.ThemeColor('debugIcon.startForeground'));
         }
+    }
+
+    private formatNumber(num: number): string {
+        if (num >= 1000000) {
+            return `${(num / 1000000).toFixed(2)}M`;
+        } else if (num >= 1000) {
+            return `${(num / 1000).toFixed(2)}K`;
+        }
+        return num.toString();
+    }
+
+    private formatBytes(bytes: number): string {
+        if (bytes >= 1048576) {
+            return `${(bytes / 1048576).toFixed(2)}MB`;
+        } else if (bytes >= 1024) {
+            return `${(bytes / 1024).toFixed(2)}KB`;
+        }
+        return `${bytes}B`;
     }
 }

--- a/internal/trace/budget_test.go
+++ b/internal/trace/budget_test.go
@@ -1,0 +1,81 @@
+// Copyright 2025 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package trace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTraceNode_BudgetMetrics(t *testing.T) {
+	node := NewTraceNode("test-node", "contract_call")
+
+	// Initially, budget metrics should be nil
+	assert.Nil(t, node.CPUDelta)
+	assert.Nil(t, node.MemoryDelta)
+
+	// Set budget metrics
+	cpuDelta := uint64(150000)
+	memDelta := uint64(2048)
+	node.CPUDelta = &cpuDelta
+	node.MemoryDelta = &memDelta
+
+	assert.NotNil(t, node.CPUDelta)
+	assert.NotNil(t, node.MemoryDelta)
+	assert.Equal(t, uint64(150000), *node.CPUDelta)
+	assert.Equal(t, uint64(2048), *node.MemoryDelta)
+}
+
+func TestCreateMockTrace_WithBudgetMetrics(t *testing.T) {
+	root := CreateMockTrace()
+
+	assert.NotNil(t, root)
+
+	// Check that contract calls have budget metrics
+	hasNodeWithBudget := false
+	for _, child := range root.Children {
+		if child.Type == "contract_call" && child.CPUDelta != nil && child.MemoryDelta != nil {
+			hasNodeWithBudget = true
+			assert.Greater(t, *child.CPUDelta, uint64(0), "CPU delta should be greater than 0")
+			assert.Greater(t, *child.MemoryDelta, uint64(0), "Memory delta should be greater than 0")
+		}
+	}
+
+	assert.True(t, hasNodeWithBudget, "Mock trace should have at least one node with budget metrics")
+}
+
+func TestTraceNode_BudgetMetrics_NestedNodes(t *testing.T) {
+	// Create a tree with nested budget metrics
+	root := NewTraceNode("root", "transaction")
+	
+	call1 := NewTraceNode("call-1", "contract_call")
+	cpu1 := uint64(100000)
+	mem1 := uint64(1024)
+	call1.CPUDelta = &cpu1
+	call1.MemoryDelta = &mem1
+	root.AddChild(call1)
+
+	call2 := NewTraceNode("call-2", "contract_call")
+	cpu2 := uint64(200000)
+	mem2 := uint64(2048)
+	call2.CPUDelta = &cpu2
+	call2.MemoryDelta = &mem2
+	call1.AddChild(call2)
+
+	// Flatten and check all nodes
+	flattened := root.FlattenAll()
+	
+	assert.Equal(t, 3, len(flattened))
+	
+	// Root should not have budget (transaction node)
+	assert.Nil(t, flattened[0].CPUDelta)
+	
+	// Child nodes should have budget
+	assert.NotNil(t, flattened[1].CPUDelta)
+	assert.Equal(t, uint64(100000), *flattened[1].CPUDelta)
+	
+	assert.NotNil(t, flattened[2].CPUDelta)
+	assert.Equal(t, uint64(200000), *flattened[2].CPUDelta)
+}

--- a/internal/trace/node.go
+++ b/internal/trace/node.go
@@ -5,16 +5,18 @@ package trace
 
 // TraceNode represents a single node in the execution trace tree
 type TraceNode struct {
-	ID         string       // Unique identifier for this node
-	Type       string       // Type of event: "contract_call", "host_fn", "error", "event"
-	ContractID string       // Contract ID if applicable
-	Function   string       // Function name being called
-	Error      string       // Error message if this is an error node
-	EventData  string       // Event data/payload
-	Depth      int          // Depth in the call tree (0 = root)
-	Children   []*TraceNode // Child nodes in the execution tree
-	Parent     *TraceNode   // Parent node (nil for root)
-	Expanded   bool         // Whether this node is expanded in the UI
+	ID            string       // Unique identifier for this node
+	Type          string       // Type of event: "contract_call", "host_fn", "error", "event"
+	ContractID    string       // Contract ID if applicable
+	Function      string       // Function name being called
+	Error         string       // Error message if this is an error node
+	EventData     string       // Event data/payload
+	Depth         int          // Depth in the call tree (0 = root)
+	Children      []*TraceNode // Child nodes in the execution tree
+	Parent        *TraceNode   // Parent node (nil for root)
+	Expanded      bool         // Whether this node is expanded in the UI
+	CPUDelta      *uint64      // CPU instructions consumed by this node (nil if not tracked)
+	MemoryDelta   *uint64      // Memory bytes consumed by this node (nil if not tracked)
 }
 
 // NewTraceNode creates a new trace node

--- a/internal/trace/parser.go
+++ b/internal/trace/parser.go
@@ -92,15 +92,23 @@ func CreateMockTrace() *TraceNode {
 	root := NewTraceNode("root", "transaction")
 	root.EventData = "Transaction: 5c0a1234567890abcdef"
 
-	// Contract call 1
+	// Contract call 1 with budget metrics
 	call1 := NewTraceNode("call-1", "contract_call")
 	call1.ContractID = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
 	call1.Function = "transfer"
+	cpu1 := uint64(150000)
+	mem1 := uint64(2048)
+	call1.CPUDelta = &cpu1
+	call1.MemoryDelta = &mem1
 	root.AddChild(call1)
 
 	// Host function call
 	hostFn1 := NewTraceNode("host-1", "host_fn")
 	hostFn1.Function = "require_auth"
+	cpu2 := uint64(50000)
+	mem2 := uint64(512)
+	hostFn1.CPUDelta = &cpu2
+	hostFn1.MemoryDelta = &mem2
 	call1.AddChild(hostFn1)
 
 	// Event
@@ -112,6 +120,10 @@ func CreateMockTrace() *TraceNode {
 	call2 := NewTraceNode("call-2", "contract_call")
 	call2.ContractID = "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE"
 	call2.Function = "swap"
+	cpu3 := uint64(250000)
+	mem3 := uint64(4096)
+	call2.CPUDelta = &cpu3
+	call2.MemoryDelta = &mem3
 	root.AddChild(call2)
 
 	// Error node
@@ -123,12 +135,20 @@ func CreateMockTrace() *TraceNode {
 	call3 := NewTraceNode("call-3", "contract_call")
 	call3.ContractID = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
 	call3.Function = "get_balance"
+	cpu4 := uint64(80000)
+	mem4 := uint64(1024)
+	call3.CPUDelta = &cpu4
+	call3.MemoryDelta = &mem4
 	root.AddChild(call3)
 
 	// Nested calls
 	nestedCall := NewTraceNode("call-4", "contract_call")
 	nestedCall.ContractID = "CBGTG4XUWRWXDJ5QQVXJVFXPQNQPQNQPQNQPQNQPQNQPQNQPQNQPQNQP"
 	nestedCall.Function = "validate"
+	cpu5 := uint64(120000)
+	mem5 := uint64(1536)
+	nestedCall.CPUDelta = &cpu5
+	nestedCall.MemoryDelta = &mem5
 	call3.AddChild(nestedCall)
 
 	event2 := NewTraceNode("event-2", "event")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "sdk",
+  "name": "hintents",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -62,7 +62,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1737,7 +1736,6 @@
       "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2186,7 +2184,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.4.tgz",
       "integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -2493,7 +2490,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4252,7 +4248,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -6359,7 +6354,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -6469,7 +6463,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/sample_trace.json
+++ b/sample_trace.json
@@ -36,7 +36,9 @@
       "memory": {
         "recipient": "GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37",
         "temp_amount": 500000
-      }
+      },
+      "cpu_delta": 125000,
+      "memory_delta": 2048
     },
     {
       "step": 2,
@@ -57,7 +59,9 @@
         "amount": 100000,
         "from_balance": 500000,
         "to_balance": 100000
-      }
+      },
+      "cpu_delta": 180000,
+      "memory_delta": 3072
     },
     {
       "step": 3,
@@ -72,7 +76,9 @@
       "memory": {
         "query_account": "GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37",
         "result": 400000
-      }
+      },
+      "cpu_delta": 75000,
+      "memory_delta": 1024
     },
     {
       "step": 4,
@@ -94,7 +100,9 @@
         "attempted_amount": 500000,
         "available_balance": 400000,
         "error_triggered": true
-      }
+      },
+      "cpu_delta": 220000,
+      "memory_delta": 4096
     },
     {
       "step": 5,


### PR DESCRIPTION
Closes #315

---

- Add CPUDelta and MemoryDelta fields to TraceNode struct
- Update TraceStep interface with cpu_delta and memory_delta
- Display inline CPU and memory metrics in trace tree view
- Format budget metrics with K/M suffixes for readability
- Add comprehensive tests for budget metrics tracking
- Update mock traces with sample budget data
- Document budget metrics feature in BUDGET_METRICS.md