### PR TITLE
feat(audit): Implement YubiKey PIV integration for signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Optional:
 
 - `ERST_PKCS11_SLOT` (numeric index into the slot list)
 - `ERST_PKCS11_TOKEN_LABEL`
+- `ERST_PKCS11_PIV_SLOT` (YubiKey PIV slot such as 9a, 9c, 9d, 9e, 82-95, f9)
 
 Example:
 
@@ -100,6 +101,8 @@ node dist/index.js audit:sign \
 ```
 
 The command prints the signed audit log JSON to stdout so it can be redirected to a file.
+
+For YubiKey PIV (YKCS11) usage details, see [docs/pkcs11-yubikey.md](docs/pkcs11-yubikey.md).
 
 ## Documentation
 

--- a/docs/pkcs11-yubikey.md
+++ b/docs/pkcs11-yubikey.md
@@ -1,0 +1,54 @@
+# YubiKey PIV (YKCS11) audit:sign
+
+This guide documents how to use a YubiKey in PIV mode with the PKCS#11 signer for `audit:sign`.
+
+## Requirements
+
+- YubiKey with PIV enabled
+- YKCS11 module (typically `libykcs11.so` from Yubico, often in `/usr/local/lib` or `/usr/lib`)
+- A PIV key and certificate in the slot you plan to use
+
+## Environment variables
+
+Required:
+
+- `ERST_PKCS11_MODULE`
+- `ERST_PKCS11_PIN`
+- `ERST_PKCS11_PUBLIC_KEY_PEM`
+- One of `ERST_PKCS11_KEY_LABEL`, `ERST_PKCS11_KEY_ID`, or `ERST_PKCS11_PIV_SLOT`
+
+Optional:
+
+- `ERST_PKCS11_TOKEN_LABEL` to select the correct YubiKey if multiple tokens are present
+- `ERST_PKCS11_SLOT` to select a slot by index instead of token label
+
+## PIV slot to key ID mapping (YKCS11)
+
+YKCS11 exposes PIV keys with PKCS#11 CKA_ID values that map to PIV slots. Use `ERST_PKCS11_PIV_SLOT` with one of the following values and the signer will derive the correct key ID:
+
+- `9a` -> key ID `01`
+- `9c` -> key ID `02`
+- `9d` -> key ID `03`
+- `9e` -> key ID `04`
+- `82` to `95` -> key ID `05` to `18`
+- `f9` -> key ID `19`
+
+## Example
+
+```bash
+export ERST_PKCS11_MODULE=/usr/local/lib/libykcs11.so
+export ERST_PKCS11_PIN=123456
+export ERST_PKCS11_TOKEN_LABEL="YubiKey PIV"
+export ERST_PKCS11_PIV_SLOT=9c
+export ERST_PKCS11_PUBLIC_KEY_PEM="$(cat ./yubikey-piv-spki.pem)"
+
+node dist/index.js audit:sign \
+  --hsm-provider pkcs11 \
+  --payload '{"input":{},"state":{},"events":[],"timestamp":"2026-01-01T00:00:00.000Z"}'
+```
+
+## Notes
+
+- PIV slot `9c` is typically used for Digital Signature keys.
+- If you already know the PKCS#11 key label exposed by YKCS11, you can use `ERST_PKCS11_KEY_LABEL` instead of `ERST_PKCS11_PIV_SLOT`.
+- The public key should be provided as SPKI PEM. If you only have a PIV certificate, extract the SPKI public key with `openssl` and set `ERST_PKCS11_PUBLIC_KEY_PEM`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "packages": {
     "": {
       "dependencies": {
-        "@aws-sdk/client-kms": "^3.609.0",
         "@stellar/stellar-sdk": "^14.5.0",
         "axios": "^1.13.4",
         "buffer": "^6.0.3",
@@ -32,6 +31,9 @@
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vscode": "^1.1.37"
+      },
+      "optionalDependencies": {
+        "@aws-sdk/client-kms": "^3.0.0"
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {
@@ -39,6 +41,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
       "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
         "@aws-crypto/supports-web-crypto": "^5.2.0",
@@ -54,6 +57,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -66,6 +70,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
@@ -79,6 +84,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
         "tslib": "^2.6.2"
@@ -92,6 +98,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
       "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
@@ -106,6 +113,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
       "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "tslib": "^2.6.2"
       }
@@ -115,6 +123,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
       "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
         "@smithy/util-utf8": "^2.0.0",
@@ -126,6 +135,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -138,6 +148,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
@@ -151,6 +162,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
         "tslib": "^2.6.2"
@@ -164,6 +176,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.996.0.tgz",
       "integrity": "sha512-8uv1UamtwcA0550HdJBk+/NDfRM+Hs68897NEcUCQyL+w6U41IumeTG4RspmbsMhBbHYrAKXuIQFAQvDvdVESg==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -214,6 +227,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.996.0.tgz",
       "integrity": "sha512-QzlZozTam0modnGanLjXBHbHC53mMxH/4XmoA9f6ZjPYaGlCcHPYLcslO6w2w68v+F3qN0kxVldUAcL/edtBBA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -263,6 +277,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.12.tgz",
       "integrity": "sha512-hFiezao0lCEddPhSQEF6vCu+TepUN3edKxWYbswMoH87XpUvHJmFVX5+zttj4qi33saGiuOaJciswWcN6YSA9g==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@aws-sdk/xml-builder": "^3.972.5",
@@ -287,6 +302,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.10.tgz",
       "integrity": "sha512-YTWjM78Wiqix0Jv/anbq7+COFOFIBBMLZ+JsLKGwbTZNJ2DG4JNBnLVJAWylPOHwurMws9157pqzU8ODrpBOow==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.12",
         "@aws-sdk/types": "^3.973.1",
@@ -303,6 +319,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.12.tgz",
       "integrity": "sha512-adDRE3iFrgJJ7XhRHkb6RdFDMrA5x64WAWxygI3F6wND+3v5qQ4Uks12vsnEZgduU/+JQBgFB6L4vfwUS+rpBQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.12",
         "@aws-sdk/types": "^3.973.1",
@@ -324,6 +341,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.10.tgz",
       "integrity": "sha512-uAXUMfnQJxJ25qeiX4e3Z36NTm1XT7woajV8BXx2yAUDD4jF6kubqnLEcqtiPzHANxmhta2SXm5PbDwSdhThBw==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.12",
         "@aws-sdk/credential-provider-env": "^3.972.10",
@@ -349,6 +367,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.10.tgz",
       "integrity": "sha512-7Me+/EkY3kQC1nehBjb9ryc558N+a8R4Dg3rSV3zpiB7iQtvXh4gU3rV14h/dIbn2/VkK9sh55YdXamSjfdb/Q==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.12",
         "@aws-sdk/nested-clients": "3.996.0",
@@ -368,6 +387,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.11.tgz",
       "integrity": "sha512-maPmjL7nOT93a1QdSDzdF/qLbI+jit3oslKp7g+pTbASewkSYax7FwboETdKRxufPfCdrsRzMW2pIJ+QA8e+Bg==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "^3.972.10",
         "@aws-sdk/credential-provider-http": "^3.972.12",
@@ -391,6 +411,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.10.tgz",
       "integrity": "sha512-tk/XxFhk37rKviArOIYbJ8crXiN3Mzn7Tb147jH51JTweNgUOwmqN+s027uqc3d8UeAyUcPUH8Bmfj86SzOhBQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.12",
         "@aws-sdk/types": "^3.973.1",
@@ -408,6 +429,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.10.tgz",
       "integrity": "sha512-tIz/O0yV1s77/FjMTWvvzU2vsztap2POlbetheOyRXq+E3PQtLOzCYopasXP+aeO1oerw3PFd9eycLbiwpgZZA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-sdk/client-sso": "3.996.0",
         "@aws-sdk/core": "^3.973.12",
@@ -427,6 +449,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.10.tgz",
       "integrity": "sha512-HFlIVx8mm+Au7hkO7Hq/ZkPomjTt26iRj8uWZqEE1cJWMZ2NKvieNiT1ngzWt60Bc2uD51LqQUqiwr5JDgS4iQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.12",
         "@aws-sdk/nested-clients": "3.996.0",
@@ -445,6 +468,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.3.tgz",
       "integrity": "sha512-aknPTb2M+G3s+0qLCx4Li/qGZH8IIYjugHMv15JTYMe6mgZO8VBpYgeGYsNMGCqCZOcWzuf900jFBG5bopfzmA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@smithy/protocol-http": "^5.3.8",
@@ -460,6 +484,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.3.tgz",
       "integrity": "sha512-Ftg09xNNRqaz9QNzlfdQWfpqMCJbsQdnZVJP55jfhbKi1+FTWxGuvfPoBhDHIovqWKjqbuiew3HuhxbJ0+OjgA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@smithy/types": "^4.12.0",
@@ -474,6 +499,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.3.tgz",
       "integrity": "sha512-PY57QhzNuXHnwbJgbWYTrqIDHYSeOlhfYERTAuc16LKZpTZRJUjzBFokp9hF7u1fuGeE3D70ERXzdbMBOqQz7Q==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@aws/lambda-invoke-store": "^0.2.2",
@@ -490,6 +516,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.12.tgz",
       "integrity": "sha512-iv9toQZloEJp+dIuOr+1XWGmBMLU9c2qqNtgscfnEBZnUq3qKdBJHmLTKoq3mkLlV+41GrCWn8LrOunc6OlP6g==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.12",
         "@aws-sdk/types": "^3.973.1",
@@ -508,6 +535,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.0.tgz",
       "integrity": "sha512-edZwYLgRI0rZlH9Hru9+JvTsR1OAxuCRGEtJohkZneIJ5JIYzvFoMR1gaASjl1aPKRhjkCv8SSAb7hes5a1GGA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -557,6 +585,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.3.tgz",
       "integrity": "sha512-v4J8qYAWfOMcZ4MJUyatntOicTzEMaU7j3OpkRCGGFSL2NgXQ5VbxauIyORA+pxdKZ0qQG2tCQjQjZDlXEC3Ow==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@smithy/config-resolver": "^4.4.6",
@@ -573,6 +602,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.996.0.tgz",
       "integrity": "sha512-jzBmlG97hYPdHjFs7G11fBgVArcwUrZX+SbGeQMph7teEWLDqIruKV+N0uzxFJF2GJJJ0UnMaKhv3PcXMltySg==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.12",
         "@aws-sdk/nested-clients": "3.996.0",
@@ -591,6 +621,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
       "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -604,6 +635,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.0.tgz",
       "integrity": "sha512-EhSBGWSGQ6Jcbt6jRyX1/0EV7rf+6RGbIIskN0MTtHk0k8uj5FAa1FZhLf+1ETfnDTy/BT39t5IUOQiZL5X1jQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@smithy/types": "^4.12.0",
@@ -620,6 +652,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.4.tgz",
       "integrity": "sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -632,6 +665,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.3.tgz",
       "integrity": "sha512-JurOwkRUcXD/5MTDBcqdyQ9eVedtAsZgw5rBwktsPTN7QtPiS2Ld1jkJepNgYoCufz1Wcut9iup7GJDoIHp8Fw==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@smithy/types": "^4.12.0",
@@ -644,6 +678,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.11.tgz",
       "integrity": "sha512-pQr35pSZANfUb0mJ9H87pziJQ39jW1D7xFRwh36eWfrEclbKoIqrzpOIVz49o1Jq9ZQzOtjS7rQVvt7V4w5awA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@aws-sdk/middleware-user-agent": "^3.972.12",
         "@aws-sdk/types": "^3.973.1",
@@ -668,6 +703,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.5.tgz",
       "integrity": "sha512-mCae5Ys6Qm1LDu0qdGwx2UQ63ONUe+FHw908fJzLDqFKTDBK4LDZUqKWm4OkTCNFq19bftjsBSESIGLD/s3/rA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/types": "^4.12.0",
         "fast-xml-parser": "5.3.6",
@@ -682,6 +718,7 @@
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
       "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -2222,6 +2259,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.9.tgz",
       "integrity": "sha512-6YGSygFmck1vMjzSxbjEPKMm1xWUr2+w+F8kWVc8rqKQYd1C5zZftvxGii4ti4Mh5ulIXZtAUoXS88Hhu6fkjQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
@@ -2235,6 +2273,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.7.tgz",
       "integrity": "sha512-RISbtc12JKdFRYadt2kW12Cp6XCSU00uFaBZPZqInNVSrRdJFPY/S6nd6/sV7+ySTgGPiKrERtnimEFI6sSweQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.9",
         "@smithy/types": "^4.12.1",
@@ -2252,6 +2291,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.4.tgz",
       "integrity": "sha512-IH7G3hWxUhd2Z6HtvjZ1EiyDBCRYRr2sngOB9KUWf96XQ8JP2O5ascUH6TouW5YCIMFaVnKADEscM/vUfI3TvA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/middleware-serde": "^4.2.10",
         "@smithy/protocol-http": "^5.3.9",
@@ -2273,6 +2313,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.9.tgz",
       "integrity": "sha512-Jf723a38EGAzWHxJHzb9DtBq7lrvdJlkCAPWQdN/oiznovx5yWXCFCVspzDe8JU6b+k9hJXYB5duFZpb+3mB6Q==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.9",
         "@smithy/property-provider": "^4.2.9",
@@ -2289,6 +2330,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.10.tgz",
       "integrity": "sha512-qF4EcrEtEf2P6f2kGGuSVe1lan26cn7PsWJBC3vZJ6D16Fm5FSN06udOMVoW6hjzQM3W7VDFwtyUG2szQY50dA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/protocol-http": "^5.3.9",
         "@smithy/querystring-builder": "^4.2.9",
@@ -2305,6 +2347,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.9.tgz",
       "integrity": "sha512-/iSYAwSIA/SAeLga2YEpPLLOmw3n86RW4/bkhxtY1DSTR9z5HGjbYTzPaBKv2m8a4nK1rqZWchhl41qTaqMLbg==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/types": "^4.12.1",
         "@smithy/util-buffer-from": "^4.2.1",
@@ -2320,6 +2363,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.9.tgz",
       "integrity": "sha512-J+0rlwWZKgOYugVgRE5VlVz/UFV+6cIpZkmfWBq1ld1x3htKDdHOutYhZTURIvSVztWn0T3aghCdEzGdXXsSMw==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
@@ -2333,6 +2377,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.1.tgz",
       "integrity": "sha512-Yfu664Qbf1B4IYIsYgKoABt010daZjkaCRvdU/sPnZG6TtHOB0md0RjNdLGzxe5UIdn9js4ftPICzmkRa9RJ4Q==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2345,6 +2390,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.9.tgz",
       "integrity": "sha512-9ViCZhFkmLUDyIPeBAsW7h5/Tcix806gWqd/BBqwW6KB8mhgZTTqjRMsyTTmMo2zpF+KckpYQsSiiFrIGHRaFw==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/protocol-http": "^5.3.9",
         "@smithy/types": "^4.12.1",
@@ -2359,6 +2405,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.18.tgz",
       "integrity": "sha512-4OS3TP3IWZysT8KlSG/UwfKdelJmuQ2CqVNfrkjm2Rsm146/DuSTfXiD1ulgWpp9L6lJmPYfWTp7/m4b4dQSdQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/core": "^3.23.4",
         "@smithy/middleware-serde": "^4.2.10",
@@ -2378,6 +2425,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.35.tgz",
       "integrity": "sha512-sz+Th9ofKypOtaboPTcyZtIfCs2LNb84bzxEhPffCElyMorVYDBdeGzxYqSLC6gWaZUqpPSbj5F6TIxYUlSCfQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.9",
         "@smithy/protocol-http": "^5.3.9",
@@ -2398,6 +2446,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.10.tgz",
       "integrity": "sha512-BQsdoi7ma4siJAzD0S6MedNPhiMcTdTLUqEUjrHeT1TJppBKWnwqySg34Oh/uGRhJeBd1sAH2t5tghBvcyD6tw==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/protocol-http": "^5.3.9",
         "@smithy/types": "^4.12.1",
@@ -2412,6 +2461,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.9.tgz",
       "integrity": "sha512-pid7ksBr7nm0X/3paIlGo9Fh3UK1pQ5yH0007tBmdkVvv+AsBZAOzC2dmLhlzDWKkSB+ZCiiyDArjAW3klkbMg==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
@@ -2425,6 +2475,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.9.tgz",
       "integrity": "sha512-EjdDTVGnnyJ9y8jXIfkF45UUZs21/Pp8xaMTZySLoC0xI3EhY7jq4co3LQnhh/bB6VVamd9ELpYJWLDw2ANhZA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/property-provider": "^4.2.9",
         "@smithy/shared-ini-file-loader": "^4.4.4",
@@ -2440,6 +2491,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.11.tgz",
       "integrity": "sha512-kQNJFwzYA9y+Fj3h9t1ToXYOJBobwUVEc6/WX45urJXyErgG0WOsres8Se8BAiFCMe8P06OkzRgakv7bQ5S+6Q==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/abort-controller": "^4.2.9",
         "@smithy/protocol-http": "^5.3.9",
@@ -2456,6 +2508,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.9.tgz",
       "integrity": "sha512-ibHwLxq4KlbfueoNxMNrZkG+O7V/5XKrewhDGYn0p9DYKCsdsofuWHKdX3QW4zHlAUfLStqdCUSDi/q/9WSjwA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
@@ -2469,6 +2522,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.9.tgz",
       "integrity": "sha512-PRy4yZqsKI3Eab8TLc16Dj2NzC4dnw/8E95+++Jc+wwlkjBpAq3tNLqkLHMmSvDfxKQ+X5PmmCYt+rM/GcMKPA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
@@ -2482,6 +2536,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.9.tgz",
       "integrity": "sha512-/AIDaq0+ehv+QfeyAjCUFShwHIt+FA1IodsV/2AZE5h4PUZcQYv5sjmy9V67UWfsBoTjOPKUFYSRfGoNW9T2UQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/types": "^4.12.1",
         "@smithy/util-uri-escape": "^4.2.1",
@@ -2496,6 +2551,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.9.tgz",
       "integrity": "sha512-kZ9AHhrYTea3UoklXudEnyA4duy9KAWERC28+ft8y8HIhR3yGsjv1PFTgzMpB+5L4tQKXNTwFbVJMeRK20vpHQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
@@ -2509,6 +2565,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.9.tgz",
       "integrity": "sha512-DYYd4xrm9Ozik+ZT4f5ZqSXdzscVHF/tFCzqieIFcLrjRDxWSgRtvtXOohJGoniLfPcBcy5ltR3tp2Lw4/d9ag==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/types": "^4.12.1"
       },
@@ -2521,6 +2578,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.4.tgz",
       "integrity": "sha512-tA5Cm11BHQCk/67y6VPIWydLh/pMY90jqOEWIr/2VAzTOoDwGpwp0C/AuHBc3/xWSOA5m5PXLN+lIOrsnTm/PQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
@@ -2534,6 +2592,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.9.tgz",
       "integrity": "sha512-QZKreDINuWf6KIcUUuurjBJiPPSRpMyU3sFPKk6urNAYcKkXhe6Ma+9MBX9e87yDnZfa/cqNMxobkdi9bpJt1A==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.1",
         "@smithy/protocol-http": "^5.3.9",
@@ -2553,6 +2612,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.11.7.tgz",
       "integrity": "sha512-gQP2J3qB/Wmc26gdmB8gA6zq2o2spG5sEU3o7TaTATBJEk29sYGWdEFoGEy91BczSpifTo0DQhVYjZXBEVcrpA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/core": "^3.23.4",
         "@smithy/middleware-endpoint": "^4.4.18",
@@ -2571,6 +2631,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.1.tgz",
       "integrity": "sha512-ow30Ze/DD02KH2p0eMyIF2+qJzGyNb0kFrnTRtPpuOkQ4hrgvLdaU4YC6r/K8aOrCML4FH0Cmm0aI4503L1Hwg==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2583,6 +2644,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.9.tgz",
       "integrity": "sha512-gYs8FrnwKoIvL+GyPz6VvweCkrXqHeD+KnOAxB+NFy6mLr4l75lFrn3dZ413DG0K2TvFtN7L43x7r8hyyohYdg==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/querystring-parser": "^4.2.9",
         "@smithy/types": "^4.12.1",
@@ -2597,6 +2659,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.1.tgz",
       "integrity": "sha512-BKGuawX4Doq/bI/uEmg+Zyc36rJKWuin3py89PquXBIBqmbnJwBBsmKhdHfNEp0+A4TDgLmT/3MSKZ1SxHcR6w==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^4.2.1",
         "@smithy/util-utf8": "^4.2.1",
@@ -2611,6 +2674,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.1.tgz",
       "integrity": "sha512-SiJeLiozrAoCrgDBUgsVbmqHmMgg/2bA15AzcbcW+zan7SuyAVHN4xTSbq0GlebAIwlcaX32xacnrG488/J/6g==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2623,6 +2687,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.2.tgz",
       "integrity": "sha512-4rHqBvxtJEBvsZcFQSPQqXP2b/yy/YlB66KlcEgcH2WNoOKCKB03DSLzXmOsXjbl8dJ4OEYTn31knhdznwk7zw==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2635,6 +2700,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.1.tgz",
       "integrity": "sha512-/swhmt1qTiVkaejlmMPPDgZhEaWb/HWMGRBheaxwuVkusp/z+ErJyQxO6kaXumOciZSWlmq6Z5mNylCd33X7Ig==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.1",
         "tslib": "^2.6.2"
@@ -2648,6 +2714,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.1.tgz",
       "integrity": "sha512-462id/00U8JWFw6qBuTSWfN5TxOHvDu4WliI97qOIOnuC/g+NDAknTU8eoGXEPlLkRVgWEr03jJBLV4o2FL8+A==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2660,6 +2727,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.34.tgz",
       "integrity": "sha512-m75CH7xaVG8ErlnfXsIBLrgVrApejrvUpohr41CMdeWNcEu/Ouvj9fbNA7oW9Qpr0Awf+BmDRrYx72hEKgY+FQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/property-provider": "^4.2.9",
         "@smithy/smithy-client": "^4.11.7",
@@ -2675,6 +2743,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.37.tgz",
       "integrity": "sha512-1LcAt0PV1dletxiGwcw2IJ8vLNhfkir02NTi1i/CFCY2ObtM5wDDjn/8V2dbPrbyoh6OTFH+uayI1rSVRBMT3A==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/config-resolver": "^4.4.7",
         "@smithy/credential-provider-imds": "^4.2.9",
@@ -2693,6 +2762,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.9.tgz",
       "integrity": "sha512-9FTqTzKxCFelCKdtHb22BTbrLgw7tTI+D6r/Ci/njI0tzqWLQctS0uEDTzraCR5K6IJItfFp1QmESlBytSpRhQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.9",
         "@smithy/types": "^4.12.1",
@@ -2707,6 +2777,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.1.tgz",
       "integrity": "sha512-c1hHtkgAWmE35/50gmdKajgGAKV3ePJ7t6UtEmpfCWJmQE9BQAQPz0URUVI89eSkcDqCtzqllxzG28IQoZPvwA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2719,6 +2790,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.9.tgz",
       "integrity": "sha512-pfnZneJ1S9X3TRmg2l3pG11Pvx2BW9O3NFhUN30llrK/yUKu8WbqMTx4/CzED+qKBYw0//ntUT00hvmaG+nLgA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/types": "^4.12.1",
         "tslib": "^2.6.2"
@@ -2732,6 +2804,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.9.tgz",
       "integrity": "sha512-79hfhL/oxP40SCXJGfjfE9pjbUVfHhXZFpCWXTHqXSluzaVy7jwWs9Ui7lLbfDBSp+7i+BIwgeVIRerbIRWN6g==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/service-error-classification": "^4.2.9",
         "@smithy/types": "^4.12.1",
@@ -2746,6 +2819,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.14.tgz",
       "integrity": "sha512-IOBEiJTOltSx6MAfwkx/GSVM8/UCJxdtw13haP5OEL543lb1DN6TAypsxv+qcj4l/rKcpapbS6zK9MQGBOhoaA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/fetch-http-handler": "^5.3.10",
         "@smithy/node-http-handler": "^4.4.11",
@@ -2765,6 +2839,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.1.tgz",
       "integrity": "sha512-YmiUDn2eo2IOiWYYvGQkgX5ZkBSiTQu4FlDo5jNPpAxng2t6Sjb6WutnZV9l6VR4eJul1ABmCrnWBC9hKHQa6Q==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2777,6 +2852,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.1.tgz",
       "integrity": "sha512-DSIwNaWtmzrNQHv8g7DBGR9mulSit65KSj5ymGEIAknmIN8IpbZefEep10LaMG/P/xquwbmJ1h9ectz8z6mV6g==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^4.2.1",
         "tslib": "^2.6.2"
@@ -2790,6 +2866,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.1.tgz",
       "integrity": "sha512-dSfDCeihDmZlV2oyr0yWPTUfh07suS+R5OB+FZGiv/hHyK3hrFBW5rR1UYjfa57vBsrP9lciFkRPzebaV1Qujw==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3639,7 +3716,8 @@
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
@@ -4824,6 +4902,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "strnum": "^2.1.2"
       },
@@ -7658,7 +7737,8 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -7928,7 +8008,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",

--- a/tests/pkcs11Signer.test.ts
+++ b/tests/pkcs11Signer.test.ts
@@ -1,7 +1,11 @@
 // Copyright (c) 2026 dotandev
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-import { Pkcs11Ed25519Signer } from '../src/audit/signing/pkcs11Signer';
+import { normalizeTokenLabel, resolvePkcs11KeyIdHex, resolveYkcs11KeyIdHex } from '../src/audit/signing/pkcs11Signer';
+
+const loadSigner = (): typeof import('../src/audit/signing/pkcs11Signer').Pkcs11Ed25519Signer =>
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('../src/audit/signing/pkcs11Signer').Pkcs11Ed25519Signer;
 
 describe('Pkcs11Ed25519Signer', () => {
   const originalEnv = process.env;
@@ -21,6 +25,7 @@ describe('Pkcs11Ed25519Signer', () => {
       process.env.ERST_PKCS11_PIN = '1234';
       process.env.ERST_PKCS11_KEY_LABEL = 'test-key';
 
+      const Pkcs11Ed25519Signer = loadSigner();
       expect(() => new Pkcs11Ed25519Signer()).toThrow(
         'pkcs11 provider selected but ERST_PKCS11_MODULE is not set'
       );
@@ -31,19 +36,22 @@ describe('Pkcs11Ed25519Signer', () => {
       delete process.env.ERST_PKCS11_PIN;
       process.env.ERST_PKCS11_KEY_LABEL = 'test-key';
 
+      const Pkcs11Ed25519Signer = loadSigner();
       expect(() => new Pkcs11Ed25519Signer()).toThrow(
         'pkcs11 provider selected but ERST_PKCS11_PIN is not set'
       );
     });
 
-    test('should throw clear error when neither key label nor key ID is set', () => {
+    test('should throw clear error when neither key label, key ID, nor PIV slot is set', () => {
       process.env.ERST_PKCS11_MODULE = '/usr/lib/softhsm/libsofthsm2.so';
       process.env.ERST_PKCS11_PIN = '1234';
       delete process.env.ERST_PKCS11_KEY_LABEL;
       delete process.env.ERST_PKCS11_KEY_ID;
+      delete process.env.ERST_PKCS11_PIV_SLOT;
 
+      const Pkcs11Ed25519Signer = loadSigner();
       expect(() => new Pkcs11Ed25519Signer()).toThrow(
-        'pkcs11 provider selected but neither ERST_PKCS11_KEY_LABEL nor ERST_PKCS11_KEY_ID is set'
+        'pkcs11 provider selected but neither ERST_PKCS11_KEY_LABEL, ERST_PKCS11_KEY_ID, nor ERST_PKCS11_PIV_SLOT is set'
       );
     });
 
@@ -52,9 +60,19 @@ describe('Pkcs11Ed25519Signer', () => {
       process.env.ERST_PKCS11_PIN = '1234';
       process.env.ERST_PKCS11_KEY_LABEL = 'test-key';
 
-      expect(() => new Pkcs11Ed25519Signer()).toThrow(
-        'pkcs11 provider selected but optional dependency `pkcs11js` is not installed'
-      );
+      jest.isolateModules(() => {
+        jest.doMock('pkcs11js', () => {
+          throw new Error('missing');
+        });
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { Pkcs11Ed25519Signer } = require('../src/audit/signing/pkcs11Signer');
+        expect(() => new Pkcs11Ed25519Signer()).toThrow(
+          'pkcs11 provider selected but optional dependency `pkcs11js` is not installed'
+        );
+      });
+
+      jest.dontMock('pkcs11js');
     });
   });
 
@@ -65,6 +83,7 @@ describe('Pkcs11Ed25519Signer', () => {
       process.env.ERST_PKCS11_KEY_LABEL = 'test-key';
       process.env.ERST_PKCS11_PUBLIC_KEY_PEM = '-----BEGIN PUBLIC KEY-----\ntest\n-----END PUBLIC KEY-----';
 
+      const Pkcs11Ed25519Signer = loadSigner();
       const signer = new Pkcs11Ed25519Signer();
       const publicKey = await signer.public_key();
 
@@ -77,6 +96,7 @@ describe('Pkcs11Ed25519Signer', () => {
       process.env.ERST_PKCS11_KEY_LABEL = 'test-key';
       delete process.env.ERST_PKCS11_PUBLIC_KEY_PEM;
 
+      const Pkcs11Ed25519Signer = loadSigner();
       const signer = new Pkcs11Ed25519Signer();
 
       await expect(signer.public_key()).rejects.toThrow(
@@ -96,15 +116,15 @@ describe('Pkcs11Ed25519Signer', () => {
     test('should provide context for initialization failures', () => {
       const testCases = [
         {
-          error: 'Library lock error',
+          error: 'Library lock error (CKR_CANT_LOCK). The PKCS#11 library may be in use by another process.',
           expected: /Library lock error \(CKR_CANT_LOCK\)\. The PKCS#11 library may be in use by another process\./
         },
         {
-          error: 'Token not present',
+          error: 'Token not present (CKR_TOKEN_NOT_PRESENT). Ensure the HSM/token is connected.',
           expected: /Token not present \(CKR_TOKEN_NOT_PRESENT\)\. Ensure the HSM\/token is connected\./
         },
         {
-          error: 'Device error',
+          error: 'Device error (CKR_DEVICE_ERROR). Check HSM/token hardware connection.',
           expected: /Device error \(CKR_DEVICE_ERROR\)\. Check HSM\/token hardware connection\./
         }
       ];
@@ -117,15 +137,15 @@ describe('Pkcs11Ed25519Signer', () => {
     test('should provide context for login failures', () => {
       const testCases = [
         {
-          error: 'PIN incorrect',
+          error: 'Wrong PIN (CKR_PIN_INCORRECT)',
           expected: /Wrong PIN \(CKR_PIN_INCORRECT\)/
         },
         {
-          error: 'PIN locked',
+          error: 'PIN locked (CKR_PIN_LOCKED). The token may be locked due to too many failed attempts.',
           expected: /PIN locked \(CKR_PIN_LOCKED\)\. The token may be locked due to too many failed attempts\./
         },
         {
-          error: 'Token not present',
+          error: 'Token not present (CKR_TOKEN_NOT_PRESENT)',
           expected: /Token not present \(CKR_TOKEN_NOT_PRESENT\)/
         }
       ];
@@ -133,6 +153,41 @@ describe('Pkcs11Ed25519Signer', () => {
       testCases.forEach(({ error, expected }) => {
         expect(expected.test(`${error}: some details`)).toBe(true);
       });
+    });
+  });
+
+  describe('YubiKey PIV helpers', () => {
+    test('normalizes token labels by trimming padding', () => {
+      expect(normalizeTokenLabel('YubiKey PIV\x00\x00  ')).toBe('YubiKey PIV');
+    });
+
+    test('maps PIV slots to YKCS11 key IDs', () => {
+      expect(resolveYkcs11KeyIdHex('9a')).toBe('01');
+      expect(resolveYkcs11KeyIdHex('0x9c')).toBe('02');
+      expect(resolveYkcs11KeyIdHex('9D')).toBe('03');
+      expect(resolveYkcs11KeyIdHex('9e')).toBe('04');
+      expect(resolveYkcs11KeyIdHex('82')).toBe('05');
+      expect(resolveYkcs11KeyIdHex('95')).toBe('18');
+      expect(resolveYkcs11KeyIdHex('f9')).toBe('19');
+    });
+
+    test('rejects unsupported PIV slots', () => {
+      expect(() => resolveYkcs11KeyIdHex('9b')).toThrow(
+        "Unsupported PIV slot '9b'. Supported slots: 9a, 9c, 9d, 9e, 82-95, f9."
+      );
+    });
+
+    test('prefers explicit key IDs over derived PIV slot IDs', () => {
+      expect(resolvePkcs11KeyIdHex({ keyIdHex: '0a', pivSlot: '9a' })).toBe('0a');
+    });
+
+    test('rejects invalid explicit key IDs', () => {
+      expect(() => resolvePkcs11KeyIdHex({ keyIdHex: 'xyz' })).toThrow(
+        "Invalid ERST_PKCS11_KEY_ID 'xyz'. Expected an even-length hex string (e.g., 01, 0a, 10)."
+      );
+      expect(() => resolvePkcs11KeyIdHex({ keyIdHex: 'a' })).toThrow(
+        "Invalid ERST_PKCS11_KEY_ID 'a'. Expected an even-length hex string (e.g., 01, 0a, 10)."
+      );
     });
   });
 });


### PR DESCRIPTION
Closes #392

---

================================================================================
  TITLE:

  feat(audit): Add YubiKey PIV support for PKCS#11 audit signing

  ================================================================================
  DESCRIPTION:

  ## Overview

  Adds YubiKey PIV-specific support for audit:sign when using the PKCS#11 provider, including PIV slot mapping, token
  label selection, and documentation.

  ## Changes

  ### Core Implementation

  - PKCS#11 signer: Add YubiKey PIV slot support via ERST_PKCS11_PIV_SLOT
  - Key resolution: Map PIV slots to YKCS11 key IDs and validate explicit key IDs
  - Token selection: Prefer token label matching when provided

  ### Testing

  - Unit tests: Added coverage for PIV slot mapping, token label normalization, and key ID validation
  - Existing PKCS#11 tests: Updated to reflect new config options

  ### Documentation

  - New guide: docs/pkcs11-yubikey.md with YubiKey PIV setup, mappings, and examples
  - README: Link to YubiKey PIV guide and new env var

  ## Configuration

  Required:

  - ERST_PKCS11_MODULE
  - ERST_PKCS11_PIN
  - ERST_PKCS11_PUBLIC_KEY_PEM
  - One of ERST_PKCS11_KEY_LABEL, ERST_PKCS11_KEY_ID, or ERST_PKCS11_PIV_SLOT

  Optional:

  - ERST_PKCS11_TOKEN_LABEL
  - ERST_PKCS11_SLOT

  ## Testing

  - npm test -- pkcs11Signer.test.ts
  - npm test (fails due to pre-existing KMS/audit/rate limiter issues unrelated to this change)

  ## Related Issues

  Addresses audit issue #76

  ## Type of Change

  - [x] New feature
  - [ ] Bug fix
  - [ ] Breaking change
  - [x] Documentation update

  ## Checklist

  - [x] Code follows project style guidelines
  - [x] Self-review completed
  - [x] Tests added/updated
  - [x] Documentation updated
  - [ ] Full test suite passing (fails due to existing unrelated issues)

  ================================================================================