### PR TITLE
test: add cross-platform protocol registration verification

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,21 +26,25 @@ jobs:
             runner: ubuntu-24.04
             binary_suffix: ""
             go_arch: amd64
+            protocol_verify_script: scripts/verify_protocol_registration_linux.sh
 
           - os: macOS-Intel
             runner: macos-latest     # Intel runner (fallback to latest if 13 fails)
             binary_suffix: ""
             go_arch: amd64
+            protocol_verify_script: scripts/verify_protocol_registration_macos.sh
 
           - os: macOS-Apple-Silicon
             runner: macos-latest     # M-series ARM runner
             binary_suffix: ""
             go_arch: arm64
+            protocol_verify_script: scripts/verify_protocol_registration_macos.sh
 
           - os: Windows
             runner: windows-2022
             binary_suffix: ".exe"
             go_arch: amd64
+            protocol_verify_script: scripts/verify_protocol_registration_windows.ps1
 
     env:
       # Allow the test suite to find the compiled binary without hard-coding a path.
@@ -95,6 +99,8 @@ jobs:
           go test -v -race -timeout 120s ./integration/...
         env:
           ERST_BINARY: ${{ env.ERST_BINARY }}
+          ERST_RUN_PROTOCOL_REGISTRATION_TESTS: "1"
+          ERST_PROTOCOL_VERIFY_SCRIPT: ${{ github.workspace }}/${{ matrix.protocol_verify_script }}
 
       # ── Upload test results on failure ────────────────────────────────────
       - name: Upload test logs on failure

--- a/docs/DASHBOARD_INTEGRATION.md
+++ b/docs/DASHBOARD_INTEGRATION.md
@@ -21,6 +21,12 @@ This command registers `erst://` with your operating system (Windows, macOS, or 
 You can check if the protocol is correctly registered by running:
 
 ```bash
+erst protocol:verify
+```
+
+For a concise pass/fail status check, you can also run:
+
+```bash
 erst protocol:status
 ```
 

--- a/integration/protocol_registration_test.go
+++ b/integration/protocol_registration_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestProtocolRegistrationLifecycle(t *testing.T) {
+	if os.Getenv("ERST_RUN_PROTOCOL_REGISTRATION_TESTS") != "1" {
+		t.Skip("set ERST_RUN_PROTOCOL_REGISTRATION_TESTS=1 to enable protocol registration integration tests")
+	}
+
+	if runtime.GOOS == "linux" {
+		if _, err := exec.LookPath("xdg-mime"); err != nil {
+			t.Skip("xdg-mime is required for protocol registration tests")
+		}
+	}
+
+	_, _, _ = runErst(t, "protocol:unregister")
+	t.Cleanup(func() {
+		_, _, _ = runErst(t, "protocol:unregister")
+	})
+
+	stdout, stderr, err := runErst(t, "protocol:register")
+	assertExitCode(t, 0, err)
+	assertContains(t, "register output", stdout+stderr, "Registered ERST protocol handler")
+
+	stdout, stderr, err = runErst(t, "protocol:verify")
+	assertExitCode(t, 0, err)
+	assertContains(t, "verify output", stdout+stderr, "Verified ERST protocol registration")
+
+	scriptPath := os.Getenv("ERST_PROTOCOL_VERIFY_SCRIPT")
+	if scriptPath == "" {
+		t.Fatal("ERST_PROTOCOL_VERIFY_SCRIPT must be set when protocol registration tests are enabled")
+	}
+	runNativeVerificationScript(t, scriptPath)
+
+	stdout, stderr, err = runErst(t, "protocol:status")
+	assertExitCode(t, 0, err)
+	assertContains(t, "status output", stdout+stderr, "REGISTERED")
+
+	stdout, stderr, err = runErst(t, "protocol:unregister")
+	assertExitCode(t, 0, err)
+	assertContains(t, "unregister output", stdout+stderr, "Unregistered ERST protocol handler")
+
+	stdout, stderr, err = runErst(t, "protocol:verify")
+	if exitCode(err) == 0 {
+		t.Fatalf("expected protocol:verify to fail after unregister, got stdout=%q stderr=%q", stdout, stderr)
+	}
+	assertContains(t, "verify failure output", stdout+stderr, "[FAIL]")
+}
+
+func runNativeVerificationScript(t *testing.T, scriptPath string) {
+	t.Helper()
+
+	absoluteScriptPath := scriptPath
+	if !filepath.IsAbs(absoluteScriptPath) {
+		absoluteScriptPath = filepath.Join(repoRoot(t), scriptPath)
+	}
+
+	ctx, cancel := timeoutCtx(t, 30*time.Second)
+	defer cancel()
+
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "windows":
+		cmd = exec.CommandContext(ctx, "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", absoluteScriptPath)
+	default:
+		cmd = exec.CommandContext(ctx, "bash", absoluteScriptPath)
+	}
+
+	cmd.Env = append(os.Environ(), "ERST_BINARY="+binaryPath(t))
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("native verification script failed: %v\n%s", err, strings.TrimSpace(output.String()))
+	}
+}

--- a/internal/cmd/protocol.go
+++ b/internal/cmd/protocol.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/dotandev/hintents/internal/protocolreg"
+	"github.com/spf13/cobra"
+)
+
+var protocolRegisterCmd = &cobra.Command{
+	Use:     "protocol:register",
+	Short:   "Register the erst:// protocol handler in the operating system",
+	GroupID: "utility",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		registrar, err := protocolreg.NewRegistrar()
+		if err != nil {
+			return err
+		}
+		if err := registrar.Register(); err != nil {
+			return err
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Registered ERST protocol handler for %s://\n", protocolreg.Scheme)
+		return nil
+	},
+}
+
+var protocolUnregisterCmd = &cobra.Command{
+	Use:     "protocol:unregister",
+	Short:   "Unregister the erst:// protocol handler from the operating system",
+	GroupID: "utility",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		registrar, err := protocolreg.NewRegistrar()
+		if err != nil {
+			return err
+		}
+		if err := registrar.Unregister(); err != nil {
+			return err
+		}
+
+		fmt.Fprintln(cmd.OutOrStdout(), "Unregistered ERST protocol handler")
+		return nil
+	},
+}
+
+var protocolStatusCmd = &cobra.Command{
+	Use:     "protocol:status",
+	Short:   "Check current registration status of the erst:// protocol handler",
+	GroupID: "utility",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		registrar, err := protocolreg.NewRegistrar()
+		if err != nil {
+			return err
+		}
+
+		if registrar.IsRegistered() {
+			fmt.Fprintln(cmd.OutOrStdout(), "ERST protocol handler is currently REGISTERED")
+			return nil
+		}
+
+		return fmt.Errorf("ERST protocol handler is NOT REGISTERED")
+	},
+}
+
+var protocolVerifyCmd = &cobra.Command{
+	Use:     "protocol:verify",
+	Short:   "Verify the native OS registration for the erst:// protocol handler",
+	GroupID: "utility",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		registrar, err := protocolreg.NewRegistrar()
+		if err != nil {
+			return err
+		}
+
+		report, err := registrar.Verify()
+		for _, check := range report.Checks {
+			fmt.Fprintf(cmd.OutOrStdout(), "[OK] %s\n", check)
+		}
+		for _, issue := range report.Issues {
+			fmt.Fprintf(cmd.ErrOrStderr(), "[FAIL] %s\n", issue)
+		}
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Verified ERST protocol registration on %s\n", report.Platform)
+		return nil
+	},
+}
+
+var protocolHandlerCmd = &cobra.Command{
+	Use:    "protocol-handler <uri>",
+	Short:  "Internal protocol entrypoint used by the OS",
+	Hidden: true,
+	Args:   cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		parsed, err := protocolreg.ParseDebugURI(args[0])
+		if err != nil {
+			return err
+		}
+
+		executablePath, err := os.Executable()
+		if err != nil {
+			return fmt.Errorf("resolve executable path: %w", err)
+		}
+
+		debugArgs := []string{"debug", parsed.TransactionHash, "--network", parsed.Network}
+		child := exec.CommandContext(cmd.Context(), executablePath, debugArgs...)
+		child.Stdout = cmd.OutOrStdout()
+		child.Stderr = cmd.ErrOrStderr()
+		return child.Run()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(protocolRegisterCmd)
+	rootCmd.AddCommand(protocolUnregisterCmd)
+	rootCmd.AddCommand(protocolStatusCmd)
+	rootCmd.AddCommand(protocolVerifyCmd)
+	rootCmd.AddCommand(protocolHandlerCmd)
+}

--- a/internal/protocolreg/registration.go
+++ b/internal/protocolreg/registration.go
@@ -1,0 +1,449 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package protocolreg
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	Scheme             = "erst"
+	windowsRegistryKey = `HKEY_CURRENT_USER\Software\Classes\erst`
+	linuxDesktopFile   = "erst-protocol.desktop"
+	linuxMimeType      = "x-scheme-handler/erst"
+	macOSAppName       = "Erst Protocol.app"
+	macOSBundleID      = "dev.dotan.erst.protocol"
+	macOSExecutable    = "erst-protocol-handler"
+)
+
+type Registrar struct {
+	executablePath string
+	homeDir        string
+}
+
+type VerificationReport struct {
+	Platform string
+	Scheme   string
+	Checks   []string
+	Issues   []string
+}
+
+func NewRegistrar() (*Registrar, error) {
+	executablePath, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("resolve executable path: %w", err)
+	}
+
+	executablePath, err = filepath.Abs(executablePath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve absolute executable path: %w", err)
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve user home directory: %w", err)
+	}
+
+	return &Registrar{
+		executablePath: executablePath,
+		homeDir:        homeDir,
+	}, nil
+}
+
+func (r *Registrar) Register() error {
+	switch runtime.GOOS {
+	case "windows":
+		return r.registerWindows()
+	case "darwin":
+		return r.registerDarwin()
+	case "linux":
+		return r.registerLinux()
+	default:
+		return fmt.Errorf("protocol registration is not supported on %s", runtime.GOOS)
+	}
+}
+
+func (r *Registrar) Unregister() error {
+	switch runtime.GOOS {
+	case "windows":
+		return r.unregisterWindows()
+	case "darwin":
+		return r.unregisterDarwin()
+	case "linux":
+		return r.unregisterLinux()
+	default:
+		return fmt.Errorf("protocol registration is not supported on %s", runtime.GOOS)
+	}
+}
+
+func (r *Registrar) IsRegistered() bool {
+	_, err := r.Verify()
+	return err == nil
+}
+
+func (r *Registrar) Verify() (*VerificationReport, error) {
+	report := &VerificationReport{
+		Platform: runtime.GOOS,
+		Scheme:   Scheme,
+	}
+
+	switch runtime.GOOS {
+	case "windows":
+		r.verifyWindows(report)
+	case "darwin":
+		r.verifyDarwin(report)
+	case "linux":
+		r.verifyLinux(report)
+	default:
+		report.Issues = append(report.Issues, fmt.Sprintf("protocol verification is not supported on %s", runtime.GOOS))
+	}
+
+	if len(report.Issues) > 0 {
+		return report, verificationError(report.Issues)
+	}
+
+	return report, nil
+}
+
+func (r *Registrar) registerWindows() error {
+	commands := [][]string{
+		{"add", windowsRegistryKey, "/ve", "/d", "URL:ERST Protocol", "/f"},
+		{"add", windowsRegistryKey, "/v", "URL Protocol", "/d", "", "/f"},
+		{"add", windowsRegistryKey + `\shell\open\command`, "/ve", "/d", r.windowsOpenCommand(), "/f"},
+	}
+
+	for _, args := range commands {
+		if _, err := runCommand("reg", args...); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *Registrar) unregisterWindows() error {
+	_, err := runCommand("reg", "delete", windowsRegistryKey, "/f")
+	if err != nil && strings.Contains(strings.ToLower(err.Error()), "unable to find") {
+		return nil
+	}
+	return err
+}
+
+func (r *Registrar) verifyWindows(report *VerificationReport) {
+	registryOutput, err := runCommand("reg", "query", windowsRegistryKey)
+	if err != nil {
+		report.Issues = append(report.Issues, fmt.Sprintf("missing registry key %s: %v", windowsRegistryKey, err))
+		return
+	}
+	report.Checks = append(report.Checks, fmt.Sprintf("Found registry key %s", windowsRegistryKey))
+
+	if !strings.Contains(registryOutput, "URL Protocol") {
+		report.Issues = append(report.Issues, "missing URL Protocol registry value")
+	} else {
+		report.Checks = append(report.Checks, "Found URL Protocol registry value")
+	}
+
+	commandOutput, err := runCommand("reg", "query", windowsRegistryKey+`\shell\open\command`, "/ve")
+	if err != nil {
+		report.Issues = append(report.Issues, fmt.Sprintf("missing shell open command: %v", err))
+		return
+	}
+
+	if !strings.Contains(commandOutput, r.windowsOpenCommand()) {
+		report.Issues = append(report.Issues, fmt.Sprintf("unexpected shell open command, want %q", r.windowsOpenCommand()))
+	} else {
+		report.Checks = append(report.Checks, fmt.Sprintf("Shell open command points to %s", r.executablePath))
+	}
+}
+
+func (r *Registrar) registerLinux() error {
+	applicationsDir := filepath.Dir(r.linuxDesktopPath())
+	if err := os.MkdirAll(applicationsDir, 0o755); err != nil {
+		return fmt.Errorf("create applications directory: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(r.linuxWrapperPath()), 0o755); err != nil {
+		return fmt.Errorf("create protocol helper directory: %w", err)
+	}
+
+	if err := os.WriteFile(r.linuxWrapperPath(), []byte(r.unixHandlerScript()), 0o755); err != nil {
+		return fmt.Errorf("write protocol helper script: %w", err)
+	}
+
+	if err := os.WriteFile(r.linuxDesktopPath(), []byte(r.linuxDesktopEntry()), 0o644); err != nil {
+		return fmt.Errorf("write desktop file: %w", err)
+	}
+
+	if _, err := runCommand("xdg-mime", "default", linuxDesktopFile, linuxMimeType); err != nil {
+		return err
+	}
+
+	if hasCommand("update-desktop-database") {
+		if _, err := runCommand("update-desktop-database", filepath.Dir(r.linuxDesktopPath())); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *Registrar) unregisterLinux() error {
+	var joined error
+
+	if err := os.Remove(r.linuxDesktopPath()); err != nil && !errors.Is(err, os.ErrNotExist) {
+		joined = errors.Join(joined, fmt.Errorf("remove desktop file: %w", err))
+	}
+	if err := os.Remove(r.linuxWrapperPath()); err != nil && !errors.Is(err, os.ErrNotExist) {
+		joined = errors.Join(joined, fmt.Errorf("remove protocol helper: %w", err))
+	}
+
+	return joined
+}
+
+func (r *Registrar) verifyLinux(report *VerificationReport) {
+	desktopBytes, err := os.ReadFile(r.linuxDesktopPath())
+	if err != nil {
+		report.Issues = append(report.Issues, fmt.Sprintf("missing desktop file %s: %v", r.linuxDesktopPath(), err))
+		return
+	}
+
+	desktopContent := string(desktopBytes)
+	report.Checks = append(report.Checks, fmt.Sprintf("Found desktop file %s", r.linuxDesktopPath()))
+
+	if !strings.Contains(desktopContent, "MimeType="+linuxMimeType+";") {
+		report.Issues = append(report.Issues, "desktop file is missing the erst MIME handler declaration")
+	} else {
+		report.Checks = append(report.Checks, "Desktop file declares x-scheme-handler/erst")
+	}
+
+	if !strings.Contains(desktopContent, "Exec="+r.linuxWrapperPath()+" %u") {
+		report.Issues = append(report.Issues, fmt.Sprintf("desktop file Exec entry does not point to %s", r.linuxWrapperPath()))
+	} else {
+		report.Checks = append(report.Checks, fmt.Sprintf("Desktop file Exec entry points to %s", r.linuxWrapperPath()))
+	}
+
+	wrapperBytes, err := os.ReadFile(r.linuxWrapperPath())
+	if err != nil {
+		report.Issues = append(report.Issues, fmt.Sprintf("missing protocol helper script %s: %v", r.linuxWrapperPath(), err))
+	} else {
+		wrapperContent := string(wrapperBytes)
+		if !strings.Contains(wrapperContent, r.executablePath) {
+			report.Issues = append(report.Issues, fmt.Sprintf("protocol helper script does not reference %s", r.executablePath))
+		} else {
+			report.Checks = append(report.Checks, fmt.Sprintf("Protocol helper script launches %s", r.executablePath))
+		}
+	}
+
+	defaultDesktop, err := runCommand("xdg-mime", "query", "default", linuxMimeType)
+	if err != nil {
+		report.Issues = append(report.Issues, fmt.Sprintf("failed to query MIME handler: %v", err))
+		return
+	}
+
+	if strings.TrimSpace(defaultDesktop) != linuxDesktopFile {
+		report.Issues = append(report.Issues, fmt.Sprintf("xdg-mime reports %q instead of %q", strings.TrimSpace(defaultDesktop), linuxDesktopFile))
+	} else {
+		report.Checks = append(report.Checks, fmt.Sprintf("xdg-mime resolves %s to %s", linuxMimeType, linuxDesktopFile))
+	}
+}
+
+func (r *Registrar) registerDarwin() error {
+	if err := os.MkdirAll(filepath.Dir(r.macOSExecutablePath()), 0o755); err != nil {
+		return fmt.Errorf("create macOS app bundle: %w", err)
+	}
+
+	if err := os.WriteFile(r.macOSExecutablePath(), []byte(r.unixHandlerScript()), 0o755); err != nil {
+		return fmt.Errorf("write app bundle executable: %w", err)
+	}
+
+	if err := os.WriteFile(r.macOSPlistPath(), []byte(r.macOSInfoPlist()), 0o644); err != nil {
+		return fmt.Errorf("write app bundle plist: %w", err)
+	}
+
+	if _, err := runCommand(macOSLSRegisterPath(), "-f", r.macOSAppPath()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *Registrar) unregisterDarwin() error {
+	var joined error
+
+	if _, err := os.Stat(r.macOSAppPath()); errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+
+	if _, err := runCommand(macOSLSRegisterPath(), "-u", r.macOSAppPath()); err != nil {
+		joined = errors.Join(joined, err)
+	}
+
+	if err := os.RemoveAll(r.macOSAppPath()); err != nil && !errors.Is(err, os.ErrNotExist) {
+		joined = errors.Join(joined, fmt.Errorf("remove macOS app bundle: %w", err))
+	}
+
+	return joined
+}
+
+func (r *Registrar) verifyDarwin(report *VerificationReport) {
+	plistBytes, err := os.ReadFile(r.macOSPlistPath())
+	if err != nil {
+		report.Issues = append(report.Issues, fmt.Sprintf("missing app bundle plist %s: %v", r.macOSPlistPath(), err))
+		return
+	}
+	plistContent := string(plistBytes)
+	report.Checks = append(report.Checks, fmt.Sprintf("Found app bundle plist %s", r.macOSPlistPath()))
+
+	if _, err := os.Stat(r.macOSExecutablePath()); err != nil {
+		report.Issues = append(report.Issues, fmt.Sprintf("missing app bundle executable %s: %v", r.macOSExecutablePath(), err))
+	} else {
+		report.Checks = append(report.Checks, fmt.Sprintf("Found app bundle executable %s", r.macOSExecutablePath()))
+	}
+
+	if !strings.Contains(plistContent, "<key>CFBundleURLSchemes</key>") || !strings.Contains(plistContent, "<string>"+Scheme+"</string>") {
+		report.Issues = append(report.Issues, "Info.plist does not declare the erst URL scheme")
+	} else {
+		report.Checks = append(report.Checks, "Info.plist declares the erst URL scheme")
+	}
+
+	registrationDump, err := runCommand(macOSLSRegisterPath(), "-dump")
+	if err != nil {
+		report.Issues = append(report.Issues, fmt.Sprintf("failed to inspect LaunchServices registration: %v", err))
+		return
+	}
+
+	if !strings.Contains(registrationDump, r.macOSAppPath()) {
+		report.Issues = append(report.Issues, fmt.Sprintf("LaunchServices dump does not contain %s", r.macOSAppPath()))
+	} else {
+		report.Checks = append(report.Checks, fmt.Sprintf("LaunchServices contains %s", r.macOSAppPath()))
+	}
+	if !strings.Contains(registrationDump, Scheme) {
+		report.Issues = append(report.Issues, "LaunchServices dump does not mention the erst scheme")
+	} else {
+		report.Checks = append(report.Checks, "LaunchServices dump mentions the erst scheme")
+	}
+
+	executableBytes, err := os.ReadFile(r.macOSExecutablePath())
+	if err == nil {
+		executableContent := string(executableBytes)
+		if !strings.Contains(executableContent, r.executablePath) {
+			report.Issues = append(report.Issues, fmt.Sprintf("app bundle executable does not launch %s", r.executablePath))
+		} else {
+			report.Checks = append(report.Checks, fmt.Sprintf("App bundle executable launches %s", r.executablePath))
+		}
+	}
+}
+
+func (r *Registrar) windowsOpenCommand() string {
+	return fmt.Sprintf(`"%s" protocol-handler "%%1"`, r.executablePath)
+}
+
+func (r *Registrar) linuxDesktopPath() string {
+	return filepath.Join(r.homeDir, ".local", "share", "applications", linuxDesktopFile)
+}
+
+func (r *Registrar) linuxWrapperPath() string {
+	return filepath.Join(r.homeDir, ".local", "share", "erst", macOSExecutable)
+}
+
+func (r *Registrar) linuxDesktopEntry() string {
+	return strings.Join([]string{
+		"[Desktop Entry]",
+		"Version=1.0",
+		"Type=Application",
+		"Name=ERST Protocol Handler",
+		"Exec=" + r.linuxWrapperPath() + " %u",
+		"MimeType=" + linuxMimeType + ";",
+		"NoDisplay=true",
+		"Terminal=false",
+		"",
+	}, "\n")
+}
+
+func (r *Registrar) macOSAppPath() string {
+	return filepath.Join(r.homeDir, "Applications", macOSAppName)
+}
+
+func (r *Registrar) macOSExecutablePath() string {
+	return filepath.Join(r.macOSAppPath(), "Contents", "MacOS", macOSExecutable)
+}
+
+func (r *Registrar) macOSPlistPath() string {
+	return filepath.Join(r.macOSAppPath(), "Contents", "Info.plist")
+}
+
+func (r *Registrar) macOSInfoPlist() string {
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>%s</string>
+    <key>CFBundleIdentifier</key>
+    <string>%s</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>ERST Protocol Handler</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>ERST Protocol</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>%s</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>
+`, macOSExecutable, macOSBundleID, Scheme)
+}
+
+func (r *Registrar) unixHandlerScript() string {
+	return fmt.Sprintf("#!/bin/sh\nexec %s protocol-handler \"$1\"\n", shellQuote(r.executablePath))
+}
+
+func macOSLSRegisterPath() string {
+	return "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+}
+
+func runCommand(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		trimmed := strings.TrimSpace(string(output))
+		if trimmed == "" {
+			return "", fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
+		}
+		return string(output), fmt.Errorf("%s %s: %w: %s", name, strings.Join(args, " "), err, trimmed)
+	}
+	return string(output), nil
+}
+
+func hasCommand(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+}
+
+func verificationError(issues []string) error {
+	return fmt.Errorf("protocol registration verification failed: %s", strings.Join(issues, "; "))
+}

--- a/internal/protocolreg/uri.go
+++ b/internal/protocolreg/uri.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package protocolreg
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var txHashPattern = regexp.MustCompile(`^[a-fA-F0-9]{64}$`)
+
+type ParsedDebugURI struct {
+	Raw             string
+	TransactionHash string
+	Network         string
+	Operation       *int
+	Source          string
+	Signature       string
+}
+
+func ParseDebugURI(raw string) (*ParsedDebugURI, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, fmt.Errorf("protocol URI must not be empty")
+	}
+	if !strings.HasPrefix(raw, Scheme+"://") {
+		return nil, fmt.Errorf("invalid protocol URI: expected %s://", Scheme)
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse protocol URI: %w", err)
+	}
+
+	if parsed.Host != "debug" {
+		return nil, fmt.Errorf("invalid protocol host %q: expected debug", parsed.Host)
+	}
+
+	transactionHash := strings.TrimPrefix(parsed.EscapedPath(), "/")
+	transactionHash, err = url.PathUnescape(transactionHash)
+	if err != nil {
+		return nil, fmt.Errorf("decode transaction hash: %w", err)
+	}
+	if !txHashPattern.MatchString(transactionHash) {
+		return nil, fmt.Errorf("invalid transaction hash format")
+	}
+
+	network := parsed.Query().Get("network")
+	if network == "" {
+		return nil, fmt.Errorf("missing required query parameter: network")
+	}
+	if network != "testnet" && network != "mainnet" && network != "futurenet" {
+		return nil, fmt.Errorf("invalid network %q", network)
+	}
+
+	result := &ParsedDebugURI{
+		Raw:             raw,
+		TransactionHash: transactionHash,
+		Network:         network,
+		Source:          parsed.Query().Get("source"),
+		Signature:       parsed.Query().Get("signature"),
+	}
+
+	if operation := parsed.Query().Get("operation"); operation != "" {
+		parsedOperation, err := strconv.Atoi(operation)
+		if err != nil || parsedOperation < 0 {
+			return nil, fmt.Errorf("invalid operation index %q", operation)
+		}
+		result.Operation = &parsedOperation
+	}
+
+	return result, nil
+}

--- a/internal/protocolreg/uri_test.go
+++ b/internal/protocolreg/uri_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package protocolreg
+
+import "testing"
+
+func TestParseDebugURI(t *testing.T) {
+	parsed, err := ParseDebugURI("erst://debug/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef?network=testnet&operation=2&source=dashboard")
+	if err != nil {
+		t.Fatalf("ParseDebugURI returned error: %v", err)
+	}
+
+	if parsed.TransactionHash != "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" {
+		t.Fatalf("unexpected transaction hash: %s", parsed.TransactionHash)
+	}
+	if parsed.Network != "testnet" {
+		t.Fatalf("unexpected network: %s", parsed.Network)
+	}
+	if parsed.Operation == nil || *parsed.Operation != 2 {
+		t.Fatalf("unexpected operation: %#v", parsed.Operation)
+	}
+	if parsed.Source != "dashboard" {
+		t.Fatalf("unexpected source: %s", parsed.Source)
+	}
+}
+
+func TestParseDebugURIRejectsInvalidValues(t *testing.T) {
+	tests := []string{
+		"",
+		"https://example.com",
+		"erst://decode/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef?network=testnet",
+		"erst://debug/not-a-hash?network=testnet",
+		"erst://debug/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		"erst://debug/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef?network=invalid",
+		"erst://debug/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef?network=testnet&operation=-1",
+	}
+
+	for _, tc := range tests {
+		if _, err := ParseDebugURI(tc); err == nil {
+			t.Fatalf("expected ParseDebugURI to fail for %q", tc)
+		}
+	}
+}

--- a/scripts/verify_protocol_registration_linux.sh
+++ b/scripts/verify_protocol_registration_linux.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+desktop_file="${HOME}/.local/share/applications/erst-protocol.desktop"
+helper_script="${HOME}/.local/share/erst/erst-protocol-handler"
+
+if [[ ! -f "${desktop_file}" ]]; then
+  echo "missing desktop file: ${desktop_file}" >&2
+  exit 1
+fi
+
+if [[ ! -x "${helper_script}" ]]; then
+  echo "missing helper script: ${helper_script}" >&2
+  exit 1
+fi
+
+grep -F "MimeType=x-scheme-handler/erst;" "${desktop_file}" >/dev/null
+grep -F "Exec=${helper_script} %u" "${desktop_file}" >/dev/null
+
+if [[ -n "${ERST_BINARY:-}" ]]; then
+  grep -F "${ERST_BINARY}" "${helper_script}" >/dev/null
+fi
+
+default_handler="$(xdg-mime query default x-scheme-handler/erst)"
+if [[ "${default_handler}" != "erst-protocol.desktop" ]]; then
+  echo "xdg-mime returned ${default_handler}, expected erst-protocol.desktop" >&2
+  exit 1
+fi
+
+echo "linux protocol registration verified"

--- a/scripts/verify_protocol_registration_macos.sh
+++ b/scripts/verify_protocol_registration_macos.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+app_path="${HOME}/Applications/Erst Protocol.app"
+plist_path="${app_path}/Contents/Info.plist"
+helper_script="${app_path}/Contents/MacOS/erst-protocol-handler"
+lsregister="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+
+if [[ ! -f "${plist_path}" ]]; then
+  echo "missing plist: ${plist_path}" >&2
+  exit 1
+fi
+
+if [[ ! -x "${helper_script}" ]]; then
+  echo "missing helper script: ${helper_script}" >&2
+  exit 1
+fi
+
+grep -F '<key>CFBundleURLSchemes</key>' "${plist_path}" >/dev/null
+grep -F '<string>erst</string>' "${plist_path}" >/dev/null
+
+if [[ -n "${ERST_BINARY:-}" ]]; then
+  grep -F "${ERST_BINARY}" "${helper_script}" >/dev/null
+fi
+
+if [[ -x "${lsregister}" ]]; then
+  "${lsregister}" -dump | grep -F "${app_path}" >/dev/null
+  "${lsregister}" -dump | grep -F 'erst' >/dev/null
+fi
+
+echo "macOS protocol registration verified"

--- a/scripts/verify_protocol_registration_windows.ps1
+++ b/scripts/verify_protocol_registration_windows.ps1
@@ -1,0 +1,34 @@
+$ErrorActionPreference = 'Stop'
+
+$registryPath = 'Registry::HKEY_CURRENT_USER\Software\Classes\erst'
+$commandPath = 'Registry::HKEY_CURRENT_USER\Software\Classes\erst\shell\open\command'
+
+if (-not (Test-Path $registryPath)) {
+    throw "Missing protocol registry key: $registryPath"
+}
+
+if (-not (Test-Path $commandPath)) {
+    throw "Missing protocol open command key: $commandPath"
+}
+
+$rootKey = Get-Item $registryPath
+$urlProtocol = $rootKey.GetValue('URL Protocol', $null)
+if ($null -eq $urlProtocol) {
+    throw 'Missing URL Protocol registry value'
+}
+
+$commandKey = Get-Item $commandPath
+$command = $commandKey.GetValue('')
+if ([string]::IsNullOrWhiteSpace($command)) {
+    throw 'Missing default protocol open command'
+}
+
+if ($env:ERST_BINARY -and $command -notlike "*$($env:ERST_BINARY)*") {
+    throw "Protocol command does not reference expected binary: $($env:ERST_BINARY)"
+}
+
+if ($command -notlike '*protocol-handler*') {
+    throw 'Protocol command does not invoke protocol-handler'
+}
+
+Write-Host 'Windows protocol registration verified'


### PR DESCRIPTION
## Summary #839  by adding native, cross-platform protocol registration verification and integrating it into CI.

## What changed

- Added a new CLI command:
  - `protocol:verify`
  - Performs native OS-level validation of protocol registration and prints `[OK]` / `[FAIL]` checks.
- Added cross-platform registrar + verifier implementation for:
  - Windows (Registry)
  - macOS (LaunchServices + app bundle plist)
  - Linux (`.desktop` + `xdg-mime`)
- Added integration lifecycle test for protocol registration:
  - register -> verify -> native script check -> status -> unregister -> verify fails
- Added platform-native verification scripts:
  - Windows PowerShell check for registry keys and open command
  - macOS shell check for plist/app bundle/LaunchServices
  - Linux shell check for desktop file/helper/xdg default handler
- Updated integration workflow matrix to run protocol registration verification on all supported platforms.
- Updated docs to include `protocol:verify`.

## Why

Automated OS-level verification for protocol registration was missing across supported platforms, which left regressions undetected in CI.

## Validation performed

- Built CLI successfully.
- Ran integration tests with protocol registration verification enabled.
- Confirmed lifecycle integration test passes locally on Windows.
- Ran full test suite locally (`go test -v ./...`) successfully.

## CI impact

- Integration matrix now includes platform-specific native verification scripts.
- Protocol registration verification is executed in CI for Linux, macOS, and Windows.

## Checklist

- [x] Native verification scripts added for all supported platforms
- [x] `protocol:verify` implemented with OS-native checks
- [x] Integration tests cover protocol registration lifecycle
- [x] GitHub Actions matrix updated for platform-specific checks
- [x] Local tests pass

Closes #839 