### PR TITLE
fix: pre-allocate slice capacities in XDR array serialization

### DIFF
--- a/internal/decoder/decoder.go
+++ b/internal/decoder/decoder.go
@@ -110,7 +110,8 @@ func parseEvent(diag xdr.DiagnosticEvent) DecodedEvent {
 		contractID = hex.EncodeToString(diag.Event.ContractId[:])
 	}
 
-	topics := make([]string, 0)
+	// Pre-allocate topics slice capacity to reduce re-allocations
+	topics := make([]string, 0, len(diag.Event.Body.V0.Topics))
 	for _, topic := range diag.Event.Body.V0.Topics {
 		// Attempt to convert to string if symbol, otherwise hex/debug
 		if topic.Type == xdr.ScValTypeScvSymbol {

--- a/internal/decoder/suggestions.go
+++ b/internal/decoder/suggestions.go
@@ -250,11 +250,14 @@ func (e *SuggestionEngine) AnalyzeCallTree(root *CallNode) []Suggestion {
 
 // collectEvents recursively collects all events from a call tree
 func (e *SuggestionEngine) collectEvents(node *CallNode) []DecodedEvent {
-	events := make([]DecodedEvent, 0)
-
 	if node == nil {
-		return events
+		return nil
 	}
+
+	// Pre-allocate with estimated capacity to reduce re-allocations
+	// Estimate: node.Events + 5 events per child call
+	capacity := len(node.Events) + len(node.SubCalls)*5
+	events := make([]DecodedEvent, 0, capacity)
 
 	events = append(events, node.Events...)
 


### PR DESCRIPTION
## Overview

Pre-allocate Vec and slice capacities across the Soroban helper module when mapping nested event parameters to reduce re-allocations.

## Changes

### `internal/decoder/decoder.go`
- Pre-allocate `topics` slice capacity in `parseEvent()` function to reduce memory re-allocations

### `internal/decoder/suggestions.go`  
- Pre-allocate events slice with estimated capacity in `collectEvents()` to reduce re-allocations during nested event parameter mapping

## Verification

- Go build succeeds
- Changes follow existing code patterns

## Related Issues

Closes #546
