### PR TITLE
feat(errors): add ErstErrorCode registry and unified ErstError wrapper

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -225,3 +225,95 @@ func WrapRPCResponseTooLarge(url string) error {
 			ErrRPCResponseTooLarge, url),
 	}
 }
+
+
+// ErstErrorCode is the canonical classification for all errors crossing
+// RPC and Simulator boundaries.
+type ErstErrorCode string
+
+const (
+	// RPC origin
+	CodeRPCConnectionFailed  ErstErrorCode = "RPC_CONNECTION_FAILED"
+	CodeRPCTimeout           ErstErrorCode = "RPC_TIMEOUT"
+	CodeRPCAllFailed         ErstErrorCode = "RPC_ALL_ENDPOINTS_FAILED"
+	CodeRPCError             ErstErrorCode = "RPC_SERVER_ERROR"
+	CodeRPCResponseTooLarge  ErstErrorCode = "RPC_RESPONSE_TOO_LARGE"
+	CodeRPCRateLimitExceeded ErstErrorCode = "RPC_RATE_LIMIT_EXCEEDED"
+	CodeRPCMarshalFailed     ErstErrorCode = "RPC_MARSHAL_FAILED"
+	CodeRPCUnmarshalFailed   ErstErrorCode = "RPC_UNMARSHAL_FAILED"
+	CodeTransactionNotFound  ErstErrorCode = "RPC_TRANSACTION_NOT_FOUND"
+	CodeLedgerNotFound       ErstErrorCode = "RPC_LEDGER_NOT_FOUND"
+	CodeLedgerArchived       ErstErrorCode = "RPC_LEDGER_ARCHIVED"
+
+	// Simulator origin
+	CodeSimNotFound     ErstErrorCode = "SIM_BINARY_NOT_FOUND"
+	CodeSimCrash        ErstErrorCode = "SIM_PROCESS_CRASHED"
+	CodeSimExecFailed   ErstErrorCode = "SIM_EXECUTION_FAILED"
+	CodeSimLogicError   ErstErrorCode = "SIM_LOGIC_ERROR"
+	CodeSimProtoUnsup   ErstErrorCode = "SIM_PROTOCOL_UNSUPPORTED"
+
+	// Shared / general
+	CodeValidationFailed ErstErrorCode = "VALIDATION_FAILED"
+	CodeUnknown          ErstErrorCode = "UNKNOWN"
+)
+
+// ErstError is the unified error type returned at all RPC and Simulator boundaries.
+// It carries a stable ErstErrorCode for programmatic handling and preserves the
+// original error string in OriginalError for backwards compatibility.
+type ErstError struct {
+	Code          ErstErrorCode
+	Message       string // human-readable summary
+	OriginalError string // raw original error string, always preserved
+}
+
+func (e *ErstError) Error() string {
+	if e.OriginalError != "" {
+		return string(e.Code) + ": " + e.OriginalError
+	}
+	return string(e.Code) + ": " + e.Message
+}
+
+// Unwrap allows errors.Is/As to traverse the chain if needed.
+func (e *ErstError) Unwrap() error {
+	return errors.New(e.OriginalError)
+}
+
+// newErstError is the internal constructor.
+func newErstError(code ErstErrorCode, message string, original error) *ErstError {
+	orig := ""
+	if original != nil {
+		orig = original.Error()
+	}
+	if message == "" {
+		message = orig
+	}
+	return &ErstError{Code: code, Message: message, OriginalError: orig}
+}
+
+// --- Typed constructors for RPC boundary ---
+
+// NewRPCError wraps any RPC error into the unified type.
+func NewRPCError(code ErstErrorCode, original error) *ErstError {
+	return newErstError(code, "", original)
+}
+
+// --- Typed constructors for Simulator boundary ---
+
+// NewSimError wraps any Simulator error into the unified type.
+func NewSimError(code ErstErrorCode, original error) *ErstError {
+	return newErstError(code, "", original)
+}
+
+// NewSimErrorMsg wraps a simulator error with an explicit message (for string-only errors).
+func NewSimErrorMsg(code ErstErrorCode, message string) *ErstError {
+	return newErstError(code, message, nil)
+}
+
+// IsErstCode checks if an error carries a specific ErstErrorCode.
+func IsErstCode(err error, code ErstErrorCode) bool {
+	var e *ErstError
+	if As(err, &e) {
+		return e.Code == code
+	}
+	return false
+}


### PR DESCRIPTION
Closes #531

---

## Description
Implements a centralized error classification registry to standardize how errors are handled across the RPC and Simulator boundaries.

Previously, errors from the network RPC and the local Simulator used inconsistent types and naming conventions, making it difficult for callers to programmatically handle specific error cases.

## Changes
- Added `ErstErrorCode` type and `ErstError` struct to `internal/errors/errors.go`. `ErstError` carries a stable code for programmatic handling and preserves the original error string in `OriginalError` for backwards compatibility
- Added `ToErstError()` and `classifyByMessage()` to `internal/ipc/types.go` to convert raw Rust simulator error strings into the unified type at the IPC boundary
- Updated `internal/simulator/runner.go` to classify simulator response errors via `ToErstError()` before returning them to callers
- Fixed `getHealthAttempt` in `internal/rpc/client.go` to use typed wrappers instead of raw `fmt.Errorf` calls

## Notes
- `internal/rpc/verification.go` has a pre-existing compile error (`[]byte does not implement io.Reader`) that is unrelated to this change and exists on main before these modifications
- The Rust simulator currently does not emit structured error codes in the `code` field — classification falls back to message-based heuristics in `classifyByMessage`. A follow-up issue should be opened to add structured codes on the Rust side

## Related Issues

## Testing
- `go build github.com/dotandev/hintents/internal/errors` — clean
- `go build github.com/dotandev/hintents/internal/ipc` — clean
- `go build github.com/dotandev/hintents/internal/simulator` — pre-existing error in unrelated file only

## Checklist
- [x] Code follows style guidelines
- [x] Documentation updated
- [x] No new warnings or errors introduced by this change