### PR TITLE
feat: Add Makefile targets for code formatting and pre-commit hook ma…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,25 @@
-# Pre-commit hooks for strict linting
+# Pre-commit hooks for strict formatting and linting
 # Install: pip install pre-commit && pre-commit install
 # Run manually: pre-commit run --all-files
 
 repos:
+  # ──────────────────────────────────────────────
+  # Go formatting: gofmt + goimports (auto-fix)
+  # ──────────────────────────────────────────────
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.5.1
+    hooks:
+      - id: go-fmt
+        name: gofmt (auto-format)
+        description: Runs gofmt and auto-formats Go files
+
+      - id: go-imports
+        name: goimports (auto-format)
+        description: Runs goimports to fix imports and formatting in Go files
+
+  # ──────────────────────────────────────────────
+  # Go linting: golangci-lint (strict)
+  # ──────────────────────────────────────────────
   - repo: https://github.com/golangci/golangci-lint
     rev: v1.61.0
     hooks:
@@ -13,6 +30,9 @@ repos:
           - --max-issues-per-linter=0
           - --max-same-issues=0
 
+  # ──────────────────────────────────────────────
+  # Local hooks: go vet, cargo fmt, cargo clippy
+  # ──────────────────────────────────────────────
   - repo: local
     hooks:
       - id: go-vet
@@ -22,23 +42,26 @@ repos:
         pass_filenames: false
         files: \.go$
 
-      - id: rust-clippy
+      - id: cargo-fmt
+        name: cargo fmt (auto-format)
+        entry: bash -c 'cd simulator && cargo fmt'
+        language: system
+        pass_filenames: false
+        files: \.rs$
+        description: Runs cargo fmt to auto-format all Rust files in simulator/
+
+      - id: cargo-fmt-check
+        name: cargo fmt --check (verify)
+        entry: bash -c 'cd simulator && cargo fmt --check'
+        language: system
+        pass_filenames: false
+        files: \.rs$
+        stages: [pre-push]
+        description: Verifies Rust formatting on push (strict gate)
+
+      - id: cargo-clippy
         name: cargo clippy (strict)
         entry: bash -c 'cd simulator && cargo clippy --all-targets --all-features -- -D warnings -D clippy::all -D unused-variables -D unused-imports -D unused-mut -D dead-code -D unused-assignments -W clippy::pedantic -W clippy::nursery'
         language: system
         pass_filenames: false
         files: \.rs$
-
-      - id: rust-fmt
-        name: cargo fmt
-        entry: bash -c 'cd simulator && cargo fmt --check'
-        language: system
-        pass_filenames: false
-        files: \.rs$
-
-      - id: go-fmt
-        name: go fmt
-        entry: bash -c 'test -z "$(gofmt -l .)"'
-        language: system
-        pass_filenames: false
-        files: \.go$

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: build test lint lint-strict lint-unused test-unused validate-ci validate-interface clean
 .PHONY: rust-lint rust-lint-strict rust-test rust-build lint-all-strict
 .PHONY: build test lint validate-errors clean bench bench-rpc bench-sim bench-profile
+.PHONY: fmt fmt-go fmt-rust pre-commit
 
 # Build variables
 VERSION?=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -113,3 +114,43 @@ rust-build:
 # Run all strict linting (Go + Rust)
 lint-all-strict: lint-strict rust-lint-strict
 	@echo " All strict linting passed"
+
+# ──────────────────────────────────────────────
+# Formatting targets
+# ──────────────────────────────────────────────
+
+# Format Go files (gofmt + goimports)
+fmt-go:
+	@echo "Formatting Go files..."
+	@gofmt -w .
+	@if command -v goimports >/dev/null 2>&1; then \
+		goimports -w .; \
+	else \
+		echo "⚠  goimports not found. Install: go install golang.org/x/tools/cmd/goimports@latest"; \
+	fi
+	@echo "✓ Go formatting done"
+
+# Format Rust files (cargo fmt)
+fmt-rust:
+	@echo "Formatting Rust files..."
+	@cd simulator && cargo fmt
+	@echo "✓ Rust formatting done"
+
+# Format everything (Go + Rust)
+fmt: fmt-go fmt-rust
+	@echo "✓ All formatting done"
+
+# ──────────────────────────────────────────────
+# Pre-commit setup
+# ──────────────────────────────────────────────
+
+# Install pre-commit hooks
+pre-commit:
+	@echo "Setting up pre-commit hooks..."
+	@if command -v pre-commit >/dev/null 2>&1; then \
+		pre-commit install; \
+		echo "✓ Pre-commit hooks installed"; \
+	else \
+		echo "⚠  pre-commit not found. Install: pip install pre-commit"; \
+		exit 1; \
+	fi


### PR DESCRIPTION
## Overview

Integrates `gofmt`, `goimports`, and `cargo fmt` strictly via [.pre-commit-config.yaml](cci:7://file:///Users/mac/Desktop/development/oss/hintents/.pre-commit-config.yaml:0:0-0:0) to prevent unformatted code from being committed. Replaces the previous check-only hooks with auto-formatting hooks that fix files in-place on every commit.

## Changes

### Pre-commit Configuration ([.pre-commit-config.yaml](cci:7://file:///Users/mac/Desktop/development/oss/hintents/.pre-commit-config.yaml:0:0-0:0))

- **gofmt (auto-format)**: Added via `dnephin/pre-commit-golang` — runs `gofmt` on staged [.go](cci:7://file:///Users/mac/Desktop/development/oss/hintents/main.go:0:0-0:0) files and auto-formats in-place
- **goimports (auto-format)**: Added via `dnephin/pre-commit-golang` — runs `goimports` to fix import grouping and ordering on staged [.go](cci:7://file:///Users/mac/Desktop/development/oss/hintents/main.go:0:0-0:0) files
- **cargo fmt (auto-format)**: Updated local hook to run `cargo fmt` (without `--check`) on staged `.rs` files in `simulator/`, auto-formatting in-place
- **cargo fmt --check (pre-push gate)**: Added strict verification hook on `pre-push` stage to block pushes with unformatted Rust code
- **Retained**: `golangci-lint` (strict), `go vet`, and `cargo clippy` (strict) hooks unchanged

### Makefile

- **`make fmt`**: New target — runs all formatters (Go + Rust)
- **`make fmt-go`**: New target — runs `gofmt -w` and `goimports -w` across the repo
- **`make fmt-rust`**: New target — runs `cargo fmt` in `simulator/`
- **`make pre-commit`**: New target — bootstraps pre-commit hooks with `pre-commit install`

## Key Design Decisions

- **Auto-fix over check-only**: Previous hooks only detected formatting issues and failed — developers had to manually run formatters. Now hooks auto-format files; if changes are made, the commit is blocked and the developer simply re-stages and commits.
- **`dnephin/pre-commit-golang`**: Industry-standard pre-commit repo for Go hooks, avoids fragile bash one-liners.
- **Two-stage Rust formatting**: `cargo fmt` (auto-fix) on commit + `cargo fmt --check` (strict gate) on push provides both convenience and safety.

## Developer Setup

```bash
pip install pre-commit   # one-time install
make pre-commit          # install git hooks

closes #543 
