### PR TITLE
refactor: Refactor SDK errors to utilize standard library

### DIFF
--- a/internal/cmd/shell.go
+++ b/internal/cmd/shell.go
@@ -124,7 +124,7 @@ func runShell(cmd *cobra.Command, args []string) error {
 
 		// Parse and execute command
 		if err := executeShellCommand(ctx, session, line); err != nil {
-			if err.Error() == "exit" {
+			if errors.Is(err, errors.ErrShellExit) {
 				break
 			}
 			fmt.Printf("Error: %v\n", err)
@@ -164,7 +164,7 @@ func executeShellCommand(ctx context.Context, session *shell.Session, line strin
 		return nil
 
 	case "exit", "quit":
-		return fmt.Errorf("exit")
+		return errors.ErrShellExit
 
 	case "invoke":
 		return handleInvoke(ctx, session, args)

--- a/internal/rpc/failover_test.go
+++ b/internal/rpc/failover_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/dotandev/hintents/internal/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,5 +47,5 @@ func TestClient_GetTransaction_Failover_Logic(t *testing.T) {
 	fallbackErr, ok := err.(*AllNodesFailedError)
 	assert.True(t, ok, "Error should be of type *AllNodesFailedError")
 	assert.Equal(t, 2, len(fallbackErr.Failures), "Should have recorded 2 failures")
-	assert.Contains(t, err.Error(), "all RPC endpoints failed")
+	assert.True(t, errors.Is(err, errors.ErrAllRPCFailed))
 }

--- a/internal/rpc/ledger_test.go
+++ b/internal/rpc/ledger_test.go
@@ -491,7 +491,7 @@ func TestGetLedgerHeader_GenericError(t *testing.T) {
 	assert.False(t, IsLedgerNotFound(err))
 	assert.False(t, IsLedgerArchived(err))
 	assert.False(t, IsRateLimitError(err))
-	assert.Contains(t, err.Error(), "RPC connection failed")
+	assert.True(t, errors.Is(err, errors.ErrRPCConnectionFailed))
 }
 
 // TestFromHorizonLedger tests the conversion from Horizon ledger to our structure

--- a/internal/simulator/interface_test.go
+++ b/internal/simulator/interface_test.go
@@ -6,6 +6,7 @@ package simulator
 import (
 	"testing"
 
+	"github.com/dotandev/hintents/internal/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,7 +26,7 @@ func TestNewRunnerInterface(t *testing.T) {
 	// but the interface structure is correct
 	if err != nil {
 		// Expected in test environment without erst-sim binary
-		assert.Contains(t, err.Error(), "erst-sim binary not found")
+		assert.True(t, errors.Is(err, errors.ErrSimulatorNotFound))
 	} else {
 		// If binary exists, verify interface is returned
 		assert.NotNil(t, runner)


### PR DESCRIPTION
================================================================================
TITLE: Refactor SDK errors to utilize standard library errors.Is
================================================================================

refactor(errors): Refactor SDK errors to utilize standard library errors.Is - Issue #590 

================================================================================
DESCRIPTION:
================================================================================

## Overview

Refactors SDK error handling so that `errors.Is(err, erst.ErrRateLimited)` works reliably instead of requiring fragile string comparisons. Fixes a critical bug where `ErstError.Unwrap()` created a fresh `errors.New()` on every call, breaking the entire `errors.Is` chain.

## Changes

### Core Implementation

- **`ErstError.Is()` method**: New method mapping [ErstErrorCode](cci:2://file:///c:/Users/HP/Desktop/Code/hintents/internal/errors/errors.go:289:5-289:25) → sentinel error via `codeToSentinel`
  - Covers all 19 error codes (RPC, Simulator, Validation)
  - Enables `errors.Is(erstErr, erst.ErrSimCrash)` to work correctly
  - Negative matching verified (wrong sentinel returns `false`)

- **`ErstError.Unwrap()` fix**: Changed from `return errors.New(e.OriginalError)` to `return nil`
  - Previous implementation created a throwaway `errors.New()` on every call
  - This broke `errors.Is` chains because the fresh error never matched any sentinel
  - [Is()](cci:1://file:///c:/Users/HP/Desktop/Code/hintents/internal/errors/errors.go:106:0-108:1) now handles sentinel matching directly

- **`codeToSentinel` mapping**: New package-level `map[ErstErrorCode]error` with 19 entries
  - Maps every [ErstErrorCode](cci:2://file:///c:/Users/HP/Desktop/Code/hintents/internal/errors/errors.go:289:5-289:25) constant to its corresponding sentinel error
  - Used by `ErstError.Is()` for reliable error classification

- **`ErrShellExit` sentinel**: New sentinel error replacing `fmt.Errorf("exit")` string

### String Comparison Removal

- **[shell.go](cci:7://file:///c:/Users/HP/Desktop/Code/hintents/internal/cmd/shell.go:0:0-0:0)**: `err.Error() == "exit"` → `errors.Is(err, errors.ErrShellExit)`
- **[failover_test.go](cci:7://file:///c:/Users/HP/Desktop/Code/hintents/internal/rpc/failover_test.go:0:0-0:0)**: `assert.Contains(err.Error(), "all RPC endpoints failed")` → `errors.Is(err, errors.ErrAllRPCFailed)`
- **[ledger_test.go](cci:7://file:///c:/Users/HP/Desktop/Code/hintents/internal/rpc/ledger_test.go:0:0-0:0)**: `assert.Contains(err.Error(), "RPC connection failed")` → `errors.Is(err, errors.ErrRPCConnectionFailed)`
- **[interface_test.go](cci:7://file:///c:/Users/HP/Desktop/Code/hintents/internal/simulator/interface_test.go:0:0-0:0)**: `assert.Contains(err.Error(), "erst-sim binary not found")` → `errors.Is(err, errors.ErrSimulatorNotFound)`

### Testing

- **[TestErstError_Is_MatchesSentinel](cci:1://file:///c:/Users/HP/Desktop/Code/hintents/internal/errors/errors_test.go:100:0-134:1)**: Table-driven test covering all 19 error code → sentinel mappings
- **[TestErstError_Is_DoesNotMatchWrongSentinel](cci:1://file:///c:/Users/HP/Desktop/Code/hintents/internal/errors/errors_test.go:136:0-142:1)**: Negative matching verification
- **[TestErstError_Is_UnknownCodeMatchesNothing](cci:1://file:///c:/Users/HP/Desktop/Code/hintents/internal/errors/errors_test.go:144:0-150:1)**: `CodeUnknown` doesn't match any sentinel
- **[TestErstError_Unwrap_ReturnsNil](cci:1://file:///c:/Users/HP/Desktop/Code/hintents/internal/errors/errors_test.go:152:0-155:1)**: Verifies [Unwrap()](cci:1://file:///c:/Users/HP/Desktop/Code/hintents/internal/errors/errors.go:368:0-373:1) returns `nil`
- **[TestShellExitSentinel](cci:1://file:///c:/Users/HP/Desktop/Code/hintents/internal/errors/errors_test.go:157:0-160:1)**: Verifies new `ErrShellExit` sentinel works with `errors.Is`
- **Coverage**: All 27 tests pass, all code paths tested

## Verification

- All 27 tests pass (including 19 sub-tests for every error code mapping)
- `go build` succeeds across `./internal/errors/`, `./internal/cmd/`, `./internal/rpc/`, `./internal/simulator/`
- Backward compatible — no public API changes, existing sentinel errors unchanged
- No new linting issues

## Related Issues

Closes #590 

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [x] Breaking change
- [ ] Documentation update

> **Note**: This is technically a breaking change for any code that relied on `ErstError.Unwrap()` returning a non-nil error. However, the previous behavior was broken (returned a fresh `errors.New()` that never matched anything), so no correct code should be affected.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added/updated
- [x] Documentation updated
- [x] No new linting issues
- [x] Changes verified locally



