### PR TITLE
feat: enhance shell completion with flag value suggestions (#592)

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -49,7 +49,7 @@ For detailed instructions on setting up completions for your shell, consult your
 
 		switch shell {
 		case "bash":
-			return rootCmd.GenBashCompletion(os.Stdout)
+			return rootCmd.GenBashCompletionV2(os.Stdout, true)
 		case "zsh":
 			return rootCmd.GenZshCompletion(os.Stdout)
 		case "fish":

--- a/internal/cmd/auth_debug.go
+++ b/internal/cmd/auth_debug.go
@@ -111,5 +111,8 @@ func init() {
 	authDebugCmd.Flags().StringVar(&authRPCURLFlag, "rpc-url", "", "Custom Horizon RPC URL")
 	authDebugCmd.Flags().BoolVar(&authDetailedFlag, "detailed", false, "Show detailed analysis and missing signatures")
 	authDebugCmd.Flags().BoolVar(&authJSONOutputFlag, "json", false, "Output as JSON")
+
+	_ = authDebugCmd.RegisterFlagCompletionFunc("network", completeNetworkFlag)
+
 	rootCmd.AddCommand(authDebugCmd)
 }

--- a/internal/cmd/compare.go
+++ b/internal/cmd/compare.go
@@ -107,7 +107,8 @@ func init() {
 		"Colour theme (default, deuteranopia, protanopia, tritanopia, high-contrast)")
 	compareCmd.Flags().Uint32Var(&cmpProtoFlag, "protocol-version", 0,
 		"Override protocol version for both simulation passes (20, 21, 22, …)")
-
+	_ = compareCmd.RegisterFlagCompletionFunc("network", completeNetworkFlag)
+	_ = compareCmd.RegisterFlagCompletionFunc("theme", completeThemeFlag)
 	rootCmd.AddCommand(compareCmd)
 }
 

--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -57,7 +57,7 @@ PowerShell:
 	Run: func(cmd *cobra.Command, args []string) {
 		switch args[0] {
 		case "bash":
-			cmd.Root().GenBashCompletion(os.Stdout)
+			cmd.Root().GenBashCompletionV2(os.Stdout, true)
 		case "zsh":
 			cmd.Root().GenZshCompletion(os.Stdout)
 		case "fish":

--- a/internal/cmd/completion_helpers.go
+++ b/internal/cmd/completion_helpers.go
@@ -1,0 +1,43 @@
+// Copyright 2025 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var networkAliases = []string{"testnet\tStellar test network", "mainnet\tStellar public network", "futurenet\tStellar future network"}
+var initNetworkAliases = []string{"public\tStellar public network", "testnet\tStellar test network", "futurenet\tStellar future network", "standalone\tLocal standalone network"}
+var themeNames = []string{"default\tStandard terminal colors", "deuteranopia\tRed-green color blind friendly", "protanopia\tRed color blind friendly", "tritanopia\tBlue-yellow color blind friendly", "high-contrast\tHigh contrast for low-vision"}
+var xdrFormats = []string{"json\tJSON output", "table\tTabular output"}
+var xdrTypes = []string{"ledger-entry\tLedger entry XDR", "diagnostic-event\tDiagnostic event XDR"}
+var reportFormats = []string{"html\tHTML report", "pdf\tPDF report", "json\tJSON report", "html,pdf\tBoth HTML and PDF"}
+
+func completeNetworkFlag(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return networkAliases, cobra.ShellCompDirectiveNoFileComp
+}
+
+func completeInitNetworkFlag(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return initNetworkAliases, cobra.ShellCompDirectiveNoFileComp
+}
+
+func completeThemeFlag(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return themeNames, cobra.ShellCompDirectiveNoFileComp
+}
+
+func completeXDRFormatFlag(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return xdrFormats, cobra.ShellCompDirectiveNoFileComp
+}
+
+func completeXDRTypeFlag(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return xdrTypes, cobra.ShellCompDirectiveNoFileComp
+}
+
+func completeReportFormatFlag(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return reportFormats, cobra.ShellCompDirectiveNoFileComp
+}
+
+func completeNoOp(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return nil, cobra.ShellCompDirectiveNoFileComp
+}

--- a/internal/cmd/completion_helpers_test.go
+++ b/internal/cmd/completion_helpers_test.go
@@ -1,0 +1,80 @@
+// Copyright 2025 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestCompleteNetworkFlag(t *testing.T) {
+	completions, directive := completeNetworkFlag(nil, nil, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("expected ShellCompDirectiveNoFileComp, got %v", directive)
+	}
+	if len(completions) != 3 {
+		t.Fatalf("expected 3 network completions, got %d", len(completions))
+	}
+}
+
+func TestCompleteInitNetworkFlag(t *testing.T) {
+	completions, directive := completeInitNetworkFlag(nil, nil, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("expected ShellCompDirectiveNoFileComp, got %v", directive)
+	}
+	if len(completions) != 4 {
+		t.Fatalf("expected 4 init network completions, got %d", len(completions))
+	}
+}
+
+func TestCompleteThemeFlag(t *testing.T) {
+	completions, directive := completeThemeFlag(nil, nil, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("expected ShellCompDirectiveNoFileComp, got %v", directive)
+	}
+	if len(completions) != 5 {
+		t.Fatalf("expected 5 theme completions, got %d", len(completions))
+	}
+}
+
+func TestCompleteXDRFormatFlag(t *testing.T) {
+	completions, directive := completeXDRFormatFlag(nil, nil, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("expected ShellCompDirectiveNoFileComp, got %v", directive)
+	}
+	if len(completions) != 2 {
+		t.Fatalf("expected 2 xdr format completions, got %d", len(completions))
+	}
+}
+
+func TestCompleteXDRTypeFlag(t *testing.T) {
+	completions, directive := completeXDRTypeFlag(nil, nil, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("expected ShellCompDirectiveNoFileComp, got %v", directive)
+	}
+	if len(completions) != 2 {
+		t.Fatalf("expected 2 xdr type completions, got %d", len(completions))
+	}
+}
+
+func TestCompleteReportFormatFlag(t *testing.T) {
+	completions, directive := completeReportFormatFlag(nil, nil, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("expected ShellCompDirectiveNoFileComp, got %v", directive)
+	}
+	if len(completions) != 4 {
+		t.Fatalf("expected 4 report format completions, got %d", len(completions))
+	}
+}
+
+func TestCompleteNoOp(t *testing.T) {
+	completions, directive := completeNoOp(nil, nil, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("expected ShellCompDirectiveNoFileComp, got %v", directive)
+	}
+	if completions != nil {
+		t.Fatalf("expected nil completions, got %v", completions)
+	}
+}

--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -110,5 +110,7 @@ func init() {
 	daemonCmd.Flags().BoolVar(&daemonTracing, "tracing", false, "Enable OpenTelemetry tracing")
 	daemonCmd.Flags().StringVar(&daemonOTLPURL, "otlp-url", "http://localhost:4318", "OTLP exporter URL")
 
+	_ = daemonCmd.RegisterFlagCompletionFunc("network", completeNetworkFlag)
+
 	rootCmd.AddCommand(daemonCmd)
 }

--- a/internal/cmd/debug.go
+++ b/internal/cmd/debug.go
@@ -1106,6 +1106,10 @@ func init() {
 	debugCmd.Flags().Uint32Var(&mockBaseFeeFlag, "mock-base-fee", 0, "Override base fee (stroops) for local fee sufficiency checks")
 	debugCmd.Flags().Uint64Var(&mockGasPriceFlag, "mock-gas-price", 0, "Override gas price multiplier for local fee sufficiency checks")
 
+	_ = debugCmd.RegisterFlagCompletionFunc("network", completeNetworkFlag)
+	_ = debugCmd.RegisterFlagCompletionFunc("compare-network", completeNetworkFlag)
+	_ = debugCmd.RegisterFlagCompletionFunc("theme", completeThemeFlag)
+
 	rootCmd.AddCommand(debugCmd)
 }
 

--- a/internal/cmd/dry_run.go
+++ b/internal/cmd/dry_run.go
@@ -57,6 +57,8 @@ func init() {
 	dryRunCmd.Flags().StringVar(&dryRunRPCURLFlag, "rpc-url", "", "Custom Horizon RPC URL to use")
 	dryRunCmd.Flags().StringVar(&dryRunRPCTokenFlag, "rpc-token", "", "RPC authentication token (can also use ERST_RPC_TOKEN env var)")
 
+	_ = dryRunCmd.RegisterFlagCompletionFunc("network", completeNetworkFlag)
+
 	rootCmd.AddCommand(dryRunCmd)
 }
 

--- a/internal/cmd/explain.go
+++ b/internal/cmd/explain.go
@@ -159,5 +159,8 @@ func init() {
 	explainCmd.Flags().StringVarP(&explainNetworkFlag, "network", "n", "mainnet", "Stellar network (testnet, mainnet, futurenet)")
 	explainCmd.Flags().StringVar(&explainRPCURLFlag, "rpc-url", "", "Custom RPC URL")
 	explainCmd.Flags().StringVar(&explainRPCToken, "rpc-token", "", "RPC authentication token (can also use ERST_RPC_TOKEN env var)")
+
+	_ = explainCmd.RegisterFlagCompletionFunc("network", completeNetworkFlag)
+
 	rootCmd.AddCommand(explainCmd)
 }

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -304,5 +304,8 @@ func init() {
 	initCmd.Flags().StringVar(&initNetworkName, "network", "testnet", "Default network to write into erst.toml (public, testnet, futurenet, standalone)")
 	initCmd.Flags().StringVar(&initRPCURLFlag, "rpc-url", "", "RPC URL to write into erst.toml (skips wizard default for this value)")
 	initCmd.Flags().StringVar(&initNetworkPassphraseFlag, "network-passphrase", "", "Network passphrase to write into erst.toml (skips wizard default for this value)")
+
+	_ = initCmd.RegisterFlagCompletionFunc("network", completeInitNetworkFlag)
+
 	rootCmd.AddCommand(initCmd)
 }

--- a/internal/cmd/report.go
+++ b/internal/cmd/report.go
@@ -220,5 +220,7 @@ func init() {
 	reportCmd.Flags().StringVar(&reportOutput, "output", ".", "Output directory for reports")
 	reportCmd.Flags().StringVar(&reportFile, "file", "", "Trace file to analyze")
 
+	_ = reportCmd.RegisterFlagCompletionFunc("format", completeReportFormatFlag)
+
 	rootCmd.AddCommand(reportCmd)
 }

--- a/internal/cmd/trace.go
+++ b/internal/cmd/trace.go
@@ -76,5 +76,8 @@ Example:
 func init() {
 	traceCmd.Flags().StringVarP(&traceFile, "file", "f", "", "Trace file to load")
 	traceCmd.Flags().StringVar(&traceThemeFlag, "theme", "", "Color theme (default, deuteranopia, protanopia, tritanopia, high-contrast)")
+
+	_ = traceCmd.RegisterFlagCompletionFunc("theme", completeThemeFlag)
+
 	rootCmd.AddCommand(traceCmd)
 }

--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -130,6 +130,8 @@ func init() {
 	upgradeCmd.Flags().StringVarP(&networkFlag, "network", "n", string(rpc.Mainnet), "Stellar network to use")
 	upgradeCmd.Flags().StringVar(&rpcURLFlag, "rpc-url", "", "Custom Horizon RPC URL")
 
+	_ = upgradeCmd.RegisterFlagCompletionFunc("network", completeNetworkFlag)
+
 	rootCmd.AddCommand(upgradeCmd)
 }
 

--- a/internal/cmd/wizard.go
+++ b/internal/cmd/wizard.go
@@ -45,5 +45,8 @@ var wizardCmd = &cobra.Command{
 func init() {
 	wizardCmd.Flags().StringP("account", "a", "", "Stellar account address")
 	wizardCmd.Flags().StringP("network", "n", string(rpc.Mainnet), "Network (testnet, mainnet, futurenet)")
+
+	_ = wizardCmd.RegisterFlagCompletionFunc("network", completeNetworkFlag)
+
 	rootCmd.AddCommand(wizardCmd)
 }

--- a/internal/cmd/xdr.go
+++ b/internal/cmd/xdr.go
@@ -75,4 +75,7 @@ func init() {
 	xdrCmd.Flags().StringVar(&xdrType, "type", "ledger-entry", "XDR type: ledger-entry, diagnostic-event")
 
 	_ = xdrCmd.MarkFlagRequired("data")
+
+	_ = xdrCmd.RegisterFlagCompletionFunc("format", completeXDRFormatFlag)
+	_ = xdrCmd.RegisterFlagCompletionFunc("type", completeXDRTypeFlag)
 }


### PR DESCRIPTION
Registers RegisterFlagCompletionFunc for all commands with enumerated flag values so shell completion scripts suggest valid options with descriptions natively.

What changed:

--network completes to testnet, mainnet, futurenet (or public/standalone for init)
--theme completes to default, deuteranopia, protanopia, tritanopia, high-contrast
--format / --type complete to their valid values on xdr and report
Bash completion upgraded to v2 for description support
Closes #592

