### PR TITLE
feat: Error for excessive storage

### DIFF
--- a/internal/cmd/dry_run.go
+++ b/internal/cmd/dry_run.go
@@ -125,6 +125,11 @@ func runDryRun(cmd *cobra.Command, args []string) error {
 		return errors.WrapRPCConnectionFailed(err)
 	}
 
+	// Warn if the fetched ledger entries exceed the Soroban network size limit.
+	// The network rejects transactions whose footprint exceeds 1 MiB, so there
+	// is no point invoking the simulator — the tx will never land on-chain.
+	simulator.WarnLedgerEntriesSizeToStderr(ledgerEntries)
+
 	runner, err := simulator.NewRunner("", false)
 	if err != nil {
 		return errors.WrapSimulatorNotFound(err.Error())

--- a/internal/simulator/ledger_limits.go
+++ b/internal/simulator/ledger_limits.go
@@ -1,0 +1,113 @@
+// Copyright 2025 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package simulator
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+)
+
+// MaxLedgerEntriesSizeBytes is the Soroban network limit for the total size of
+// ledger entries passed to a single transaction.  Transactions whose read/write
+// footprint exceeds this limit are rejected by the network before execution.
+//
+// Source: Soroban protocol limit `max_transaction_size_bytes` = 1 MiB.
+// Ref: https://github.com/stellar/stellar-core/blob/master/src/herder/TxSetUtils.cpp
+const MaxLedgerEntriesSizeBytes = 1 * 1024 * 1024 // 1 MiB
+
+// LedgerSizeWarning is returned by CheckLedgerEntriesSize when the total
+// base64-decoded size of the provided entries exceeds MaxLedgerEntriesSizeBytes.
+type LedgerSizeWarning struct {
+	TotalBytes int
+	LimitBytes int
+	EntryCount int
+}
+
+func (w *LedgerSizeWarning) Error() string {
+	return fmt.Sprintf(
+		"ledger entries total size %d bytes (%d entries) exceeds the %d-byte network limit — "+
+			"this transaction would be rejected by the Soroban network",
+		w.TotalBytes, w.EntryCount, w.LimitBytes,
+	)
+}
+
+// CheckLedgerEntriesSize computes the total byte size of the decoded ledger
+// entry values in entries and returns a *LedgerSizeWarning if it exceeds
+// MaxLedgerEntriesSizeBytes.  It returns nil when the size is within limits.
+//
+// entries is a map of base64-encoded XDR LedgerKey → base64-encoded XDR
+// LedgerEntry, as produced by rpc.Client.GetLedgerEntries.  Both key and
+// value bytes are counted because both are transmitted in the transaction
+// footprint.
+//
+// Entries whose values cannot be base64-decoded are counted as zero bytes
+// (the simulator will surface the decode error separately).
+func CheckLedgerEntriesSize(entries map[string]string) *LedgerSizeWarning {
+	total := 0
+	for k, v := range entries {
+		// Key bytes
+		if kb, err := base64.StdEncoding.DecodeString(k); err == nil {
+			total += len(kb)
+		}
+		// Value bytes
+		if vb, err := base64.StdEncoding.DecodeString(v); err == nil {
+			total += len(vb)
+		}
+	}
+
+	if total > MaxLedgerEntriesSizeBytes {
+		return &LedgerSizeWarning{
+			TotalBytes: total,
+			LimitBytes: MaxLedgerEntriesSizeBytes,
+			EntryCount: len(entries),
+		}
+	}
+	return nil
+}
+
+// WarnLedgerEntriesSize calls CheckLedgerEntriesSize and, if the size limit is
+// exceeded, writes a formatted warning to w (typically os.Stderr).  It returns
+// true when a warning was emitted so callers can decide whether to surface it
+// differently (e.g. prefix with a command name).
+func WarnLedgerEntriesSize(entries map[string]string, w io.Writer) bool {
+	warning := CheckLedgerEntriesSize(entries)
+	if warning == nil {
+		return false
+	}
+
+	fmt.Fprintf(w,
+		"WARNING: %s\n"+
+			"         Total: %s across %d entries (limit: %s)\n"+
+			"         The network will reject this transaction. "+
+			"Reduce the number of ledger entries read in a single invocation.\n",
+		warning.Error(),
+		formatBytes(warning.TotalBytes),
+		warning.EntryCount,
+		formatBytes(warning.LimitBytes),
+	)
+	return true
+}
+
+// WarnLedgerEntriesSizeToStderr is a convenience wrapper that writes to
+// os.Stderr, matching the CLI convention that warnings go to stderr so they
+// don't corrupt stdout output.
+func WarnLedgerEntriesSizeToStderr(entries map[string]string) bool {
+	return WarnLedgerEntriesSize(entries, os.Stderr)
+}
+
+// formatBytes formats a byte count as a human-readable string.
+func formatBytes(n int) string {
+	const kib = 1024
+	const mib = 1024 * kib
+	switch {
+	case n >= mib:
+		return fmt.Sprintf("%.2f MiB (%d bytes)", float64(n)/float64(mib), n)
+	case n >= kib:
+		return fmt.Sprintf("%.2f KiB (%d bytes)", float64(n)/float64(kib), n)
+	default:
+		return fmt.Sprintf("%d bytes", n)
+	}
+}

--- a/internal/simulator/ledger_limits_test.go
+++ b/internal/simulator/ledger_limits_test.go
@@ -1,0 +1,163 @@
+// Copyright 2025 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package simulator
+
+import (
+	"bytes"
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+// makeEntry returns a base64-encoded string of n zero bytes, simulating an
+// XDR-encoded ledger key or entry of the given decoded size.
+func makeEntry(n int) string {
+	return base64.StdEncoding.EncodeToString(make([]byte, n))
+}
+
+func TestCheckLedgerEntriesSize_UnderLimit(t *testing.T) {
+	entries := map[string]string{
+		makeEntry(64):  makeEntry(512),
+		makeEntry(128): makeEntry(1024),
+	}
+	warning := CheckLedgerEntriesSize(entries)
+	if warning != nil {
+		t.Errorf("expected no warning for small entries, got: %v", warning)
+	}
+}
+
+func TestCheckLedgerEntriesSize_ExactlyAtLimit(t *testing.T) {
+	// One entry whose key+value decoded bytes == MaxLedgerEntriesSizeBytes.
+	// key = 512 KiB, value = 512 KiB → total = 1 MiB exactly = no warning.
+	half := MaxLedgerEntriesSizeBytes / 2
+	entries := map[string]string{
+		makeEntry(half): makeEntry(half),
+	}
+	warning := CheckLedgerEntriesSize(entries)
+	if warning != nil {
+		t.Errorf("expected no warning at exactly the limit, got: %v", warning)
+	}
+}
+
+func TestCheckLedgerEntriesSize_OneByteOver(t *testing.T) {
+	half := MaxLedgerEntriesSizeBytes / 2
+	entries := map[string]string{
+		makeEntry(half): makeEntry(half + 1), // 1 byte over
+	}
+	warning := CheckLedgerEntriesSize(entries)
+	if warning == nil {
+		t.Fatal("expected a warning for entries 1 byte over the limit, got nil")
+	}
+	if warning.TotalBytes <= MaxLedgerEntriesSizeBytes {
+		t.Errorf("expected TotalBytes > limit, got TotalBytes=%d limit=%d",
+			warning.TotalBytes, MaxLedgerEntriesSizeBytes)
+	}
+	if warning.LimitBytes != MaxLedgerEntriesSizeBytes {
+		t.Errorf("expected LimitBytes=%d, got %d", MaxLedgerEntriesSizeBytes, warning.LimitBytes)
+	}
+}
+
+func TestCheckLedgerEntriesSize_MultipleEntriesOverLimit(t *testing.T) {
+	// 10 entries, each key=64KiB + value=128KiB → 10 * 192 KiB = 1920 KiB > 1 MiB
+	entries := make(map[string]string, 10)
+	for i := 0; i < 10; i++ {
+		entries[makeEntry(64*1024)] = makeEntry(128 * 1024)
+	}
+	warning := CheckLedgerEntriesSize(entries)
+	if warning == nil {
+		t.Fatal("expected a warning for 10 large entries, got nil")
+	}
+	if warning.EntryCount != 10 {
+		t.Errorf("expected EntryCount=10, got %d", warning.EntryCount)
+	}
+}
+
+func TestCheckLedgerEntriesSize_EmptyMap(t *testing.T) {
+	warning := CheckLedgerEntriesSize(map[string]string{})
+	if warning != nil {
+		t.Errorf("expected no warning for empty map, got: %v", warning)
+	}
+}
+
+func TestCheckLedgerEntriesSize_InvalidBase64Skipped(t *testing.T) {
+	// An invalid base64 value should be counted as zero bytes, not panic.
+	entries := map[string]string{
+		"not-valid-base64!!!": "also-not-valid!!!",
+	}
+	warning := CheckLedgerEntriesSize(entries)
+	// Total = 0, so no warning expected.
+	if warning != nil {
+		t.Errorf("expected no warning when base64 decode fails, got: %v", warning)
+	}
+}
+
+func TestLedgerSizeWarning_ErrorMessage(t *testing.T) {
+	w := &LedgerSizeWarning{
+		TotalBytes: 2 * 1024 * 1024,
+		LimitBytes: MaxLedgerEntriesSizeBytes,
+		EntryCount: 5,
+	}
+	msg := w.Error()
+	if !strings.Contains(msg, "rejected") {
+		t.Errorf("expected error message to mention rejection, got: %q", msg)
+	}
+	if !strings.Contains(msg, "5") {
+		t.Errorf("expected error message to mention entry count, got: %q", msg)
+	}
+}
+
+func TestWarnLedgerEntriesSize_WritesWarningWhenOverLimit(t *testing.T) {
+	half := MaxLedgerEntriesSizeBytes / 2
+	entries := map[string]string{
+		makeEntry(half): makeEntry(half + 1),
+	}
+
+	var buf bytes.Buffer
+	warned := WarnLedgerEntriesSize(entries, &buf)
+
+	if !warned {
+		t.Fatal("expected WarnLedgerEntriesSize to return true when over limit")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "WARNING") {
+		t.Errorf("expected output to contain WARNING, got: %q", out)
+	}
+	if !strings.Contains(out, "rejected") {
+		t.Errorf("expected output to mention rejection, got: %q", out)
+	}
+}
+
+func TestWarnLedgerEntriesSize_SilentWhenUnderLimit(t *testing.T) {
+	entries := map[string]string{
+		makeEntry(64): makeEntry(128),
+	}
+
+	var buf bytes.Buffer
+	warned := WarnLedgerEntriesSize(entries, &buf)
+
+	if warned {
+		t.Error("expected WarnLedgerEntriesSize to return false when under limit")
+	}
+	if buf.Len() > 0 {
+		t.Errorf("expected no output when under limit, got: %q", buf.String())
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		input    int
+		contains string
+	}{
+		{512, "512 bytes"},
+		{1024, "KiB"},
+		{1024 * 1024, "MiB"},
+		{2 * 1024 * 1024, "MiB"},
+	}
+	for _, tt := range tests {
+		got := formatBytes(tt.input)
+		if !strings.Contains(got, tt.contains) {
+			t.Errorf("formatBytes(%d) = %q, expected to contain %q", tt.input, got, tt.contains)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #581. Adds an explicit warning when an invocation request passes ledger entries whose total decoded size exceeds the Soroban network limit of 1 MiB. The warning is emitted to stderr before the simulator runs so users are informed immediately that the transaction would be rejected on-chain, without suppressing the local simulation result.

---

## Files Changed

### `internal/simulator/ledger_limits.go` *(new)*
- `MaxLedgerEntriesSizeBytes` — named constant (1 MiB) with a source reference to `stellar-core` so the value is traceable to the protocol, not magic
- `LedgerSizeWarning` — typed struct carrying `TotalBytes`, `LimitBytes`, and `EntryCount`; callers can inspect the violation programmatically without parsing a string
- `CheckLedgerEntriesSize` — pure function; base64-decodes both keys and values and sums their lengths; invalid base64 is silently counted as zero so the function cannot panic on malformed input
- `WarnLedgerEntriesSize(entries, w io.Writer)` — writes a formatted warning to any writer and returns a bool; `io.Writer` injection makes it directly testable without capturing stderr
- `WarnLedgerEntriesSizeToStderr` — convenience wrapper for CLI call sites; stderr keeps warnings out of stdout where structured output lives
- `formatBytes` — renders byte counts as `KiB` / `MiB` with the raw count alongside

### `internal/simulator/ledger_limits_test.go` *(new)*
9 tests:
- Under limit → no warning
- Exactly at limit → no warning
- One byte over → warning emitted with correct field values
- Multiple entries over → `EntryCount` is accurate
- Empty map → no warning
- Invalid base64 → no panic, no false-positive
- `LedgerSizeWarning.Error()` message content
- `WarnLedgerEntriesSize` output contains `WARNING` and `rejected`
- `WarnLedgerEntriesSize` is silent when under limit

### `internal/cmd/dry_run.go` *(modified)*
- Calls `simulator.WarnLedgerEntriesSizeToStderr(ledgerEntries)` immediately after `client.GetLedgerEntries` returns, before the simulator is invoked
- Warning fires early so it's visible even if the simulator run is slow
- Not a hard error — simulation still proceeds; dry-run output (budget, events, gas estimate) has diagnostic value even for a tx that would be rejected

---

## Why a warning, not an error?
The issue asks for a warning. Blocking the run would remove signal — the local simulation still surfaces budget usage and gas estimates that help the developer understand what to trim before resubmitting.

---

## Testing
```bash
go test ./internal/simulator/... -run "TestCheckLedger|TestWarnLedger|TestLedgerSize|TestFormatBytes" -v
```