### PR TITLE
chore: fix CI license check step name to include TypeScript

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Check license headers in Go and Rust files
+      - name: Check license headers (Go, Rust, TypeScript)
         run: ./scripts/check-license-headers.sh
 
       - name: Guard against conflict markers and leaked secrets


### PR DESCRIPTION
## Summary
Fix the license check CI step name to accurately reflect all languages being checked.

Closes #833

## Changes

- Updated CI step name from `Check license headers in Go and Rust files` to `Check license headers (Go, Rust, TypeScript)`
- The underlying `scripts/check-license-headers.sh` already scans .go, .rs, and .ts files  the step name was inaccurate

## Verification

- All .go, .ts, and .rs files confirmed to have correct Apache-2.0 headers
- No duplicate or malformed headers found
- `fix_all_licenses.sh --check` passes
- `scripts/check-license-headers.sh` passes
- No functional CI changes  existing workflows remain intact