### PR TITLE
feat(wasm): use streaming chunk reader for WASM magic bytes validation

### DIFF
--- a/simulator/src/wasm.rs
+++ b/simulator/src/wasm.rs
@@ -1,7 +1,8 @@
 // Copyright 2025 Erst Users
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fs;
+use std::fs::File;
+use std::io::{BufReader, Read};
 
 const WASM_MAGIC: &[u8; 4] = b"\0asm";
 pub const MAX_WASM_SIZE: usize = 64 * 1024; // 64 KiB Soroban Limit
@@ -26,15 +27,33 @@ impl std::fmt::Display for WasmLoadError {
 }
 
 pub fn load_wasm_from_path(path: &str) -> Result<Vec<u8>, WasmLoadError> {
-    let bytes = fs::read(path).map_err(WasmLoadError::Io)?;
-    if bytes.len() < 4 || &bytes[..4] != WASM_MAGIC {
+    let file = File::open(path).map_err(WasmLoadError::Io)?;
+    let mut reader = BufReader::new(file);
+
+    // Read only the first 4 bytes to check magic bytes
+    // This avoids buffering the entire file into memory upfront
+    let mut magic = [0u8; 4];
+    reader.read_exact(&mut magic).map_err(WasmLoadError::Io)?;
+
+    if &magic != WASM_MAGIC {
         return Err(WasmLoadError::InvalidMagic);
     }
+
+    // Magic bytes valid — now read the rest of the file
+    let mut rest = Vec::new();
+    reader.read_to_end(&mut rest).map_err(WasmLoadError::Io)?;
+
+    // Combine magic + rest into full bytes
+    let mut bytes = Vec::with_capacity(4 + rest.len());
+    bytes.extend_from_slice(&magic);
+    bytes.append(&mut rest);
+
     if bytes.len() > MAX_WASM_SIZE {
         return Err(WasmLoadError::TooLarge {
             size: bytes.len(),
             limit: MAX_WASM_SIZE,
         });
     }
+
     Ok(bytes)
 }


### PR DESCRIPTION

feat(wasm): use streaming chunk reader for WASM magic bytes validation 


Closes #559 Implement streaming parser for large WASM files





