### PR TITLE
feat(errors): add ErrRPCResponseTooLarge and related error handling

### DIFF
--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -21,6 +21,7 @@ func TestSentinelErrors(t *testing.T) {
 	assert.NotNil(t, ErrMarshalFailed)
 	assert.NotNil(t, ErrUnmarshalFailed)
 	assert.NotNil(t, ErrSimulationLogicError)
+	assert.NotNil(t, ErrRPCResponseTooLarge)
 }
 
 func TestErrorWrapping(t *testing.T) {
@@ -80,4 +81,19 @@ func TestErrorComparison(t *testing.T) {
 
 	assert.True(t, errors.Is(err2, ErrRPCConnectionFailed))
 	assert.False(t, errors.Is(err2, ErrTransactionNotFound))
+}
+
+func TestWrapRPCResponseTooLarge(t *testing.T) {
+	url := "https://soroban-testnet.stellar.org"
+	err := WrapRPCResponseTooLarge(url)
+
+	assert.True(t, errors.Is(err, ErrRPCResponseTooLarge))
+	assert.False(t, errors.Is(err, ErrRPCConnectionFailed))
+	assert.Contains(t, err.Error(), url)
+	assert.Contains(t, err.Error(), "exceeded the server's maximum allowed size")
+	assert.Contains(t, err.Error(), "Soroban RPC response limit")
+
+	var rte *ResponseTooLargeError
+	assert.True(t, errors.As(err, &rte))
+	assert.Equal(t, url, rte.URL)
 }


### PR DESCRIPTION
# TITLE

feat(rpc): Handle oversized Soroban RPC responses gracefully (#391)

# DESCRIPTION

## Overview

Implements graceful handling for HTTP 413 (Payload Too Large / Response Too Large) in RPC client and retry paths by mapping it to a clear, user-readable Soroban REST limit message.

## Changes

### Core Implementation

- Added explicit handling for HTTP 413 in RPC client request flows.
- Mapped 413 into a dedicated readable error for Soroban response-size limits (`ErrRPCResponseTooLarge` + wrapper).
- Updated retry logic to treat 413 as non-retryable and fail fast with actionable messaging.
- Added helper detection in RPC layer for response-too-large conditions.

### Error Mapping Behavior

When a Soroban endpoint returns 413, the system now reports a clear message indicating the response exceeded provider limits and suggests reducing request scope (for example, fewer ledger keys) or adjusting provider limits.

### Testing

- Added error package tests for:
  - `ErrRPCResponseTooLarge` sentinel behavior
  - wrapping/unwrapping behavior
- Added RPC client tests for:
  - `GetLedgerEntries` 413 handling
  - `SimulateTransaction` 413 handling
  - response-too-large helper checks
- Added retry tests for:
  - fast-fail behavior on 413 (no retry loops)
  - transport-level 413 handling

## Verification

- Targeted tests for new 413 behavior pass.
- Existing unrelated ledger integration/unit failures are pre-existing on main and not introduced by this change.
- No lint suppressions added.

## Related Issues

Closes #391  
Refs #175

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added/updated
- [x] No lint suppressions added
- [x] No new linting issues from this change
- [x] Changes verified locally
