### PR TITLE
refactor: add compile-time interface compliance checks

### DIFF
--- a/internal/authtrace/custom_auth.go
+++ b/internal/authtrace/custom_auth.go
@@ -14,6 +14,11 @@ type ContractAuthHandler interface {
 	GetAuthDetails() map[string]interface{}
 }
 
+var (
+	_ ContractAuthHandler = (*MultiSigContractAuth)(nil)
+	_ ContractAuthHandler = (*RecoveryAuth)(nil)
+)
+
 type CustomContractAuthValidator struct {
 	contracts map[string]ContractAuthHandler
 }

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 )
 
+var _ DecoderPlugin = (*mockDecoder)(nil)
+
 type mockDecoder struct {
 	name       string
 	version    string

--- a/internal/rpc/method_telemetry.go
+++ b/internal/rpc/method_telemetry.go
@@ -16,6 +16,11 @@ type MethodTimer interface {
 	Stop(err error)
 }
 
+var (
+	_ MethodTelemetry = (*noopMethodTelemetry)(nil)
+	_ MethodTimer     = (*noopMethodTimer)(nil)
+)
+
 type noopMethodTelemetry struct{}
 
 func (noopMethodTelemetry) StartMethodTimer(_ context.Context, _ string, _ map[string]string) MethodTimer {

--- a/internal/simulator/mock_runner.go
+++ b/internal/simulator/mock_runner.go
@@ -7,6 +7,8 @@ import (
 	"context"
 )
 
+var _ RunnerInterface = (*MockRunner)(nil)
+
 type MockRunner struct {
 	RunFunc   func(ctx context.Context, req *SimulationRequest) (*SimulationResponse, error)
 	CloseFunc func() error

--- a/internal/terminal/ansi.go
+++ b/internal/terminal/ansi.go
@@ -23,6 +23,8 @@ const (
 	sgrBold    = "\033[1m"
 )
 
+var _ Renderer = (*ANSIRenderer)(nil)
+
 type ANSIRenderer struct {
 }
 

--- a/internal/terminal/mock.go
+++ b/internal/terminal/mock.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 )
 
+var _ Renderer = (*MockRenderer)(nil)
+
 type MockRenderer struct {
 	Output []string
 	TTY    bool


### PR DESCRIPTION
Adds var _ Interface = (*Struct)(nil) assertions across the Go codebase to enforce interface compliance at compile time, covering MethodTelemetry, MethodTimer, Renderer, ContractAuthHandler, RunnerInterface, and DecoderPlugin.

Closes #564