### PR TITLE
Update CONTRIBUTING.md to remove outdated references and clarify local setup

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -5,12 +5,21 @@ Thank you for your interest in contributing to Erst! We welcome contributions fr
 ## Getting Started
 
 1.  **Fork the repository** on GitHub.
+
+
 2.  **Clone your fork** locally:
     ```bash
-    git clone https://github.com/your-username/erst.git
-    cd erst
+    git clone https://github.com/your-username/hintents.git
+    cd hintents
     ```
-3.  **Create a branch** for your feature or bug fix:
+
+3.  **Sync with the latest `main` branch**:
+    ```bash
+    git checkout main
+    git pull origin main
+    ```
+
+4.  **Create a new branch** for your feature or bug fix (always branch from `main`):
     ```bash
     git checkout -b feature/my-new-feature
     ```
@@ -64,17 +73,23 @@ You will need the following installed:
 *   **Rust**: Standard Stable Toolchain. [Install Rust](https://www.rust-lang.org/tools/install)
 *   **(Optional) Docker**: If you prefer building in a container.
 
-### detailed Setup
+### Detailed Local Development Setup
 
 #### 1. Rust Simulator Setup
 
 The simulator must be built first because the Go CLI depends on the binary being available (or in the path).
 
 ```bash
+# From the project root
 cd simulator
-# Ensure you have the latest stable toolchain
+
+# Ensure the latest stable Rust toolchain is installed
 rustup update stable
-# Build the release binary (release is recommended for performance)
+
+# Install required Rust components (if not already installed)
+rustup component add rustfmt clippy
+
+# Build the release binary (recommended for performance)
 cargo build --release
 ```
 
@@ -85,8 +100,14 @@ cargo build --release
 Once the simulator is built, you can build and run the Go CLI.
 
 ```bash
-# From the project root
+# Return to the project root
+cd ..
+
+# Download Go dependencies
+go mod tidy
 go mod download
+
+# Build the CLI binary
 go build -o erst cmd/erst/main.go
 ```
 
@@ -111,6 +132,8 @@ go test ./...
 cd simulator
 cargo test
 ```
+> Always run both Go and Rust tests before submitting a pull request.
+
 
 ## Submitting a Pull Request
 


### PR DESCRIPTION
- Updated repository cloning instructions to use hintents instead of erst
- Explicitly documented branching from main
- Improved clarity of local development setup steps
- Added missing Rust component setup
- Made setup instructions more sequential and beginner-friendly

Closes #551