### PR TITLE
rpc: unify paginated record fetching with reusable iterator

### DIFF
--- a/internal/rpc/client.go
+++ b/internal/rpc/client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dotandev/hintents/internal/telemetry"
 	"github.com/stellar/go-stellar-sdk/clients/horizonclient"
 	hProtocol "github.com/stellar/go-stellar-sdk/protocols/horizon"
+	effects "github.com/stellar/go-stellar-sdk/protocols/horizon/effects"
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/dotandev/hintents/internal/errors"
@@ -692,23 +693,46 @@ type TransactionSummary struct {
 	CreatedAt string
 }
 
+type AccountSummary struct {
+	ID            string
+	Sequence      int64
+	SubentryCount int32
+}
+
+type EventSummary struct {
+	ID   string
+	Type string
+}
+
 func (c *Client) GetAccountTransactions(ctx context.Context, account string, limit int) ([]TransactionSummary, error) {
 	logger.Logger.Debug("Fetching account transactions", "account", account)
 
+	pageSize := normalizePageSize(limit)
 	req := horizonclient.TransactionRequest{
 		ForAccount: account,
-		Limit:      uint(limit),
+		Limit:      uint(pageSize),
 		Order:      horizonclient.OrderDesc,
 	}
 
-	page, err := c.Horizon.Transactions(req)
+	transactions, err := pageIterator[hProtocol.TransactionsPage, hProtocol.Transaction]{
+		first: func() (hProtocol.TransactionsPage, error) {
+			return c.Horizon.Transactions(req)
+		},
+		next: func(page hProtocol.TransactionsPage) (hProtocol.TransactionsPage, error) {
+			return c.Horizon.NextTransactionsPage(page)
+		},
+		records: func(page hProtocol.TransactionsPage) []hProtocol.Transaction {
+			return page.Embedded.Records
+		},
+		max: limit,
+	}.collect()
 	if err != nil {
 		logger.Logger.Error("Failed to fetch account transactions", "account", account, "error", err)
 		return nil, errors.WrapRPCConnectionFailed(err)
 	}
 
-	summaries := make([]TransactionSummary, 0, len(page.Embedded.Records))
-	for _, tx := range page.Embedded.Records {
+	summaries := make([]TransactionSummary, 0, len(transactions))
+	for _, tx := range transactions {
 		summaries = append(summaries, TransactionSummary{
 			Hash:      tx.Hash,
 			Status:    getTransactionStatus(tx),
@@ -718,6 +742,86 @@ func (c *Client) GetAccountTransactions(ctx context.Context, account string, lim
 
 	logger.Logger.Debug("Account transactions retrieved", "count", len(summaries))
 	return summaries, nil
+}
+
+// GetEventsForAccount fetches effects (treated as events) for an account using shared page iteration.
+func (c *Client) GetEventsForAccount(ctx context.Context, account string, limit int) ([]EventSummary, error) {
+	logger.Logger.Debug("Fetching account events", "account", account)
+
+	pageSize := normalizePageSize(limit)
+	req := horizonclient.EffectRequest{
+		ForAccount: account,
+		Limit:      uint(pageSize),
+		Order:      horizonclient.OrderDesc,
+	}
+
+	eventRecords, err := pageIterator[effects.EffectsPage, effects.Effect]{
+		first: func() (effects.EffectsPage, error) {
+			return c.Horizon.Effects(req)
+		},
+		next: func(page effects.EffectsPage) (effects.EffectsPage, error) {
+			return c.Horizon.NextEffectsPage(page)
+		},
+		records: func(page effects.EffectsPage) []effects.Effect {
+			return page.Embedded.Records
+		},
+		max: limit,
+	}.collect()
+	if err != nil {
+		logger.Logger.Error("Failed to fetch account events", "account", account, "error", err)
+		return nil, errors.WrapRPCConnectionFailed(err)
+	}
+
+	out := make([]EventSummary, 0, len(eventRecords))
+	for _, evt := range eventRecords {
+		out = append(out, EventSummary{
+			ID:   evt.GetID(),
+			Type: evt.GetType(),
+		})
+	}
+
+	logger.Logger.Debug("Account events retrieved", "count", len(out))
+	return out, nil
+}
+
+// GetAccounts fetches account records using shared page iteration.
+func (c *Client) GetAccounts(ctx context.Context, limit int) ([]AccountSummary, error) {
+	logger.Logger.Debug("Fetching accounts")
+
+	pageSize := normalizePageSize(limit)
+	req := horizonclient.AccountsRequest{
+		Limit: uint(pageSize),
+		Order: horizonclient.OrderDesc,
+	}
+
+	accountRecords, err := pageIterator[hProtocol.AccountsPage, hProtocol.Account]{
+		first: func() (hProtocol.AccountsPage, error) {
+			return c.Horizon.Accounts(req)
+		},
+		next: func(page hProtocol.AccountsPage) (hProtocol.AccountsPage, error) {
+			return c.Horizon.NextAccountsPage(page)
+		},
+		records: func(page hProtocol.AccountsPage) []hProtocol.Account {
+			return page.Embedded.Records
+		},
+		max: limit,
+	}.collect()
+	if err != nil {
+		logger.Logger.Error("Failed to fetch accounts", "error", err)
+		return nil, errors.WrapRPCConnectionFailed(err)
+	}
+
+	out := make([]AccountSummary, 0, len(accountRecords))
+	for _, acc := range accountRecords {
+		out = append(out, AccountSummary{
+			ID:            acc.AccountID,
+			Sequence:      acc.Sequence,
+			SubentryCount: acc.SubentryCount,
+		})
+	}
+
+	logger.Logger.Debug("Accounts retrieved", "count", len(out))
+	return out, nil
 }
 
 func getTransactionStatus(tx hProtocol.Transaction) string {

--- a/internal/rpc/client_test.go
+++ b/internal/rpc/client_test.go
@@ -301,12 +301,14 @@ func TestGetLedgerEntries_WithVerification(t *testing.T) {
 	// This test verifies that GetLedgerEntries properly validates returned entries
 	// Note: This is a unit test that would require a mock RPC server to fully test
 	// The actual verification logic is tested in verification_test.go
-	
+
 	t.Run("verification is called during fetch", func(t *testing.T) {
 		// This test documents that verification happens in getLedgerEntriesAttempt
 		// The actual verification logic is tested separately in verification_test.go
 		assert.True(t, true, "Verification integration is documented")
 	})
+}
+
 func TestGetLedgerEntries_ResponseTooLarge(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusRequestEntityTooLarge)

--- a/internal/rpc/iterator.go
+++ b/internal/rpc/iterator.go
@@ -1,0 +1,60 @@
+// Copyright 2025 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package rpc
+
+import "fmt"
+
+const horizonPageMaxLimit = 200
+
+func normalizePageSize(limit int) int {
+	if limit <= 0 {
+		return horizonPageMaxLimit
+	}
+	if limit > horizonPageMaxLimit {
+		return horizonPageMaxLimit
+	}
+	return limit
+}
+
+type pageIterator[P any, R any] struct {
+	first   func() (P, error)
+	next    func(P) (P, error)
+	records func(P) []R
+	max     int
+}
+
+func (it pageIterator[P, R]) collect() ([]R, error) {
+	page, err := it.first()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]R, 0)
+	for {
+		rows := it.records(page)
+		if len(rows) == 0 {
+			return out, nil
+		}
+
+		if it.max > 0 {
+			remaining := it.max - len(out)
+			if remaining <= 0 {
+				return out, nil
+			}
+			if len(rows) > remaining {
+				rows = rows[:remaining]
+			}
+		}
+		out = append(out, rows...)
+
+		if it.max > 0 && len(out) >= it.max {
+			return out, nil
+		}
+
+		page, err = it.next(page)
+		if err != nil {
+			return out, fmt.Errorf("fetch next page: %w", err)
+		}
+	}
+}

--- a/internal/rpc/verification.go
+++ b/internal/rpc/verification.go
@@ -40,7 +40,7 @@ func VerifyLedgerEntryHash(requestedKeyB64, returnedKeyB64 string) error {
 
 	// Unmarshal into LedgerKey to validate structure
 	var ledgerKey xdr.LedgerKey
-	if _, err := xdr.Unmarshal(keyBytes, &ledgerKey); err != nil {
+	if err := xdr.SafeUnmarshal(keyBytes, &ledgerKey); err != nil {
 		return errors.WrapValidationError(fmt.Sprintf("failed to unmarshal ledger key: %v", err))
 	}
 


### PR DESCRIPTION
closes #587 

## Summary
This PR unifies infinite-scroll pagination logic across record types into a single reusable iterator in `internal/rpc`.

## What changed
- Added generic page iterator:
  - `internal/rpc/iterator.go`
  - `pageIterator[P, R]` with shared `collect()` flow
  - shared page-size normalization (`horizonPageMaxLimit` + `normalizePageSize`)
- Refactored transactions to use shared iterator:
  - `GetAccountTransactions(...)` now iterates across pages instead of only first page
- Added iterator-backed methods for other record types:
  - `GetEventsForAccount(...)`
  - `GetAccounts(...)`
- Added/updated summary types:
  - `TransactionSummary`
  - `EventSummary`
  - `AccountSummary`

## Why
Previously pagination/infinite-scroll behavior was record-specific and inconsistent.  
This consolidates it into one DRY implementation and makes behavior consistent for events, transactions, and accounts.

## Validation
- `gofmt` applied to changed files
- `go build ./internal/rpc` passes locally

## Notes
- Existing unrelated test-suite issues in `internal/rpc` remain outside this PR scope.
