### PR TITLE
chore(simulator): add missing colored crate dependency

### DIFF
--- a/simulator/Cargo.lock
+++ b/simulator/Cargo.lock
@@ -424,6 +424,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2327,6 +2337,7 @@ dependencies = [
  "base64 0.21.7",
  "bincode",
  "clap",
+ "colored",
  "dirs",
  "ed25519-dalek",
  "gimli",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -40,6 +40,7 @@ bincode = "1.3.3"
 async-trait = "0.1.89"
 thiserror = "2.0.18"
 libloading = "0.8"
+colored = "2.1"
 ed25519-dalek = { version = "2.2.0", features = ["pem", "pkcs8"] }
 k256 = { version = "0.13.4", features = ["ecdsa"] }
 rand = "0.8"


### PR DESCRIPTION
## Summary
Add the missing `colored` crate to `simulator/Cargo.toml`. The `theme/ansi` module imports `colored::Colorize` for terminal color output but the dependency was not declared, causing compilation failure when the module is compiled.

## Changes
- Add `colored = 2.1` to `simulator/Cargo.toml`
- Update `Cargo.lock` accordingly

## Validation
- `cargo fetch` resolves all dependencies
- `cargo check` passes
- `cargo build` succeeds
- `cargo clippy --all-targets --all-features -- -D warnings` passes
- `cargo test --verbose` passes (137 passed, 0 failed)
- `cargo fmt --check` passes

Closes #828