### PR TITLE
feat: add partial ID and tx-hash prefix resolution to session lookup

### DIFF
--- a/internal/cmd/resource_lookup_test.go
+++ b/internal/cmd/resource_lookup_test.go
@@ -3,7 +3,11 @@
 
 package cmd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/dotandev/hintents/internal/session"
+)
 
 func TestLevenshteinDistance(t *testing.T) {
 	tests := []struct {
@@ -50,5 +54,82 @@ func TestResourceNotFoundError(t *testing.T) {
 
 	if got := resourceNotFoundError("").Error(); got != "Resource not found." {
 		t.Fatalf("unexpected no-suggestion message: %q", got)
+	}
+}
+
+func TestResolvePartialID(t *testing.T) {
+	candidates := []string{
+		"abc123-1700000000",
+		"def456-1700001111",
+		"abc999-1700002222",
+	}
+
+	// Unique prefix resolves to the single match.
+	if got := resolvePartialID("def4", candidates); got != "def456-1700001111" {
+		t.Fatalf("resolvePartialID unique prefix: got %q, want %q", got, "def456-1700001111")
+	}
+
+	// Ambiguous prefix returns empty.
+	if got := resolvePartialID("abc", candidates); got != "" {
+		t.Fatalf("resolvePartialID ambiguous prefix: got %q, want empty", got)
+	}
+
+	// No match returns empty.
+	if got := resolvePartialID("zzz", candidates); got != "" {
+		t.Fatalf("resolvePartialID no match: got %q, want empty", got)
+	}
+
+	// Empty input returns empty.
+	if got := resolvePartialID("", candidates); got != "" {
+		t.Fatalf("resolvePartialID empty input: got %q, want empty", got)
+	}
+
+	// Full ID still resolves.
+	if got := resolvePartialID("def456-1700001111", candidates); got != "def456-1700001111" {
+		t.Fatalf("resolvePartialID full ID: got %q, want %q", got, "def456-1700001111")
+	}
+
+	// Case-insensitive matching.
+	if got := resolvePartialID("DEF4", candidates); got != "def456-1700001111" {
+		t.Fatalf("resolvePartialID case-insensitive: got %q, want %q", got, "def456-1700001111")
+	}
+}
+
+func TestResolveByTxHash(t *testing.T) {
+	sessions := []*session.SessionData{
+		{ID: "abc123-1700000000", TxHash: "aabbccdd11223344"},
+		{ID: "def456-1700001111", TxHash: "eeff001122334455"},
+	}
+
+	// Unique tx hash prefix resolves.
+	if got := resolveByTxHash("aabbcc", sessions); got != "abc123-1700000000" {
+		t.Fatalf("resolveByTxHash unique prefix: got %q, want %q", got, "abc123-1700000000")
+	}
+
+	// No match returns empty.
+	if got := resolveByTxHash("999999", sessions); got != "" {
+		t.Fatalf("resolveByTxHash no match: got %q, want empty", got)
+	}
+
+	// Empty input returns empty.
+	if got := resolveByTxHash("", sessions); got != "" {
+		t.Fatalf("resolveByTxHash empty input: got %q, want empty", got)
+	}
+}
+
+func TestClosestStringMatchCaseInsensitive(t *testing.T) {
+	candidates := []string{"MySession-001", "PROD-session-42"}
+
+	if got := closestStringMatch("mysession-001", candidates); got != "MySession-001" {
+		t.Fatalf("closestStringMatch case-insensitive: got %q, want %q", got, "MySession-001")
+	}
+}
+
+func TestClosestStringMatchEmptyCandidates(t *testing.T) {
+	if got := closestStringMatch("anything", nil); got != "" {
+		t.Fatalf("closestStringMatch nil candidates: got %q", got)
+	}
+	if got := closestStringMatch("anything", []string{}); got != "" {
+		t.Fatalf("closestStringMatch empty candidates: got %q", got)
 	}
 }

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/dotandev/hintents/internal/errors"
@@ -151,14 +150,10 @@ Use 'erst session list' to see available sessions.`,
 			fmt.Fprintf(os.Stderr, "Warning: session cleanup failed: %v\n", err)
 		}
 
-		// Load session
-		data, err := store.Load(ctx, sessionID)
+		// Resolve session by exact ID, partial ID prefix, tx hash, or fuzzy match
+		data, err := resolveSessionInput(ctx, store, sessionID)
 		if err != nil {
-			suggestion, suggestErr := suggestSessionID(ctx, store, sessionID)
-			if suggestErr != nil {
-				return errors.WrapValidationError(fmt.Sprintf("failed to list sessions: %v", suggestErr))
-			}
-			return resourceNotFoundError(suggestion)
+			return err
 		}
 
 		// Check schema version compatibility
@@ -277,19 +272,17 @@ Use 'erst session list' to see available sessions.`,
 		}
 		defer store.Close()
 
-		// Delete session
-		if err := store.Delete(ctx, sessionID); err != nil {
-			if strings.Contains(strings.ToLower(err.Error()), "not found") {
-				suggestion, suggestErr := suggestSessionID(ctx, store, sessionID)
-				if suggestErr != nil {
-					return errors.WrapValidationError(fmt.Sprintf("failed to list sessions: %v", suggestErr))
-				}
-				return resourceNotFoundError(suggestion)
-			}
-			return errors.WrapValidationError(fmt.Sprintf("failed to delete session '%s': %v", sessionID, err))
+		// Resolve to a valid session ID before deleting
+		resolved, resolveErr := resolveSessionInput(ctx, store, sessionID)
+		if resolveErr != nil {
+			return resolveErr
 		}
 
-		fmt.Printf("Session deleted: %s\n", sessionID)
+		if err := store.Delete(ctx, resolved.ID); err != nil {
+			return errors.WrapValidationError(fmt.Sprintf("failed to delete session '%s': %v", resolved.ID, err))
+		}
+
+		fmt.Printf("Session deleted: %s\n", resolved.ID)
 		return nil
 	},
 }

--- a/internal/cmd/stats.go
+++ b/internal/cmd/stats.go
@@ -74,13 +74,9 @@ func loadSimulationResponse(cmd *cobra.Command, id string) (*simulator.Simulatio
 		}
 		defer store.Close()
 
-		data, err := store.Load(cmd.Context(), id)
+		data, err := resolveSessionInput(cmd.Context(), store, id)
 		if err != nil {
-			suggestion, suggestErr := suggestSessionID(cmd.Context(), store, id)
-			if suggestErr != nil {
-				return nil, fmt.Errorf("failed to list sessions: %w", suggestErr)
-			}
-			return nil, resourceNotFoundError(suggestion)
+			return nil, err
 		}
 		return data.ToSimulationResponse()
 	}


### PR DESCRIPTION
Extend fuzzy-matching for CLI resource lookup with partial ID resolution and transaction hash prefix matching. The unified resolveSessionInput function chains exact ID -> partial ID prefix -> tx-hash prefix -> Levenshtein-based fuzzy suggestion, letting users type partial session IDs or tx-hash prefixes instead of full identifiers. Integrated into session resume, session delete, and stats --session. 

Closes #525.