### PR TITLE
Add dark mode support to the exported SVG Flamegraph

### DIFF
--- a/internal/cmd/debug.go
+++ b/internal/cmd/debug.go
@@ -446,6 +446,7 @@ Local WASM Replay Mode:
 					LedgerEntries:   ledgerEntries,
 					Timestamp:       ts,
 					ProtocolVersion: nil,
+					Profile:         ProfileFlag,
 				}
 
 				// Apply protocol version override if specified
@@ -494,6 +495,7 @@ Local WASM Replay Mode:
 						ResultMetaXdr: resp.ResultMetaXdr,
 						LedgerEntries: entries,
 						Timestamp:     ts,
+						Profile:       ProfileFlag,
 					}
 					applySimulationFeeMocks(primaryReq)
 					primaryResult, primaryErr = runner.Run(primaryReq)
@@ -534,6 +536,7 @@ Local WASM Replay Mode:
 						ResultMetaXdr: compareResp.ResultMetaXdr,
 						LedgerEntries: entries,
 						Timestamp:     ts,
+						Profile:       ProfileFlag,
 					}
 					applySimulationFeeMocks(compareReq)
 					compareResult, compareErr = runner.Run(compareReq)
@@ -564,6 +567,17 @@ Local WASM Replay Mode:
 
 		if lastSimResp == nil {
 			return errors.WrapSimulationLogicError("no simulation results generated")
+		}
+
+		// Save flamegraph SVG with dark-mode CSS when profiling is enabled
+		if ProfileFlag && lastSimResp.Flamegraph != "" {
+			svgContent := visualizer.InjectDarkMode(lastSimResp.Flamegraph)
+			svgFilename := txHash + ".flamegraph.svg"
+			if err := os.WriteFile(svgFilename, []byte(svgContent), 0644); err != nil {
+				fmt.Printf("%s Failed to write flamegraph: %v\n", visualizer.Warning(), err)
+			} else {
+				fmt.Printf("%s Flamegraph saved: %s\n", visualizer.Success(), svgFilename)
+			}
 		}
 
 		// Analysis: Error Suggestions (Heuristic-based)

--- a/internal/visualizer/flamegraph.go
+++ b/internal/visualizer/flamegraph.go
@@ -1,0 +1,69 @@
+// Copyright 2025 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package visualizer
+
+import "strings"
+
+// darkModeCSS contains CSS media queries that adapt flamegraph colors
+// when the developer's system is set to dark mode.
+const darkModeCSS = `
+/* Dark mode support for flamegraph SVGs */
+@media (prefers-color-scheme: dark) {
+  /* Invert the background from white to a dark surface */
+  svg { background-color: #1e1e2e; }
+
+  /* Main text (function names, labels) */
+  text { fill: #cdd6f4 !important; }
+
+  /* Title and subtitle */
+  text.title { fill: #cdd6f4 !important; }
+
+  /* Details / info bar at the bottom */
+  rect.background { fill: #1e1e2e !important; }
+
+  /* Slightly desaturate the flame rectangles for better contrast on dark bg */
+  rect[fill] {
+    opacity: 0.92;
+  }
+
+  /* Search match highlight */
+  rect[fill="rgb(230,0,230)"] {
+    fill: rgb(200,80,200) !important;
+  }
+}
+`
+
+// InjectDarkMode takes a raw SVG string produced by the inferno crate and
+// returns a new SVG string with an embedded <style> block containing CSS
+// media queries for dark mode. The injection point is right after the
+// opening <svg ...> tag so the styles apply to the entire document.
+//
+// If the SVG already contains a prefers-color-scheme rule (idempotency guard)
+// or does not look like a valid SVG, the original string is returned unchanged.
+func InjectDarkMode(svg string) string {
+	if svg == "" {
+		return svg
+	}
+
+	// Idempotency: don't inject twice.
+	if strings.Contains(svg, "prefers-color-scheme") {
+		return svg
+	}
+
+	// Find the end of the opening <svg ...> tag.
+	idx := strings.Index(svg, ">")
+	if idx < 0 {
+		return svg
+	}
+
+	// Verify that the tag we found is actually an <svg> tag (very basic check).
+	prefix := strings.ToLower(svg[:idx])
+	if !strings.Contains(prefix, "<svg") {
+		return svg
+	}
+
+	// Insert the <style> block right after the opening <svg> tag.
+	styleBlock := "\n<style type=\"text/css\">" + darkModeCSS + "</style>\n"
+	return svg[:idx+1] + styleBlock + svg[idx+1:]
+}

--- a/internal/visualizer/flamegraph_test.go
+++ b/internal/visualizer/flamegraph_test.go
@@ -1,0 +1,67 @@
+// Copyright 2025 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package visualizer
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInjectDarkMode_BasicInjection(t *testing.T) {
+	svg := `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="600"><rect x="0" y="0" width="100" height="20"/></svg>`
+	result := InjectDarkMode(svg)
+
+	if !strings.Contains(result, "prefers-color-scheme: dark") {
+		t.Error("InjectDarkMode() did not inject dark mode CSS")
+	}
+	if !strings.Contains(result, "<style type=\"text/css\">") {
+		t.Error("InjectDarkMode() did not inject <style> tag")
+	}
+	// Ensure the SVG still starts and ends correctly
+	if !strings.HasPrefix(result, "<svg") {
+		t.Error("InjectDarkMode() corrupted SVG start tag")
+	}
+	if !strings.HasSuffix(result, "</svg>") {
+		t.Error("InjectDarkMode() corrupted SVG end tag")
+	}
+}
+
+func TestInjectDarkMode_Idempotency(t *testing.T) {
+	svg := `<svg><style>@media (prefers-color-scheme: dark) {}</style><rect/></svg>`
+	result := InjectDarkMode(svg)
+
+	if result != svg {
+		t.Error("InjectDarkMode() should not double-inject when prefers-color-scheme already present")
+	}
+}
+
+func TestInjectDarkMode_EmptyString(t *testing.T) {
+	result := InjectDarkMode("")
+	if result != "" {
+		t.Error("InjectDarkMode() should return empty string for empty input")
+	}
+}
+
+func TestInjectDarkMode_InvalidSVG(t *testing.T) {
+	input := "this is not an svg"
+	result := InjectDarkMode(input)
+	if result != input {
+		t.Error("InjectDarkMode() should return input unchanged for non-SVG content")
+	}
+}
+
+func TestInjectDarkMode_PreservesContent(t *testing.T) {
+	svg := `<svg xmlns="http://www.w3.org/2000/svg"><text>hello</text></svg>`
+	result := InjectDarkMode(svg)
+
+	if !strings.Contains(result, "<text>hello</text>") {
+		t.Error("InjectDarkMode() lost original SVG content")
+	}
+	if !strings.Contains(result, "background-color: #1e1e2e") {
+		t.Error("InjectDarkMode() missing dark background rule")
+	}
+	if !strings.Contains(result, "fill: #cdd6f4") {
+		t.Error("InjectDarkMode() missing dark text color rule")
+	}
+}


### PR DESCRIPTION
================================================================================
TITLE: Add dark mode support to the exported SVG Flamegraph
================================================================================

feat(flamegraph): Add dark mode support to the exported SVG Flamegraph - Issue #547

================================================================================
DESCRIPTION:
================================================================================

## Overview

Add dark mode support to exported SVG flamegraphs by injecting CSS `@media (prefers-color-scheme: dark)` media queries that automatically adapt to the developer's system theme preferences. Also fixes a gap where the `--profile` CLI flag was defined but never wired into the simulation pipeline.

## Changes

### Core Implementation

- **[internal/visualizer/flamegraph.go](cci:7://file:///c:/Users/HP/Desktop/Code/hintents/internal/visualizer/flamegraph.go:0:0-0:0)**: New [InjectDarkMode()](cci:1://file:///c:/Users/HP/Desktop/Code/hintents/internal/visualizer/flamegraph.go:36:0-68:1) function
  - Injects a `<style>` block with `@media (prefers-color-scheme: dark)` CSS into SVG output
  - Dark surface background (`#1e1e2e`), light text (`#cdd6f4`), desaturated flame rects
  - Idempotency guard to prevent double-injection
  - Safe handling of empty/invalid SVG input

- **[internal/cmd/debug.go](cci:7://file:///c:/Users/HP/Desktop/Code/hintents/internal/cmd/debug.go:0:0-0:0)**: Wired `ProfileFlag` into simulation pipeline
  - Set `Profile: ProfileFlag` on all 3 [SimulationRequest](cci:2://file:///c:/Users/HP/Desktop/Code/hintents/internal/simulator/schema.go:16:0-44:1) construction sites (single-network, primary comparison, compare comparison)
  - Added flamegraph saving logic: calls [InjectDarkMode()](cci:1://file:///c:/Users/HP/Desktop/Code/hintents/internal/visualizer/flamegraph.go:36:0-68:1) on the SVG and writes `<txhash>.flamegraph.svg` to the current directory
  - User-facing success/failure messages using existing `visualizer.Success()` / `visualizer.Warning()` helpers

### Testing

- **Unit Tests** ([internal/visualizer/flamegraph_test.go](cci:7://file:///c:/Users/HP/Desktop/Code/hintents/internal/visualizer/flamegraph_test.go:0:0-0:0)):
  - [TestInjectDarkMode_BasicInjection](cci:1://file:///c:/Users/HP/Desktop/Code/hintents/internal/visualizer/flamegraph_test.go:10:0-27:1): Verifies CSS injection and SVG structure preservation
  - [TestInjectDarkMode_Idempotency](cci:1://file:///c:/Users/HP/Desktop/Code/hintents/internal/visualizer/flamegraph_test.go:29:0-36:1): Ensures no double-injection
  - [TestInjectDarkMode_EmptyString](cci:1://file:///c:/Users/HP/Desktop/Code/hintents/internal/visualizer/flamegraph_test.go:38:0-43:1): Edge case handling
  - [TestInjectDarkMode_InvalidSVG](cci:1://file:///c:/Users/HP/Desktop/Code/hintents/internal/visualizer/flamegraph_test.go:45:0-51:1): Non-SVG input handling
  - [TestInjectDarkMode_PreservesContent](cci:1://file:///c:/Users/HP/Desktop/Code/hintents/internal/visualizer/flamegraph_test.go:53:0-66:1): Original SVG content preserved after injection
- **All 5 tests pass**, `go build ./internal/cmd/` compiles cleanly

## Design Decisions

- **CSS injection on Go side** (not Rust simulator): Avoids recompiling the Rust binary for styling changes; the `inferno` crate generates the base SVG and Go post-processes it
- **`@media (prefers-color-scheme: dark)`**: Automatically respects the developer's OS/browser theme — no manual toggle or CLI flag needed
- **Idempotency**: [InjectDarkMode](cci:1://file:///c:/Users/HP/Desktop/Code/hintents/internal/visualizer/flamegraph.go:36:0-68:1) checks for existing `prefers-color-scheme` before injecting, making it safe to call multiple times

## Verification

- All 5 unit tests pass
- `go build ./internal/cmd/` compiles with exit code 0
- No new linting issues introduced
- Backward compatible — no changes to existing behavior when `--profile` is not used

## Related Issues

Closes #547

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added/updated
- [x] Documentation updated
- [x] No new linting issues
- [x] Changes verified locally

================================================================================
