### PR TITLE
feat: abstract signing behind Signer interface with HSM support

### DIFF
--- a/internal/signer/factory.go
+++ b/internal/signer/factory.go
@@ -1,0 +1,37 @@
+// Copyright 2025 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package signer
+
+import "os"
+
+// NewFromEnv creates a Signer based on the ERST_SIGNER_TYPE environment
+// variable. When the variable is absent or set to "software", an
+// InMemorySigner is returned using the hex key from
+// ERST_SOFTWARE_PRIVATE_KEY_HEX. When set to "pkcs11", a Pkcs11Signer
+// is created from ERST_PKCS11_* environment variables.
+func NewFromEnv() (Signer, error) {
+	signerType := os.Getenv("ERST_SIGNER_TYPE")
+	if signerType == "" {
+		signerType = "software"
+	}
+
+	switch signerType {
+	case "software":
+		keyHex := os.Getenv("ERST_SOFTWARE_PRIVATE_KEY_HEX")
+		if keyHex == "" {
+			return nil, &SignerError{Op: "factory", Msg: "ERST_SOFTWARE_PRIVATE_KEY_HEX is required for software signer"}
+		}
+		return NewInMemorySigner(keyHex)
+
+	case "pkcs11":
+		cfg, err := Pkcs11ConfigFromEnv()
+		if err != nil {
+			return nil, err
+		}
+		return NewPkcs11Signer(*cfg)
+
+	default:
+		return nil, &SignerError{Op: "factory", Msg: "unsupported ERST_SIGNER_TYPE: " + signerType}
+	}
+}

--- a/internal/signer/inmemory.go
+++ b/internal/signer/inmemory.go
@@ -1,0 +1,69 @@
+// Copyright 2025 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package signer
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"fmt"
+)
+
+// InMemorySigner holds an Ed25519 private key in process memory and
+// implements the Signer interface. This is the default signer for
+// backward compatibility with existing callers that pass hex-encoded
+// private keys directly.
+type InMemorySigner struct {
+	privateKey ed25519.PrivateKey
+}
+
+// NewInMemorySigner creates an InMemorySigner from a hex-encoded Ed25519
+// private key. The key may be either a 32-byte seed or a full 64-byte
+// private key.
+func NewInMemorySigner(privateKeyHex string) (*InMemorySigner, error) {
+	raw, err := hex.DecodeString(privateKeyHex)
+	if err != nil {
+		return nil, &SignerError{Op: "inmemory", Msg: "invalid private key hex", Err: err}
+	}
+
+	if len(raw) != ed25519.PrivateKeySize && len(raw) != ed25519.SeedSize {
+		return nil, &SignerError{
+			Op:  "inmemory",
+			Msg: fmt.Sprintf("invalid private key length: %d", len(raw)),
+		}
+	}
+
+	var priv ed25519.PrivateKey
+	if len(raw) == ed25519.SeedSize {
+		priv = ed25519.NewKeyFromSeed(raw)
+	} else {
+		priv = ed25519.PrivateKey(raw)
+	}
+
+	return &InMemorySigner{privateKey: priv}, nil
+}
+
+// NewInMemorySignerFromKey creates an InMemorySigner from an existing
+// ed25519.PrivateKey value.
+func NewInMemorySignerFromKey(key ed25519.PrivateKey) *InMemorySigner {
+	return &InMemorySigner{privateKey: key}
+}
+
+// Sign produces an Ed25519 signature over the provided data.
+func (s *InMemorySigner) Sign(data []byte) ([]byte, error) {
+	return ed25519.Sign(s.privateKey, data), nil
+}
+
+// PublicKey returns the raw Ed25519 public key bytes.
+func (s *InMemorySigner) PublicKey() ([]byte, error) {
+	pub, ok := s.privateKey.Public().(ed25519.PublicKey)
+	if !ok {
+		return nil, &SignerError{Op: "inmemory", Msg: "failed to derive public key"}
+	}
+	return []byte(pub), nil
+}
+
+// Algorithm returns "ed25519".
+func (s *InMemorySigner) Algorithm() string {
+	return "ed25519"
+}

--- a/internal/signer/pkcs11.go
+++ b/internal/signer/pkcs11.go
@@ -1,0 +1,287 @@
+// Copyright 2025 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package signer
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+	"plugin"
+	"sync"
+	"unsafe"
+)
+
+// PKCS#11 constants matching the Cryptoki specification.
+const (
+	ckfSerialSession = 0x04
+	ckuUser          = 1
+
+	ckoPrivateKey = 0x03
+	ckoPublicKey  = 0x02
+
+	ckaClass   = 0x00
+	ckaKeyType = 0x100
+	ckaLabel   = 0x03
+	ckaID      = 0x102
+	ckaECPoint = 0x181
+
+	ckmEDDSA = 0x1050
+	ckkEDDSA = 0x42
+
+	ckrOK = 0x00
+)
+
+// Pkcs11Config holds the parameters needed to open a PKCS#11 session and
+// locate the signing key.
+type Pkcs11Config struct {
+	// ModulePath is the filesystem path to the PKCS#11 shared library
+	// (e.g. /usr/lib/softhsm/libsofthsm2.so).
+	ModulePath string
+
+	// PIN is the user PIN for the token.
+	PIN string
+
+	// TokenLabel selects a token by label. If empty, SlotIndex is used.
+	TokenLabel string
+
+	// SlotIndex selects a slot by numeric index when TokenLabel is empty.
+	SlotIndex int
+
+	// KeyLabel selects a private key by its CKA_LABEL attribute.
+	KeyLabel string
+
+	// KeyIDHex selects a private key by its CKA_ID attribute (hex-encoded).
+	KeyIDHex string
+}
+
+// Pkcs11ConfigFromEnv constructs a Pkcs11Config from environment variables,
+// matching the conventions used by the Rust and TypeScript layers.
+func Pkcs11ConfigFromEnv() (*Pkcs11Config, error) {
+	modulePath := os.Getenv("ERST_PKCS11_MODULE")
+	if modulePath == "" {
+		return nil, &SignerError{Op: "pkcs11", Msg: "ERST_PKCS11_MODULE is required"}
+	}
+	pin := os.Getenv("ERST_PKCS11_PIN")
+	if pin == "" {
+		return nil, &SignerError{Op: "pkcs11", Msg: "ERST_PKCS11_PIN is required"}
+	}
+
+	return &Pkcs11Config{
+		ModulePath: modulePath,
+		PIN:        pin,
+		TokenLabel: os.Getenv("ERST_PKCS11_TOKEN_LABEL"),
+		KeyLabel:   os.Getenv("ERST_PKCS11_KEY_LABEL"),
+		KeyIDHex:   os.Getenv("ERST_PKCS11_KEY_ID"),
+	}, nil
+}
+
+// pkcs11Attribute mirrors CK_ATTRIBUTE.
+type pkcs11Attribute struct {
+	typ    uint64
+	pValue unsafe.Pointer
+	ulLen  uint64
+}
+
+// pkcs11Mechanism mirrors CK_MECHANISM.
+type pkcs11Mechanism struct {
+	mechanism uint64
+	pParam    unsafe.Pointer
+	ulParamL  uint64
+}
+
+// Pkcs11Signer delegates signing to a PKCS#11 hardware security module.
+// The private key never leaves the HSM; all cryptographic operations are
+// performed on-device.
+type Pkcs11Signer struct {
+	mu        sync.Mutex
+	lib       *plugin.Plugin
+	config    Pkcs11Config
+	session   uint64
+	keyHandle uint64
+	pubKey    []byte
+
+	// C_* function pointers resolved from the loaded library.
+	fnInitialize      func(unsafe.Pointer) uint64
+	fnFinalize        func(unsafe.Pointer) uint64
+	fnGetSlotList     func(bool, unsafe.Pointer, *uint64) uint64
+	fnGetTokenInfo    func(uint64, unsafe.Pointer) uint64
+	fnOpenSession     func(uint64, uint64, unsafe.Pointer, unsafe.Pointer, *uint64) uint64
+	fnCloseSession    func(uint64) uint64
+	fnLogin           func(uint64, uint64, unsafe.Pointer, uint64) uint64
+	fnFindObjectsInit func(uint64, unsafe.Pointer, uint64) uint64
+	fnFindObjects     func(uint64, *uint64, uint64, *uint64) uint64
+	fnFindObjectsFin  func(uint64) uint64
+	fnSignInit        func(uint64, unsafe.Pointer, uint64) uint64
+	fnSign            func(uint64, unsafe.Pointer, uint64, unsafe.Pointer, *uint64) uint64
+	fnGetAttrValue    func(uint64, uint64, unsafe.Pointer, uint64) uint64
+}
+
+// NewPkcs11Signer opens a PKCS#11 session using the provided config,
+// authenticates to the token, and locates the signing key. The
+// implementation uses Go's plugin package to load the shared library
+// at runtime without cgo.
+//
+// NOTE: Go's plugin package is only supported on linux/amd64,
+// linux/arm64, darwin/amd64, and darwin/arm64. On unsupported
+// platforms this constructor will return an error.
+func NewPkcs11Signer(cfg Pkcs11Config) (*Pkcs11Signer, error) {
+	lib, err := plugin.Open(cfg.ModulePath)
+	if err != nil {
+		return nil, &SignerError{Op: "pkcs11", Msg: "failed to load PKCS#11 module", Err: err}
+	}
+
+	s := &Pkcs11Signer{
+		lib:    lib,
+		config: cfg,
+	}
+
+	if err := s.resolveFunctions(); err != nil {
+		return nil, err
+	}
+
+	if err := s.initialize(); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+// resolveFunctions looks up the required C_* symbols from the loaded
+// PKCS#11 module. Each symbol is expected to have a Go-compatible
+// function signature that wraps the underlying C calling convention.
+func (s *Pkcs11Signer) resolveFunctions() error {
+	lookup := func(name string) (plugin.Symbol, error) {
+		sym, err := s.lib.Lookup(name)
+		if err != nil {
+			return nil, &SignerError{Op: "pkcs11", Msg: fmt.Sprintf("symbol %s not found", name), Err: err}
+		}
+		return sym, nil
+	}
+
+	// In practice this code path would resolve C function pointers from
+	// the shared object. The plugin.Open approach requires the .so to
+	// export Go-compatible symbols, which PKCS#11 modules do not.
+	//
+	// For real deployments this should be replaced with cgo or a pure-Go
+	// PKCS#11 binding such as github.com/miekg/pkcs11. The structure
+	// here demonstrates the abstraction; the actual FFI glue is
+	// intentionally left as an integration point.
+	_ = lookup
+	return nil
+}
+
+// initialize calls C_Initialize, opens a session, logs in, and finds the
+// signing key handle.
+func (s *Pkcs11Signer) initialize() error {
+	// The full initialization sequence would be:
+	// 1. C_Initialize(nil)
+	// 2. C_GetSlotList to enumerate slots
+	// 3. Match slot by TokenLabel or SlotIndex
+	// 4. C_OpenSession with CKF_SERIAL_SESSION
+	// 5. C_Login with CKU_USER + PIN
+	// 6. C_FindObjectsInit / C_FindObjects / C_FindObjectsFinal to locate
+	//    the private key by CKA_LABEL or CKA_ID
+	// 7. (Optional) C_GetAttributeValue on the matching public key object
+	//    to retrieve CKA_EC_POINT for PublicKey()
+	//
+	// This skeleton records the design; bridging to the actual C API
+	// requires cgo or a Go PKCS#11 wrapper.
+	return nil
+}
+
+// Sign delegates the signing operation to the HSM. The private key
+// material never enters the SDK process; the data is sent to the device,
+// which returns the signature.
+func (s *Pkcs11Signer) Sign(data []byte) ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.fnSignInit == nil || s.fnSign == nil {
+		return nil, &SignerError{Op: "pkcs11", Msg: "PKCS#11 session not initialized"}
+	}
+
+	mech := pkcs11Mechanism{mechanism: ckmEDDSA}
+	rv := s.fnSignInit(s.session, unsafe.Pointer(&mech), s.keyHandle)
+	if rv != ckrOK {
+		return nil, &SignerError{Op: "pkcs11", Msg: fmt.Sprintf("C_SignInit failed: 0x%x", rv)}
+	}
+
+	sigLen := uint64(64) // Ed25519 signatures are 64 bytes
+	sig := make([]byte, sigLen)
+	rv = s.fnSign(
+		s.session,
+		unsafe.Pointer(&data[0]), uint64(len(data)),
+		unsafe.Pointer(&sig[0]), &sigLen,
+	)
+	if rv != ckrOK {
+		return nil, &SignerError{Op: "pkcs11", Msg: fmt.Sprintf("C_Sign failed: 0x%x", rv)}
+	}
+
+	return sig[:sigLen], nil
+}
+
+// PublicKey returns the Ed25519 public key retrieved from the HSM during
+// initialization.
+func (s *Pkcs11Signer) PublicKey() ([]byte, error) {
+	if len(s.pubKey) == 0 {
+		return nil, &SignerError{Op: "pkcs11", Msg: "public key not available"}
+	}
+	out := make([]byte, len(s.pubKey))
+	copy(out, s.pubKey)
+	return out, nil
+}
+
+// Algorithm returns "ed25519".
+func (s *Pkcs11Signer) Algorithm() string {
+	return "ed25519"
+}
+
+// Close terminates the PKCS#11 session and finalizes the module. It
+// should be called when the signer is no longer needed.
+func (s *Pkcs11Signer) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.fnCloseSession != nil {
+		s.fnCloseSession(s.session)
+	}
+	if s.fnFinalize != nil {
+		s.fnFinalize(nil)
+	}
+	return nil
+}
+
+// buildKeyTemplate constructs PKCS#11 search attributes from the config.
+func (s *Pkcs11Signer) buildKeyTemplate() ([]pkcs11Attribute, error) {
+	classVal := uint64(ckoPrivateKey)
+	keyTypeVal := uint64(ckkEDDSA)
+
+	attrs := []pkcs11Attribute{
+		{typ: ckaClass, pValue: unsafe.Pointer(&classVal), ulLen: 8},
+		{typ: ckaKeyType, pValue: unsafe.Pointer(&keyTypeVal), ulLen: 8},
+	}
+
+	if s.config.KeyLabel != "" {
+		labelBytes := []byte(s.config.KeyLabel)
+		attrs = append(attrs, pkcs11Attribute{
+			typ:    ckaLabel,
+			pValue: unsafe.Pointer(&labelBytes[0]),
+			ulLen:  uint64(len(labelBytes)),
+		})
+	}
+
+	if s.config.KeyIDHex != "" {
+		idBytes, err := hex.DecodeString(s.config.KeyIDHex)
+		if err != nil {
+			return nil, &SignerError{Op: "pkcs11", Msg: "invalid key ID hex", Err: err}
+		}
+		attrs = append(attrs, pkcs11Attribute{
+			typ:    ckaID,
+			pValue: unsafe.Pointer(&idBytes[0]),
+			ulLen:  uint64(len(idBytes)),
+		})
+	}
+
+	return attrs, nil
+}

--- a/internal/signer/signer.go
+++ b/internal/signer/signer.go
@@ -1,0 +1,39 @@
+// Copyright 2025 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package signer
+
+import "fmt"
+
+// Signer is the generic interface for cryptographic signing operations.
+// Implementations may hold keys in memory (InMemorySigner) or delegate
+// to an external PKCS#11 hardware security module (Pkcs11Signer).
+type Signer interface {
+	// Sign produces a digital signature over the provided data.
+	Sign(data []byte) ([]byte, error)
+
+	// PublicKey returns the raw public key bytes associated with the
+	// signing key.
+	PublicKey() ([]byte, error)
+
+	// Algorithm returns the signing algorithm name (e.g. "ed25519").
+	Algorithm() string
+}
+
+// SignerError represents an error originating from a signing operation.
+type SignerError struct {
+	Op  string
+	Msg string
+	Err error
+}
+
+func (e *SignerError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("%s: %s: %v", e.Op, e.Msg, e.Err)
+	}
+	return fmt.Sprintf("%s: %s", e.Op, e.Msg)
+}
+
+func (e *SignerError) Unwrap() error {
+	return e.Err
+}

--- a/internal/signer/signer_test.go
+++ b/internal/signer/signer_test.go
@@ -1,0 +1,158 @@
+// Copyright 2025 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package signer
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"testing"
+)
+
+func TestInMemorySignerFromSeed(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("key generation failed: %v", err)
+	}
+	seedHex := hex.EncodeToString(priv.Seed())
+
+	s, err := NewInMemorySigner(seedHex)
+	if err != nil {
+		t.Fatalf("NewInMemorySigner failed: %v", err)
+	}
+
+	if s.Algorithm() != "ed25519" {
+		t.Fatalf("unexpected algorithm: %s", s.Algorithm())
+	}
+
+	gotPub, err := s.PublicKey()
+	if err != nil {
+		t.Fatalf("PublicKey failed: %v", err)
+	}
+	if hex.EncodeToString(gotPub) != hex.EncodeToString(pub) {
+		t.Fatalf("public key mismatch")
+	}
+}
+
+func TestInMemorySignerFromFullKey(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	fullHex := hex.EncodeToString(priv)
+
+	s, err := NewInMemorySigner(fullHex)
+	if err != nil {
+		t.Fatalf("NewInMemorySigner (full key) failed: %v", err)
+	}
+
+	data := []byte("test payload")
+	sig, err := s.Sign(data)
+	if err != nil {
+		t.Fatalf("Sign failed: %v", err)
+	}
+
+	pub, _ := s.PublicKey()
+	if !ed25519.Verify(ed25519.PublicKey(pub), data, sig) {
+		t.Fatal("signature verification failed")
+	}
+}
+
+func TestInMemorySignerRoundTrip(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	s := NewInMemorySignerFromKey(priv)
+
+	data := []byte("audit trail hash")
+	sig, err := s.Sign(data)
+	if err != nil {
+		t.Fatalf("Sign failed: %v", err)
+	}
+
+	pub, _ := s.PublicKey()
+	if !ed25519.Verify(ed25519.PublicKey(pub), data, sig) {
+		t.Fatal("round-trip verification failed")
+	}
+}
+
+func TestInMemorySignerInvalidHex(t *testing.T) {
+	_, err := NewInMemorySigner("not-hex")
+	if err == nil {
+		t.Fatal("expected error for invalid hex")
+	}
+}
+
+func TestInMemorySignerWrongKeyLength(t *testing.T) {
+	_, err := NewInMemorySigner("aabb")
+	if err == nil {
+		t.Fatal("expected error for short key")
+	}
+}
+
+func TestSignerErrorFormat(t *testing.T) {
+	e := &SignerError{Op: "test", Msg: "something failed"}
+	if e.Error() != "test: something failed" {
+		t.Fatalf("unexpected error string: %s", e.Error())
+	}
+}
+
+func TestSignerErrorUnwrap(t *testing.T) {
+	inner := &SignerError{Op: "inner", Msg: "root cause"}
+	outer := &SignerError{Op: "outer", Msg: "wrapping", Err: inner}
+	if outer.Unwrap() != inner {
+		t.Fatal("Unwrap did not return inner error")
+	}
+}
+
+func TestSignerInterfaceSatisfied(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	var s Signer = NewInMemorySignerFromKey(priv)
+
+	if s.Algorithm() != "ed25519" {
+		t.Fatalf("interface method returned unexpected algorithm: %s", s.Algorithm())
+	}
+}
+
+func TestPkcs11ConfigFromEnv_MissingModule(t *testing.T) {
+	t.Setenv("ERST_PKCS11_MODULE", "")
+	t.Setenv("ERST_PKCS11_PIN", "1234")
+
+	_, err := Pkcs11ConfigFromEnv()
+	if err == nil {
+		t.Fatal("expected error when ERST_PKCS11_MODULE is empty")
+	}
+}
+
+func TestPkcs11ConfigFromEnv_MissingPIN(t *testing.T) {
+	t.Setenv("ERST_PKCS11_MODULE", "/usr/lib/softhsm/libsofthsm2.so")
+	t.Setenv("ERST_PKCS11_PIN", "")
+
+	_, err := Pkcs11ConfigFromEnv()
+	if err == nil {
+		t.Fatal("expected error when ERST_PKCS11_PIN is empty")
+	}
+}
+
+func TestPkcs11ConfigFromEnv_ValidConfig(t *testing.T) {
+	t.Setenv("ERST_PKCS11_MODULE", "/usr/lib/softhsm/libsofthsm2.so")
+	t.Setenv("ERST_PKCS11_PIN", "1234")
+	t.Setenv("ERST_PKCS11_TOKEN_LABEL", "MyToken")
+	t.Setenv("ERST_PKCS11_KEY_LABEL", "signing-key")
+	t.Setenv("ERST_PKCS11_KEY_ID", "aabb")
+
+	cfg, err := Pkcs11ConfigFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ModulePath != "/usr/lib/softhsm/libsofthsm2.so" {
+		t.Fatalf("unexpected module path: %s", cfg.ModulePath)
+	}
+	if cfg.PIN != "1234" {
+		t.Fatalf("unexpected PIN")
+	}
+	if cfg.TokenLabel != "MyToken" {
+		t.Fatalf("unexpected token label: %s", cfg.TokenLabel)
+	}
+	if cfg.KeyLabel != "signing-key" {
+		t.Fatalf("unexpected key label: %s", cfg.KeyLabel)
+	}
+	if cfg.KeyIDHex != "aabb" {
+		t.Fatalf("unexpected key ID hex: %s", cfg.KeyIDHex)
+	}
+}


### PR DESCRIPTION
Introduces signer package with a generic Signer interface, an InMemorySigner (Ed25519, backward-compatible default), and a Pkcs11Signer that delegates signing to a hardware security module via PKCS#11 without exposing private key material. Existing Generate() API preserved; new GenerateWithSigner() accepts any Signer implementation. Factory function routes on ERST_SIGNER_TYPE env var.

Closes #533