### PR TITLE
feat(protocol): add concurrency lock for protocol handler

### DIFF
--- a/src/commands/protocol-handler.ts
+++ b/src/commands/protocol-handler.ts
@@ -5,9 +5,46 @@ import { Command } from 'commander';
 import { ProtocolHandler } from '../protocol/handler';
 import { ProtocolRegistrar } from '../protocol/register';
 import * as dotenv from 'dotenv';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
 
 // Load environment variables for security configuration
 dotenv.config();
+
+const LOCK_FILE = path.join(os.tmpdir(), 'erst-protocol-handler.lock');
+const LOCK_STALE_MS = 30_000;
+
+function acquireLock(force: boolean): boolean {
+    if (force) {
+        writeLock();
+        return true;
+    }
+
+    try {
+        const stat = fs.statSync(LOCK_FILE);
+        if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
+            writeLock();
+            return true;
+        }
+        return false;
+    } catch {
+        writeLock();
+        return true;
+    }
+}
+
+function writeLock(): void {
+    fs.writeFileSync(LOCK_FILE, String(process.pid), { flag: 'w' });
+}
+
+function releaseLock(): void {
+    try {
+        fs.unlinkSync(LOCK_FILE);
+    } catch {
+        // Lock already removed — no action needed.
+    }
+}
 
 /**
  * registerProtocolCommands adds protocol-related commands to the ERST CLI.
@@ -16,11 +53,21 @@ dotenv.config();
  */
 export function registerProtocolCommands(program: Command): void {
     // 1. Internal Protocol Handler (hidden from standard help via description)
-    // TODO: Implement a lock mechanism if multiple instances are launched simultaneously
     program
         .command('protocol-handler <uri>')
         .description('Internal: Handle ERST protocol URI (invoked by OS)')
-        .action(async (uri: string) => {
+        .option('--force', 'Bypass the concurrency lock')
+        .action(async (uri: string, opts: { force?: boolean }) => {
+            if (!acquireLock(opts.force === true)) {
+                console.error('[WARN] Another protocol handler instance is running. Use --force to override.');
+                process.exit(1);
+            }
+
+            const cleanup = (): void => { releaseLock(); };
+            process.on('exit', cleanup);
+            process.on('SIGINT', () => { cleanup(); process.exit(130); });
+            process.on('SIGTERM', () => { cleanup(); process.exit(143); });
+
             try {
                 const handler = new ProtocolHandler({
                     secret: process.env.ERST_PROTOCOL_SECRET,
@@ -35,6 +82,8 @@ export function registerProtocolCommands(program: Command): void {
                     console.error('[FAIL] Protocol handler error: An unknown error occurred');
                 }
                 process.exit(1);
+            } finally {
+                releaseLock();
             }
         });
 


### PR DESCRIPTION
## Summary
Prevent multiple concurrent executions of the protocol handler by introducing a file-based locking mechanism.

## Changes
- Add file-based lock in OS temp directory
- Lock automatically acquired before handler execution
- Lock released after execution via finally block and signal handlers
- Stale locks older than 30s automatically reclaimed
- Add --force flag to bypass the lock
- Signal handlers ensure cleanup on interruption

## Validation
- TypeScript compiles with zero errors
- npm run build succeeds
- Tests pass (pre-existing failures unrelated)

Closes #829