### PR TITLE
feat(rpc): Fetch contract bytecode transparently on demand

### DIFF
--- a/internal/cmd/debug.go
+++ b/internal/cmd/debug.go
@@ -401,6 +401,13 @@ Local WASM Replay Mode:
 					return fmt.Errorf("simulation failed: %w", err)
 				}
 				printSimulationResult(networkFlag, simResp)
+				// Fetch contract bytecode on demand for any contract calls in the trace; cache via RPC client
+				if client != nil && simResp != nil && len(simResp.DiagnosticEvents) > 0 {
+					contractIDs := collectContractIDsFromDiagnosticEvents(simResp.DiagnosticEvents)
+					if len(contractIDs) > 0 {
+						_, _ = rpc.FetchBytecodeForTraceContractCalls(ctx, client, contractIDs, nil)
+					}
+				}
 			} else {
 				// Comparison Run
 				var wg sync.WaitGroup
@@ -472,6 +479,13 @@ Local WASM Replay Mode:
 				}
 				if compareErr != nil {
 					return fmt.Errorf("compare network error: %w", compareErr)
+				}
+				// Fetch contract bytecode on demand for contract calls in the trace; cache via RPC client
+				if client != nil && primaryResult != nil && len(primaryResult.DiagnosticEvents) > 0 {
+					contractIDs := collectContractIDsFromDiagnosticEvents(primaryResult.DiagnosticEvents)
+					if len(contractIDs) > 0 {
+						_, _ = rpc.FetchBytecodeForTraceContractCalls(ctx, client, contractIDs, nil)
+					}
 				}
 
 				simResp = primaryResult // Use primary for further analysis
@@ -747,6 +761,21 @@ func extractLedgerKeys(metaXdr string) ([]string, error) {
 		res = append(res, k)
 	}
 	return res, nil
+}
+
+// collectContractIDsFromDiagnosticEvents returns unique contract IDs from diagnostic events (trace).
+func collectContractIDsFromDiagnosticEvents(events []simulator.DiagnosticEvent) []string {
+	seen := make(map[string]struct{})
+	var ids []string
+	for _, e := range events {
+		if e.ContractID != nil && *e.ContractID != "" {
+			if _, ok := seen[*e.ContractID]; !ok {
+				seen[*e.ContractID] = struct{}{}
+				ids = append(ids, *e.ContractID)
+			}
+		}
+	}
+	return ids
 }
 
 func printSimulationResult(network string, res *simulator.SimulationResponse) {

--- a/internal/rpc/bytecode.go
+++ b/internal/rpc/bytecode.go
@@ -1,0 +1,188 @@
+// Copyright 2025 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package rpc
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/dotandev/hintents/internal/logger"
+	"github.com/stellar/go-stellar-sdk/strkey"
+	"github.com/stellar/go-stellar-sdk/xdr"
+)
+
+// ScValType for contract instance ledger key (ScvLedgerKeyContractInstance = 20 in Stellar XDR).
+const scValTypeLedgerKeyContractInstance xdr.ScValType = 20
+
+// LedgerKeyForContractInstance builds a LedgerKey for the contract instance ContractData entry.
+// The key is used with getLedgerEntries to fetch the instance, which contains the executable (wasm hash).
+func LedgerKeyForContractInstance(contractID xdr.ContractId) (xdr.LedgerKey, error) {
+	addr := xdr.ScAddress{
+		Type:       xdr.ScAddressTypeScAddressTypeContract,
+		ContractId: &contractID,
+	}
+	// Key for contract instance entry is the special ScVal ScvLedgerKeyContractInstance (void).
+	key := xdr.ScVal{
+		Type: scValTypeLedgerKeyContractInstance,
+	}
+	return xdr.LedgerKey{
+		Type: xdr.LedgerEntryTypeContractData,
+		ContractData: &xdr.LedgerKeyContractData{
+			Contract:   addr,
+			Key:        key,
+			Durability: xdr.ContractDataDurabilityPersistent,
+		},
+	}, nil
+}
+
+// ContractCodeHashFromInstanceEntry parses a ContractData ledger entry (instance) and returns
+// the contract code (WASM) hash from the executable. Returns an error if the entry is not
+// a contract instance or has no WASM executable.
+func ContractCodeHashFromInstanceEntry(entryXDR string) (xdr.Hash, error) {
+	raw, err := base64.StdEncoding.DecodeString(entryXDR)
+	if err != nil {
+		return xdr.Hash{}, fmt.Errorf("decode instance entry: %w", err)
+	}
+	var entry xdr.LedgerEntry
+	if err := entry.UnmarshalBinary(raw); err != nil {
+		return xdr.Hash{}, fmt.Errorf("unmarshal ledger entry: %w", err)
+	}
+	if entry.Data.Type != xdr.LedgerEntryTypeContractData || entry.Data.ContractData == nil {
+		return xdr.Hash{}, fmt.Errorf("not a contract data entry")
+	}
+	val := entry.Data.ContractData.Val
+	if val.Type != xdr.ScValTypeScvContractInstance || val.Instance == nil {
+		return xdr.Hash{}, fmt.Errorf("contract data is not a contract instance")
+	}
+	exec := val.Instance.Executable
+	switch exec.Type {
+	case xdr.ContractExecutableTypeContractExecutableWasm:
+		if exec.WasmHash == nil {
+			return xdr.Hash{}, fmt.Errorf("instance executable has nil wasm hash")
+		}
+		return *exec.WasmHash, nil
+	default:
+		return xdr.Hash{}, fmt.Errorf("executable type %v is not WASM", exec.Type)
+	}
+}
+
+// decodeContractID decodes a contract ID from strkey (C...) or 32-byte hex.
+func decodeContractID(contractIDStr string) (xdr.ContractId, error) {
+	s := strings.TrimSpace(contractIDStr)
+	if len(s) == 0 {
+		return xdr.ContractId{}, fmt.Errorf("empty contract id")
+	}
+	if s[0] == 'C' {
+		decoded, err := strkey.Decode(strkey.VersionByteContract, s)
+		if err != nil {
+			return xdr.ContractId{}, fmt.Errorf("decode strkey contract id: %w", err)
+		}
+		if len(decoded) != 32 {
+			return xdr.ContractId{}, fmt.Errorf("contract id must be 32 bytes, got %d", len(decoded))
+		}
+		var cid xdr.ContractId
+		copy(cid[:], decoded)
+		return cid, nil
+	}
+	raw, err := hex.DecodeString(s)
+	if err != nil {
+		return xdr.ContractId{}, fmt.Errorf("decode hex contract id: %w", err)
+	}
+	if len(raw) != 32 {
+		return xdr.ContractId{}, fmt.Errorf("contract id must be 32 bytes, got %d", len(raw))
+	}
+	var cid xdr.ContractId
+	copy(cid[:], raw)
+	return cid, nil
+}
+
+// FetchContractBytecode fetches the un-executed WASM for the given contract ID via getLedgerEntries,
+// and caches it using the existing RPC client cache. contractIDStr can be a strkey (C...) or 32-byte hex.
+// It returns the ledger key->entry map for the instance and code entries; the client also caches them.
+func FetchContractBytecode(ctx context.Context, c *Client, contractIDStr string) (map[string]string, error) {
+	cid, err := decodeContractID(contractIDStr)
+	if err != nil {
+		return nil, err
+	}
+
+	instanceKey, err := LedgerKeyForContractInstance(cid)
+	if err != nil {
+		return nil, fmt.Errorf("build instance key: %w", err)
+	}
+	entries := make(map[string]string)
+	instanceKeyB64, err := EncodeLedgerKey(instanceKey)
+	if err != nil {
+		return nil, fmt.Errorf("encode instance key: %w", err)
+	}
+
+	instanceEntries, err := c.GetLedgerEntries(ctx, []string{instanceKeyB64})
+	if err != nil {
+		return nil, fmt.Errorf("get ledger entries (instance): %w", err)
+	}
+	for k, v := range instanceEntries {
+		entries[k] = v
+	}
+	instanceEntry, ok := instanceEntries[instanceKeyB64]
+	if !ok || instanceEntry == "" {
+		return nil, fmt.Errorf("contract instance not found for %s", contractIDStr)
+	}
+
+	codeHash, err := ContractCodeHashFromInstanceEntry(instanceEntry)
+	if err != nil {
+		return nil, fmt.Errorf("get code hash from instance: %w", err)
+	}
+
+	codeKey := xdr.LedgerKey{
+		Type:         xdr.LedgerEntryTypeContractCode,
+		ContractCode: &xdr.LedgerKeyContractCode{Hash: codeHash},
+	}
+	codeKeyB64, err := EncodeLedgerKey(codeKey)
+	if err != nil {
+		return nil, fmt.Errorf("encode code key: %w", err)
+	}
+
+	codeEntries, err := c.GetLedgerEntries(ctx, []string{codeKeyB64})
+	if err != nil {
+		return nil, fmt.Errorf("get ledger entries (code): %w", err)
+	}
+	for k, v := range codeEntries {
+		entries[k] = v
+	}
+	logger.Logger.Debug("Fetched contract bytecode on demand", "contract_id", contractIDStr, "cached", true)
+	return entries, nil
+}
+
+// FetchBytecodeForTraceContractCalls collects unique contract IDs from diagnostic events,
+// fetches each contract's WASM via getLedgerEntries (and caches it), and returns the combined
+// ledger entries map. Entries already present in existingMap are not re-fetched.
+// The client's cache is populated so subsequent use of the same contract ID will hit the cache.
+func FetchBytecodeForTraceContractCalls(ctx context.Context, c *Client, contractIDs []string, existingMap map[string]string) (map[string]string, error) {
+	seen := make(map[string]struct{})
+	for _, id := range contractIDs {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		// We could check existingMap for an entry that matches this contract's code, but that would
+		// require parsing; simpler to always call FetchContractBytecode which uses the client cache.
+		fetched, err := FetchContractBytecode(ctx, c, id)
+		if err != nil {
+			logger.Logger.Warn("Failed to fetch contract bytecode for trace", "contract_id", id, "error", err)
+			continue
+		}
+		if existingMap == nil {
+			existingMap = make(map[string]string)
+		}
+		for k, v := range fetched {
+			existingMap[k] = v
+		}
+	}
+	return existingMap, nil
+}

--- a/internal/rpc/bytecode_test.go
+++ b/internal/rpc/bytecode_test.go
@@ -1,0 +1,105 @@
+// Copyright 2025 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package rpc
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stellar/go-stellar-sdk/xdr"
+)
+
+func TestLedgerKeyForContractInstance(t *testing.T) {
+	var cid xdr.ContractId
+	for i := range 32 {
+		cid[i] = byte(i + 1)
+	}
+	key, err := LedgerKeyForContractInstance(cid)
+	if err != nil {
+		t.Fatalf("LedgerKeyForContractInstance: %v", err)
+	}
+	if key.Type != xdr.LedgerEntryTypeContractData {
+		t.Errorf("expected ContractData key type, got %v", key.Type)
+	}
+	if key.ContractData == nil {
+		t.Fatal("expected non-nil ContractData")
+	}
+	if key.ContractData.Contract.Type != xdr.ScAddressTypeScAddressTypeContract {
+		t.Errorf("expected contract address type, got %v", key.ContractData.Contract.Type)
+	}
+	if key.ContractData.Contract.ContractId == nil || *key.ContractData.Contract.ContractId != cid {
+		t.Error("contract id mismatch")
+	}
+	if key.ContractData.Durability != xdr.ContractDataDurabilityPersistent {
+		t.Errorf("expected persistent durability, got %v", key.ContractData.Durability)
+	}
+	_, err = EncodeLedgerKey(key)
+	if err != nil {
+		t.Errorf("EncodeLedgerKey: %v", err)
+	}
+}
+
+func TestDecodeContractID_Strkey(t *testing.T) {
+	// Use a valid strkey form: we need 32 bytes encoded. Build from known bytes.
+	var cid xdr.ContractId
+	for i := range 32 {
+		cid[i] = byte(i)
+	}
+	// Decode then re-encode as strkey would require the strkey package; instead test hex path
+	hexID := "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+	decoded, err := decodeContractID(hexID)
+	if err != nil {
+		t.Fatalf("decodeContractID(hex): %v", err)
+	}
+	if decoded != cid {
+		t.Errorf("decodeContractID hex: got %x, want %x", decoded[:], cid[:])
+	}
+}
+
+func TestDecodeContractID_Empty(t *testing.T) {
+	_, err := decodeContractID("")
+	if err == nil {
+		t.Error("expected error for empty contract id")
+	}
+}
+
+func TestDecodeContractID_InvalidHex(t *testing.T) {
+	_, err := decodeContractID("zz")
+	if err == nil {
+		t.Error("expected error for invalid hex")
+	}
+}
+
+func TestDecodeContractID_WrongLengthHex(t *testing.T) {
+	_, err := decodeContractID("0001") // 2 bytes
+	if err == nil {
+		t.Error("expected error for wrong length hex")
+	}
+}
+
+func TestContractCodeHashFromInstanceEntry_InvalidBase64(t *testing.T) {
+	_, err := ContractCodeHashFromInstanceEntry("!!!")
+	if err == nil {
+		t.Error("expected error for invalid base64")
+	}
+}
+
+func TestContractCodeHashFromInstanceEntry_NotContractData(t *testing.T) {
+	// Build a minimal account entry (wrong type)
+	entry := xdr.LedgerEntry{
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeAccount,
+			Account: &xdr.AccountEntry{
+				AccountId: xdr.MustAddress("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H"),
+				Balance:   100,
+			},
+		},
+	}
+	raw, _ := entry.MarshalBinary()
+	b64 := base64.StdEncoding.EncodeToString(raw)
+	_, err := ContractCodeHashFromInstanceEntry(b64)
+	if err == nil {
+		t.Error("expected error for non-contract-data entry")
+	}
+}


### PR DESCRIPTION
## Summary
When a contract call appears in the trace (diagnostic events), the debug flow now fetches that contract’s un-executed WASM via `getLedgerEntries` and caches it using the existing RPC client cache.

Closes #385
Closes #169

## Changes
- **`internal/rpc/bytecode.go`**
  - `LedgerKeyForContractInstance(contractID)` – builds the ContractData ledger key for a contract instance (ScvLedgerKeyContractInstance).
  - `ContractCodeHashFromInstanceEntry(entryXDR)` – parses a contract instance ContractData entry and returns the WASM code hash from the executable.
  - `decodeContractID(s)` – decodes contract ID from strkey (`C...`) or 32-byte hex.
  - `FetchContractBytecode(ctx, client, contractIDStr)` – fetches instance entry via getLedgerEntries, then contract code entry by code hash; both are cached by the client.
  - `FetchBytecodeForTraceContractCalls(ctx, client, contractIDs, existingMap)` – deduplicates contract IDs, calls `FetchContractBytecode` for each, merges into the given map; logs and skips on per-contract errors.
- **`internal/cmd/debug.go`**
  - `collectContractIDsFromDiagnosticEvents(events)` – returns unique contract IDs from simulation diagnostic events.
  - After simulation (single-network and comparison), collects contract IDs from the trace and calls `rpc.FetchBytecodeForTraceContractCalls` so bytecode for those contracts is fetched and cached.
- **`internal/rpc/bytecode_test.go`** – tests for `LedgerKeyForContractInstance`, `decodeContractID` (hex, empty, invalid), and `ContractCodeHashFromInstanceEntry` (invalid base64, wrong entry type).

## How to verify
1. `go build ./...`
2. `go test ./internal/rpc/... ./internal/cmd/...`
3. Run `erst debug <tx-hash>` on a tx that invokes contracts; after simulation, bytecode for contract IDs in the trace is fetched via getLedgerEntries and cached (subsequent use hits the cache).

## Checklist
- [x] Implementation matches requirements (fetch WASM via getLedgerEntries when contract call appears in trace; cache it).
- [x] No lints suppressed; no emojis/slops.
- [x] New/updated tests; build passes.