### PR TITLE
feat(ux): Color-blind accessible theme for the terminal UI

### DIFF
--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -1,0 +1,119 @@
+# Color-Blind Accessible Themes
+
+Erst supports multiple color themes to ensure accessibility for users with color vision deficiencies.
+
+## Available Themes
+
+### `default`
+Standard color palette using red, green, yellow, blue, cyan, and magenta.
+
+### `deuteranopia`
+Optimized for red-green color blindness (most common form). Uses blue, yellow, cyan, and magenta to avoid red-green confusion.
+
+### `protanopia`
+Optimized for red-blind color vision deficiency. Similar to deuteranopia, avoids red-green combinations.
+
+### `tritanopia`
+Optimized for blue-yellow color blindness. Uses red, green, and magenta to avoid blue-yellow confusion.
+
+### `high-contrast`
+Bold, high-contrast colors for improved visibility in all conditions. Useful for low-light environments or visual impairments.
+
+## Usage
+
+### Command Line Flag
+
+Use the `--theme` flag with any command that produces colored output:
+
+```bash
+# Debug command with deuteranopia theme
+erst debug <tx-hash> --theme deuteranopia
+
+# Trace viewer with high-contrast theme
+erst trace execution.json --theme high-contrast
+
+# Protanopia theme
+erst debug <tx-hash> --theme protanopia --network testnet
+```
+
+### Environment Variable
+
+Set the `ERST_THEME` environment variable to apply a theme globally:
+
+```bash
+export ERST_THEME=deuteranopia
+erst debug <tx-hash>
+```
+
+### Auto-Detection
+
+If no theme is specified, Erst will auto-detect an appropriate theme:
+- If `ERST_THEME` is set, use that theme
+- If `COLORTERM=truecolor`, use default theme
+- Otherwise, use high-contrast theme for maximum compatibility
+
+## Color Mappings
+
+### Default Theme
+- Success: Green
+- Error: Red
+- Warning: Yellow
+- Info: Blue
+
+### Deuteranopia/Protanopia Themes
+- Success: Cyan
+- Error: Magenta
+- Warning: Yellow
+- Info: Blue
+
+### Tritanopia Theme
+- Success: Green
+- Error: Red
+- Warning: Magenta
+- Info: Cyan
+
+### High-Contrast Theme
+- Success: Bold Green
+- Error: Bold Red
+- Warning: Bold Yellow
+- Info: Bold Cyan
+
+## Testing Your Theme
+
+Use demo mode to test color output without network access:
+
+```bash
+erst debug --demo --theme deuteranopia
+erst debug --demo --theme high-contrast
+```
+
+## Disabling Colors
+
+To disable all colors (e.g., for logging or CI):
+
+```bash
+export NO_COLOR=1
+erst debug <tx-hash>
+```
+
+Or force colors even in non-TTY environments:
+
+```bash
+export FORCE_COLOR=1
+erst debug <tx-hash> | tee output.log
+```
+
+## Accessibility Best Practices
+
+1. **Use semantic indicators**: Erst uses text indicators like `[OK]`, `[!]`, and `[X]` in addition to colors
+2. **Test with different themes**: Verify your terminal output is readable with all themes
+3. **Respect NO_COLOR**: Always honor the NO_COLOR environment variable
+4. **Provide context**: Don't rely solely on color to convey information
+
+## Contributing
+
+When adding new colored output:
+1. Use semantic color functions: `Success()`, `Error()`, `Warning()`, `Info()`
+2. Test with all themes to ensure accessibility
+3. Include text indicators alongside colors
+4. Document color usage in code comments

--- a/internal/cmd/debug.go
+++ b/internal/cmd/debug.go
@@ -50,6 +50,7 @@ var (
 	watchFlag           bool
 	watchTimeoutFlag    int
 	protocolVersionFlag uint32
+	themeFlag           string
 )
 
 // DebugCommand holds dependencies for the debug command
@@ -219,6 +220,13 @@ Local WASM Replay Mode:
 			logger.SetLevel(slog.LevelInfo)
 		} else {
 			logger.SetLevel(slog.LevelWarn)
+		}
+
+		// Apply theme if specified, otherwise auto-detect
+		if themeFlag != "" {
+			visualizer.SetTheme(visualizer.Theme(themeFlag))
+		} else {
+			visualizer.SetTheme(visualizer.DetectTheme())
 		}
 
 		// Demo mode: print sample output for testing color detection (no network)
@@ -956,6 +964,7 @@ func init() {
 	debugCmd.Flags().BoolVar(&watchFlag, "watch", false, "Poll for transaction on-chain before debugging")
 	debugCmd.Flags().IntVar(&watchTimeoutFlag, "watch-timeout", 30, "Timeout in seconds for watch mode")
 	debugCmd.Flags().Uint32Var(&protocolVersionFlag, "protocol-version", 0, "Override protocol version for simulation (20, 21, 22, etc)")
+	debugCmd.Flags().StringVar(&themeFlag, "theme", "", "Color theme (default, deuteranopia, protanopia, tritanopia, high-contrast)")
 
 	rootCmd.AddCommand(debugCmd)
 }

--- a/internal/cmd/trace.go
+++ b/internal/cmd/trace.go
@@ -9,11 +9,13 @@ import (
 
 	"github.com/dotandev/hintents/internal/errors"
 	"github.com/dotandev/hintents/internal/trace"
+	"github.com/dotandev/hintents/internal/visualizer"
 	"github.com/spf13/cobra"
 )
 
 var (
-	traceFile string
+	traceFile      string
+	traceThemeFlag string
 )
 
 var traceCmd = &cobra.Command{
@@ -32,6 +34,13 @@ Example:
   erst trace --file debug_trace.json`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Apply theme if specified, otherwise auto-detect
+		if traceThemeFlag != "" {
+			visualizer.SetTheme(visualizer.Theme(traceThemeFlag))
+		} else {
+			visualizer.SetTheme(visualizer.DetectTheme())
+		}
+
 		var filename string
 		if len(args) > 0 {
 			filename = args[0]
@@ -65,5 +74,6 @@ Example:
 
 func init() {
 	traceCmd.Flags().StringVarP(&traceFile, "file", "f", "", "Trace file to load")
+	traceCmd.Flags().StringVar(&traceThemeFlag, "theme", "", "Color theme (default, deuteranopia, protanopia, tritanopia, high-contrast)")
 	rootCmd.AddCommand(traceCmd)
 }

--- a/internal/visualizer/color.go
+++ b/internal/visualizer/color.go
@@ -98,10 +98,9 @@ func ansiWrap(text, color string) string {
 }
 
 // Success returns a success indicator: colored checkmark if enabled, "[OK]" otherwise.
-// Success returns a success indicator: colored checkmark if enabled, "[OK]" otherwise.
 func Success() string {
 	if ColorEnabled() {
-		return sgrGreen + "[OK]" + sgrReset
+		return themeColors("success") + "[OK]" + sgrReset
 	}
 	return "[OK]"
 }
@@ -109,7 +108,7 @@ func Success() string {
 // Warning returns a warning indicator: colored warning sign if enabled, "[!]" otherwise.
 func Warning() string {
 	if ColorEnabled() {
-		return sgrYellow + "[!]" + sgrReset
+		return themeColors("warning") + "[!]" + sgrReset
 	}
 	return "[!]"
 }
@@ -117,9 +116,17 @@ func Warning() string {
 // Error returns an error indicator: colored X if enabled, "[X]" otherwise.
 func Error() string {
 	if ColorEnabled() {
-		return sgrRed + "[X]" + sgrReset
+		return themeColors("error") + "[X]" + sgrReset
 	}
 	return "[X]"
+}
+
+// Info returns an info indicator with theme-aware coloring.
+func Info() string {
+	if ColorEnabled() {
+		return themeColors("info") + "[i]" + sgrReset
+	}
+	return "[i]"
 }
 
 // Symbol returns a symbol that may be styled; when colors disabled, returns plain ASCII equivalent.

--- a/internal/visualizer/color_blind_test.go
+++ b/internal/visualizer/color_blind_test.go
@@ -1,0 +1,80 @@
+// Copyright 2025 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package visualizer
+
+import (
+	"os"
+	"testing"
+)
+
+func TestColorBlindThemes(t *testing.T) {
+	os.Setenv("FORCE_COLOR", "1")
+	defer os.Unsetenv("FORCE_COLOR")
+
+	tests := []struct {
+		name  string
+		theme Theme
+	}{
+		{"deuteranopia", ThemeDeuteranopia},
+		{"protanopia", ThemeProtanopia},
+		{"tritanopia", ThemeTritanopia},
+		{"high-contrast", ThemeHighContrast},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetTheme(tt.theme)
+
+			success := Success()
+			if success == "" {
+				t.Error("Success() returned empty string")
+			}
+
+			warning := Warning()
+			if warning == "" {
+				t.Error("Warning() returned empty string")
+			}
+
+			errorMsg := Error()
+			if errorMsg == "" {
+				t.Error("Error() returned empty string")
+			}
+
+			info := Info()
+			if info == "" {
+				t.Error("Info() returned empty string")
+			}
+		})
+	}
+}
+
+func TestThemeConsistency(t *testing.T) {
+	os.Setenv("FORCE_COLOR", "1")
+	defer os.Unsetenv("FORCE_COLOR")
+
+	themes := []Theme{
+		ThemeDefault,
+		ThemeDeuteranopia,
+		ThemeProtanopia,
+		ThemeTritanopia,
+		ThemeHighContrast,
+	}
+
+	for _, theme := range themes {
+		t.Run(string(theme), func(t *testing.T) {
+			SetTheme(theme)
+
+			successColor := themeColors("success")
+			errorColor := themeColors("error")
+			warningColor := themeColors("warning")
+
+			if successColor == errorColor {
+				t.Error("success and error colors should be different")
+			}
+			if successColor == warningColor {
+				t.Error("success and warning colors should be different")
+			}
+		})
+	}
+}

--- a/internal/visualizer/theme.go
+++ b/internal/visualizer/theme.go
@@ -1,0 +1,118 @@
+// Copyright 2025 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package visualizer
+
+import "os"
+
+// Theme defines a color palette for terminal output
+type Theme string
+
+const (
+	ThemeDefault      Theme = "default"
+	ThemeDeuteranopia Theme = "deuteranopia"
+	ThemeProtanopia   Theme = "protanopia"
+	ThemeTritanopia   Theme = "tritanopia"
+	ThemeHighContrast Theme = "high-contrast"
+)
+
+var currentTheme = ThemeDefault
+
+// SetTheme configures the active color theme
+func SetTheme(theme Theme) {
+	currentTheme = theme
+}
+
+// GetTheme returns the currently active theme
+func GetTheme() Theme {
+	return currentTheme
+}
+
+// DetectTheme attempts to detect an appropriate theme from environment
+func DetectTheme() Theme {
+	if theme := os.Getenv("ERST_THEME"); theme != "" {
+		return Theme(theme)
+	}
+	if os.Getenv("COLORTERM") == "truecolor" {
+		return ThemeDefault
+	}
+	return ThemeHighContrast
+}
+
+// themeColors maps semantic color names to ANSI codes per theme
+func themeColors(semantic string) string {
+	switch currentTheme {
+	case ThemeDeuteranopia, ThemeProtanopia:
+		// Red-green color blindness: use blue/yellow/cyan
+		switch semantic {
+		case "success":
+			return sgrCyan
+		case "error":
+			return sgrMagenta
+		case "warning":
+			return sgrYellow
+		case "info":
+			return sgrBlue
+		case "dim":
+			return sgrDim
+		case "bold":
+			return sgrBold
+		default:
+			return ""
+		}
+	case ThemeTritanopia:
+		// Blue-yellow color blindness: use red/green/magenta
+		switch semantic {
+		case "success":
+			return sgrGreen
+		case "error":
+			return sgrRed
+		case "warning":
+			return sgrMagenta
+		case "info":
+			return sgrCyan
+		case "dim":
+			return sgrDim
+		case "bold":
+			return sgrBold
+		default:
+			return ""
+		}
+	case ThemeHighContrast:
+		// High contrast: bold colors only
+		switch semantic {
+		case "success":
+			return sgrBold + sgrGreen
+		case "error":
+			return sgrBold + sgrRed
+		case "warning":
+			return sgrBold + sgrYellow
+		case "info":
+			return sgrBold + sgrCyan
+		case "dim":
+			return ""
+		case "bold":
+			return sgrBold
+		default:
+			return ""
+		}
+	default:
+		// Default theme
+		switch semantic {
+		case "success":
+			return sgrGreen
+		case "error":
+			return sgrRed
+		case "warning":
+			return sgrYellow
+		case "info":
+			return sgrBlue
+		case "dim":
+			return sgrDim
+		case "bold":
+			return sgrBold
+		default:
+			return ""
+		}
+	}
+}

--- a/internal/visualizer/theme_test.go
+++ b/internal/visualizer/theme_test.go
@@ -1,0 +1,127 @@
+// Copyright 2025 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package visualizer
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSetTheme(t *testing.T) {
+	tests := []struct {
+		name  string
+		theme Theme
+		want  Theme
+	}{
+		{"default", ThemeDefault, ThemeDefault},
+		{"deuteranopia", ThemeDeuteranopia, ThemeDeuteranopia},
+		{"protanopia", ThemeProtanopia, ThemeProtanopia},
+		{"tritanopia", ThemeTritanopia, ThemeTritanopia},
+		{"high-contrast", ThemeHighContrast, ThemeHighContrast},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetTheme(tt.theme)
+			if got := GetTheme(); got != tt.want {
+				t.Errorf("GetTheme() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectTheme(t *testing.T) {
+	tests := []struct {
+		name      string
+		envTheme  string
+		colorTerm string
+		want      Theme
+	}{
+		{"explicit theme", "deuteranopia", "", ThemeDeuteranopia},
+		{"truecolor", "", "truecolor", ThemeDefault},
+		{"fallback", "", "", ThemeHighContrast},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Unsetenv("ERST_THEME")
+			os.Unsetenv("COLORTERM")
+
+			if tt.envTheme != "" {
+				os.Setenv("ERST_THEME", tt.envTheme)
+			}
+			if tt.colorTerm != "" {
+				os.Setenv("COLORTERM", tt.colorTerm)
+			}
+
+			if got := DetectTheme(); got != tt.want {
+				t.Errorf("DetectTheme() = %v, want %v", got, tt.want)
+			}
+
+			os.Unsetenv("ERST_THEME")
+			os.Unsetenv("COLORTERM")
+		})
+	}
+}
+
+func TestThemeColors(t *testing.T) {
+	tests := []struct {
+		name     string
+		theme    Theme
+		semantic string
+		wantCode string
+	}{
+		{"default success", ThemeDefault, "success", sgrGreen},
+		{"default error", ThemeDefault, "error", sgrRed},
+		{"default warning", ThemeDefault, "warning", sgrYellow},
+		{"deuteranopia success", ThemeDeuteranopia, "success", sgrCyan},
+		{"deuteranopia error", ThemeDeuteranopia, "error", sgrMagenta},
+		{"protanopia success", ThemeProtanopia, "success", sgrCyan},
+		{"tritanopia success", ThemeTritanopia, "success", sgrGreen},
+		{"tritanopia warning", ThemeTritanopia, "warning", sgrMagenta},
+		{"high-contrast success", ThemeHighContrast, "success", sgrBold + sgrGreen},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetTheme(tt.theme)
+			if got := themeColors(tt.semantic); got != tt.wantCode {
+				t.Errorf("themeColors(%q) = %q, want %q", tt.semantic, got, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestThemeAwareIndicators(t *testing.T) {
+	originalTheme := GetTheme()
+	defer SetTheme(originalTheme)
+
+	os.Setenv("FORCE_COLOR", "1")
+	defer os.Unsetenv("FORCE_COLOR")
+
+	tests := []struct {
+		name  string
+		theme Theme
+		fn    func() string
+	}{
+		{"success default", ThemeDefault, Success},
+		{"success deuteranopia", ThemeDeuteranopia, Success},
+		{"error default", ThemeDefault, Error},
+		{"warning high-contrast", ThemeHighContrast, Warning},
+		{"info default", ThemeDefault, Info},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetTheme(tt.theme)
+			result := tt.fn()
+			if result == "" {
+				t.Error("indicator returned empty string")
+			}
+			if !ColorEnabled() {
+				t.Skip("colors disabled")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add --theme flag to debug and trace commands with 5 accessible themes:
- default: standard colors
- deuteranopia/protanopia: red-green color blind friendly
- tritanopia: blue-yellow color blind friendly
- high-contrast: bold colors for low vision

Themes auto-detect from ERST_THEME env var or terminal capabilities. All themes maintain text indicators alongside colors for accessibility.

Closes #313

<img width="664" height="603" alt="Screenshot 2026-02-25 065749" src="https://github.com/user-attachments/assets/05069d31-c976-406d-a430-bd26d252b10f" />
<img width="636" height="558" alt="Screenshot 2026-02-25 065808" src="https://github.com/user-attachments/assets/ad7ecb5e-5990-4995-92e8-713c991f2e5a" />
