### PR TITLE
feat(source-map): Highlight opt-level mismatch warnings

### DIFF
--- a/internal/sourcemap/discovery.go
+++ b/internal/sourcemap/discovery.go
@@ -6,12 +6,41 @@ package sourcemap
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 )
 
 const wasmTargetPath = "target/wasm32-unknown-unknown/release"
+
+// HashMismatchError is returned when the local WASM hash does not match
+// the expected on-chain hash.
+type HashMismatchError struct {
+	Path     string
+	Local    string
+	OnChain  string
+}
+
+func (e *HashMismatchError) Error() string {
+	return fmt.Sprintf("opt-level mismatch: local WASM hash %q does not match on-chain hash %q (path: %s)", e.Local, e.OnChain, e.Path)
+}
+
+// CheckHashMismatch computes the SHA256 hash of the WASM at path and
+// compares it to onChainHash. It returns a HashMismatchError when they
+// differ, so callers can surface a warning to the user.
+func CheckHashMismatch(path, onChainHash string) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read WASM file %q: %w", path, err)
+	}
+	sum := sha256.Sum256(content)
+	local := hex.EncodeToString(sum[:])
+	if local != onChainHash {
+		return &HashMismatchError{Path: path, Local: local, OnChain: onChainHash}
+	}
+	return nil
+}
 
 // DiscoverLocalSymbols scans for WASM files in the local target directory.
 // It returns a map of WASM hashes to their absolute file paths.


### PR DESCRIPTION
Closes #373

## Summary

Adds hash-mismatch detection for local WASM files with debug symbols
against the on-chain bytecode hash.

## Changes

- `internal/sourcemap/discovery.go`: Add `CheckHashMismatch(path, onChainHash string) error`
  that reads the local WASM, computes its SHA256, and returns a
  `HashMismatchError` when the hashes differ. `HashMismatchError` carries
  the local hash, the expected on-chain hash, and the file path so
  callers can surface a clear warning to the user.

- `internal/sourcemap/sourcemap_test.go`: Add tests covering:
  - matching hash (no error)
  - mismatched hash (HashMismatchError returned with correct fields)
  - missing file (plain error, not HashMismatchError)
  - error message content

## Testing

Run:
  go test ./internal/sourcemap/... -run TestCheckHash -v