### PR TITLE
feat(sim): add --no-cache flag to bypass SourceMapCacheEntry

### DIFF
--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -312,7 +312,7 @@ fn main() {
                 if let Err(e) = vm::enforce_soroban_compatibility(&wasm_bytes) {
                     return send_error(format!("Strict VM enforcement failed: {}", e));
                 }
-                let mapper = SourceMapper::new(wasm_bytes);
+                let mapper = SourceMapper::new_with_options(wasm_bytes, request.no_cache.unwrap_or(false));
                 if mapper.has_debug_symbols() {
                     eprintln!("Debug symbols found in WASM");
                     Some(mapper)
@@ -1094,7 +1094,7 @@ mod tests {
         use crate::source_mapper::SourceMapper;
 
         let wasm_bytes = vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]; // WASM magic + version
-        let mapper = SourceMapper::new(wasm_bytes);
+        let mapper = SourceMapper::new_with_options(wasm_bytes, false);
         assert!(!mapper.has_debug_symbols());
         assert!(
             mapper.map_wasm_offset_to_source(0).is_none(),

--- a/simulator/src/source_map_cache.rs
+++ b/simulator/src/source_map_cache.rs
@@ -73,8 +73,15 @@ impl SourceMapCache {
         self.cache_dir.join(format!("{}.bin", wasm_hash))
     }
 
-    /// Gets a cached source map entry if it exists and is valid
-    pub fn get(&self, wasm_hash: &str) -> Option<SourceMapCacheEntry> {
+    /// Gets a cached source map entry if it exists and is valid.
+    /// When `no_cache` is true, skips the cache and returns None immediately,
+    /// forcing the caller to re-parse WASM symbols from scratch.
+    pub fn get(&self, wasm_hash: &str, no_cache: bool) -> Option<SourceMapCacheEntry> {
+        if no_cache {
+            println!("Cache bypassed via --no-cache flag. Re-parsing WASM symbols.");
+            return None;
+        }
+
         let cache_path = self.get_cache_path(wasm_hash);
 
         if !cache_path.exists() {
@@ -299,8 +306,8 @@ mod tests {
         // Store the entry
         cache.store(entry.clone()).unwrap();
 
-        // Retrieve the entry
-        let retrieved = cache.get(&wasm_hash).unwrap();
+        // Retrieve the entry — no_cache=false so cache is used normally
+        let retrieved = cache.get(&wasm_hash, false).unwrap();
         assert_eq!(retrieved.wasm_hash, wasm_hash);
         assert!(retrieved.has_symbols);
         assert_eq!(retrieved.mappings.len(), 1);
@@ -310,7 +317,30 @@ mod tests {
     fn test_get_missing() {
         let (cache, _temp) = create_test_cache();
 
-        let result = cache.get("nonexistent_hash_12345678901234567890123456789012");
+        let result = cache.get("nonexistent_hash_12345678901234567890123456789012", false);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_no_cache_bypasses_cache() {
+        let (cache, _temp) = create_test_cache();
+
+        let wasm_bytes = vec![0x00, 0x61, 0x73, 0x6d];
+        let wasm_hash = SourceMapCache::compute_wasm_hash(&wasm_bytes);
+
+        let entry = SourceMapCacheEntry {
+            wasm_hash: wasm_hash.clone(),
+            has_symbols: true,
+            mappings: HashMap::new(),
+            created_at: 1234567890,
+        };
+
+        // Store an entry so it exists on disk
+        cache.store(entry).unwrap();
+        assert!(cache.get(&wasm_hash, false).is_some());
+
+        // With no_cache=true, it should return None even though cache exists
+        let result = cache.get(&wasm_hash, true);
         assert!(result.is_none());
     }
 
@@ -329,11 +359,11 @@ mod tests {
         };
 
         cache.store(entry).unwrap();
-        assert!(cache.get(&wasm_hash).is_some());
+        assert!(cache.get(&wasm_hash, false).is_some());
 
         let count = cache.clear().unwrap();
         assert_eq!(count, 1);
-        assert!(cache.get(&wasm_hash).is_none());
+        assert!(cache.get(&wasm_hash, false).is_none());
     }
 
     #[test]


### PR DESCRIPTION
feat(sim): add --no-cache flag to bypass SourceMapCacheEntry

## Description
Adds a `--no-cache` flag to the source map utility that forces the simulator to re-parse WASM debug symbols instead of loading a cached `SourceMapCacheEntry`.

## Changes
- `source_map_cache.rs` — `get()` now accepts a `no_cache: bool` parameter. When `true`, it skips the cache and returns `None` immediately, forcing a fresh parse
- `source_mapper.rs` — added `new_with_options(wasm_bytes, no_cache)` constructor. `new()` delegates to it with `false` for backwards compatibility
- `main.rs` — both `SourceMapper::new()` call sites updated to pass `request.no_cache.unwrap_or(false)` from the incoming `SimulationRequest`

## Testing
- Added `test_no_cache_bypasses_cache` — stores a cache entry then asserts `get(..., true)` returns `None` even when the entry exists on disk
- Added `test_new_with_options_no_cache_still_parses` — asserts the mapper still works correctly when instantiated with `no_cache: true`

## Related Issues
Closes #562

## Notes
`simulator/src/main.rs` has pre-existing delimiter errors on lines 466/473 that exist on the base branch before any of my changes. Confirmed via `git stash && cargo build`. This is out of scope for this issue.

## Checklist
- [x] Code follows style guidelines
- [x] Tests added
- [x] No new warnings or errors introduced by my changes