### PR TITLE
Add confidence indicators to suggestions

### DIFF
--- a/internal/decoder/integration_test.go
+++ b/internal/decoder/integration_test.go
@@ -58,6 +58,9 @@ func TestIntegration_SuggestionEngineWithDecoder(t *testing.T) {
 		if !strings.Contains(output, "Potential Fixes") {
 			t.Error("Expected formatted output to contain 'Potential Fixes'")
 		}
+		if !strings.Contains(output, "🟢") && !strings.Contains(output, "🟡") && !strings.Contains(output, "🔴") {
+			t.Error("Expected formatted output to contain a confidence indicator")
+		}
 	})
 
 	// Scenario 2: Multiple errors in nested calls
@@ -269,6 +272,9 @@ func TestIntegration_RealWorldScenario(t *testing.T) {
 	}
 	if !strings.Contains(output, "Confidence") {
 		t.Error("Output should show confidence levels")
+	}
+	if !strings.Contains(output, "🟡") {
+		t.Error("Output should include the medium-confidence indicator for this match set")
 	}
 	if !strings.Contains(output, "initialize()") {
 		t.Error("Should suggest calling initialize()")

--- a/internal/decoder/suggestions.go
+++ b/internal/decoder/suggestions.go
@@ -8,11 +8,28 @@ import (
 	"strings"
 )
 
+const (
+	confidenceHigh   = "high"
+	confidenceMedium = "medium"
+	confidenceLow    = "low"
+)
+
 // Suggestion represents a potential fix for a Soroban error
 type Suggestion struct {
 	Rule        string
 	Description string
-	Confidence  string // "high", "medium", "low"
+	Confidence  string // Derived from match specificity: "high", "medium", "low"
+}
+
+type ruleMatch struct {
+	keywordMatches  int
+	exactKeywordHit bool
+	eventCheckMatch bool
+}
+
+type scoredSuggestion struct {
+	suggestion Suggestion
+	score      int
 }
 
 // ErrorPattern defines a heuristic rule for error detection
@@ -57,7 +74,7 @@ func (e *SuggestionEngine) loadDefaultRules() {
 		Suggestion: Suggestion{
 			Rule:        "uninitialized_contract",
 			Description: "Potential Fix: Ensure you have called initialize() on this contract before invoking other functions.",
-			Confidence:  "high",
+			Confidence:  confidenceHigh,
 		},
 	})
 
@@ -79,7 +96,7 @@ func (e *SuggestionEngine) loadDefaultRules() {
 		Suggestion: Suggestion{
 			Rule:        "missing_authorization",
 			Description: "Potential Fix: Verify that all required signatures are present and the invoker has proper authorization.",
-			Confidence:  "high",
+			Confidence:  confidenceHigh,
 		},
 	})
 
@@ -101,7 +118,7 @@ func (e *SuggestionEngine) loadDefaultRules() {
 		Suggestion: Suggestion{
 			Rule:        "insufficient_balance",
 			Description: "Potential Fix: Ensure the account has sufficient balance to cover the transaction and maintain minimum reserves.",
-			Confidence:  "high",
+			Confidence:  confidenceHigh,
 		},
 	})
 
@@ -123,7 +140,7 @@ func (e *SuggestionEngine) loadDefaultRules() {
 		Suggestion: Suggestion{
 			Rule:        "invalid_parameters",
 			Description: "Potential Fix: Check that all function parameters match the expected types and constraints.",
-			Confidence:  "medium",
+			Confidence:  confidenceMedium,
 		},
 	})
 
@@ -139,7 +156,7 @@ func (e *SuggestionEngine) loadDefaultRules() {
 		Suggestion: Suggestion{
 			Rule:        "contract_not_found",
 			Description: "Potential Fix: Verify the contract ID is correct and the contract has been deployed to the network.",
-			Confidence:  "high",
+			Confidence:  confidenceHigh,
 		},
 	})
 
@@ -161,7 +178,7 @@ func (e *SuggestionEngine) loadDefaultRules() {
 		Suggestion: Suggestion{
 			Rule:        "resource_limit_exceeded",
 			Description: "Potential Fix: Optimize your contract code to reduce CPU/memory usage, or increase resource limits in the transaction.",
-			Confidence:  "medium",
+			Confidence:  confidenceMedium,
 		},
 	})
 
@@ -183,59 +200,112 @@ func (e *SuggestionEngine) loadDefaultRules() {
 		Suggestion: Suggestion{
 			Rule:        "reentrancy_detected",
 			Description: "Potential Fix: Implement reentrancy guards or use the checks-effects-interactions pattern to prevent recursive calls.",
-			Confidence:  "medium",
+			Confidence:  confidenceMedium,
 		},
 	})
 }
 
 // AnalyzeEvents analyzes decoded events and returns suggestions
 func (e *SuggestionEngine) AnalyzeEvents(events []DecodedEvent) []Suggestion {
-	suggestions := []Suggestion{}
-	seenRules := make(map[string]bool)
+	ruleOrder := make([]string, 0, len(e.rules))
+	bestMatches := make(map[string]scoredSuggestion, len(e.rules))
 
 	for _, event := range events {
 		for _, rule := range e.rules {
-			// Skip if we already found this rule
-			if seenRules[rule.Name] {
+			match, matched := e.matchRule(rule, event)
+			if !matched {
 				continue
 			}
 
-			// Check keywords in topics and data
-			keywordMatch := false
-			for _, keyword := range rule.Keywords {
-				for _, topic := range event.Topics {
-					if strings.Contains(strings.ToLower(topic), strings.ToLower(keyword)) {
-						keywordMatch = true
-						break
-					}
-				}
-				if keywordMatch {
-					break
-				}
-				if strings.Contains(strings.ToLower(event.Data), strings.ToLower(keyword)) {
-					keywordMatch = true
-					break
-				}
+			suggestion := rule.Suggestion
+			suggestion.Confidence = confidenceFromMatch(match)
+			score := match.specificityScore()
+
+			existing, exists := bestMatches[rule.Name]
+			if !exists {
+				ruleOrder = append(ruleOrder, rule.Name)
+				bestMatches[rule.Name] = scoredSuggestion{suggestion: suggestion, score: score}
+				continue
 			}
 
-			// Check event-specific conditions
-			eventCheckMatch := false
-			for _, check := range rule.EventChecks {
-				if check(event) {
-					eventCheckMatch = true
-					break
-				}
-			}
-
-			// If either keywords or event checks match, add suggestion
-			if keywordMatch || eventCheckMatch {
-				suggestions = append(suggestions, rule.Suggestion)
-				seenRules[rule.Name] = true
+			if score > existing.score {
+				bestMatches[rule.Name] = scoredSuggestion{suggestion: suggestion, score: score}
 			}
 		}
 	}
 
+	suggestions := make([]Suggestion, 0, len(ruleOrder))
+	for _, ruleName := range ruleOrder {
+		suggestions = append(suggestions, bestMatches[ruleName].suggestion)
+	}
+
 	return suggestions
+}
+
+func (e *SuggestionEngine) matchRule(rule ErrorPattern, event DecodedEvent) (ruleMatch, bool) {
+	match := ruleMatch{}
+	topics := make([]string, 0, len(event.Topics))
+	for _, topic := range event.Topics {
+		topics = append(topics, strings.ToLower(topic))
+	}
+	data := strings.ToLower(event.Data)
+
+	for _, keyword := range rule.Keywords {
+		lowerKeyword := strings.ToLower(keyword)
+		for _, topic := range topics {
+			if topic == lowerKeyword {
+				match.exactKeywordHit = true
+				match.keywordMatches++
+				break
+			}
+			if strings.Contains(topic, lowerKeyword) {
+				match.keywordMatches++
+				break
+			}
+		}
+
+		if strings.Contains(data, lowerKeyword) {
+			match.keywordMatches++
+		}
+	}
+
+	for _, check := range rule.EventChecks {
+		if check(event) {
+			match.eventCheckMatch = true
+			break
+		}
+	}
+
+	return match, match.keywordMatches > 0 || match.eventCheckMatch
+}
+
+func (m ruleMatch) specificityScore() int {
+	score := 0
+	if m.eventCheckMatch {
+		score += 2
+	}
+	if m.keywordMatches > 0 {
+		score++
+	}
+	if m.keywordMatches > 1 {
+		score++
+	}
+	if m.exactKeywordHit {
+		score++
+	}
+	return score
+}
+
+func confidenceFromMatch(match ruleMatch) string {
+	score := match.specificityScore()
+	switch {
+	case score >= 4:
+		return confidenceHigh
+	case score >= 2:
+		return confidenceMedium
+	default:
+		return confidenceLow
+	}
 }
 
 // AnalyzeCallTree analyzes a call tree and returns suggestions
@@ -279,17 +349,17 @@ func FormatSuggestions(suggestions []Suggestion) string {
 	output.WriteString("⚠️  These are suggestions based on common error patterns. Always verify before applying.\n\n")
 
 	for i, suggestion := range suggestions {
-		confidenceIcon := "●"
+		confidenceIcon := "⚪"
 		switch suggestion.Confidence {
-		case "high":
-			confidenceIcon = "🔴"
-		case "medium":
-			confidenceIcon = "🟡"
-		case "low":
+		case confidenceHigh:
 			confidenceIcon = "🟢"
+		case confidenceMedium:
+			confidenceIcon = "🟡"
+		case confidenceLow:
+			confidenceIcon = "🔴"
 		}
 
-		output.WriteString(fmt.Sprintf("%d. %s [Confidence: %s]\n", i+1, confidenceIcon, suggestion.Confidence))
+		output.WriteString(fmt.Sprintf("%d. %s [Confidence: %s]\n", i+1, confidenceIcon, strings.Title(suggestion.Confidence)))
 		output.WriteString(fmt.Sprintf("   %s\n", suggestion.Description))
 		if i < len(suggestions)-1 {
 			output.WriteString("\n")

--- a/internal/decoder/suggestions_test.go
+++ b/internal/decoder/suggestions_test.go
@@ -135,8 +135,8 @@ func TestAnalyzeEvents_InvalidParameters(t *testing.T) {
 	for _, s := range suggestions {
 		if s.Rule == "invalid_parameters" {
 			found = true
-			if s.Confidence != "medium" {
-				t.Errorf("Expected medium confidence, got: %s", s.Confidence)
+			if s.Confidence != confidenceHigh {
+				t.Errorf("Expected high confidence for a highly specific match, got: %s", s.Confidence)
 			}
 		}
 	}
@@ -268,7 +268,7 @@ func TestFormatSuggestions(t *testing.T) {
 		{
 			Rule:        "test_rule",
 			Description: "Test suggestion",
-			Confidence:  "high",
+			Confidence:  confidenceHigh,
 		},
 	}
 
@@ -280,8 +280,80 @@ func TestFormatSuggestions(t *testing.T) {
 	if !strings.Contains(output, "Test suggestion") {
 		t.Error("Expected output to contain suggestion description")
 	}
-	if !strings.Contains(output, "high") {
-		t.Error("Expected output to contain confidence level")
+	if !strings.Contains(output, "Confidence: High") {
+		t.Error("Expected output to contain title-cased confidence level")
+	}
+	if !strings.Contains(output, "🟢") {
+		t.Error("Expected output to contain a green confidence indicator for high confidence")
+	}
+}
+
+func TestAnalyzeEvents_ConfidenceBasedOnSpecificity(t *testing.T) {
+	engine := NewSuggestionEngine()
+	engine.AddCustomRule(ErrorPattern{
+		Name:     "specificity_probe",
+		Keywords: []string{"timeout", "deadline"},
+		EventChecks: []func(DecodedEvent) bool{
+			func(event DecodedEvent) bool {
+				for _, topic := range event.Topics {
+					if strings.EqualFold(topic, "timeout_signal") {
+						return true
+					}
+				}
+				return false
+			},
+		},
+		Suggestion: Suggestion{
+			Rule:        "specificity_probe",
+			Description: "Potential Fix: Review timeout configuration.",
+			Confidence:  confidenceLow,
+		},
+	})
+
+	tests := []struct {
+		name       string
+		events     []DecodedEvent
+		confidence string
+	}{
+		{
+			name: "low specificity keyword match",
+			events: []DecodedEvent{{
+				ContractID: "abc123",
+				Topics:     []string{"warning"},
+				Data:       "timeout while waiting",
+			}},
+			confidence: confidenceLow,
+		},
+		{
+			name: "medium specificity multiple keywords",
+			events: []DecodedEvent{{
+				ContractID: "abc123",
+				Topics:     []string{"warning", "deadline-near"},
+				Data:       "timeout while waiting",
+			}},
+			confidence: confidenceMedium,
+		},
+		{
+			name: "high specificity event check and exact keyword",
+			events: []DecodedEvent{{
+				ContractID: "abc123",
+				Topics:     []string{"timeout_signal", "deadline"},
+				Data:       "timeout while waiting",
+			}},
+			confidence: confidenceHigh,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			suggestions := engine.AnalyzeEvents(test.events)
+			if len(suggestions) != 1 {
+				t.Fatalf("expected 1 suggestion, got %d", len(suggestions))
+			}
+			if suggestions[0].Confidence != test.confidence {
+				t.Fatalf("expected %s confidence, got %s", test.confidence, suggestions[0].Confidence)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Implements visual confidence indicators for suggestion engine output so users can prioritize suggested fixes in the CLI based on pattern-match specificity.

Changes
Core Implementation
Specificity-Based Confidence Scoring: Confidence is now derived from match strength rather than treated as a static display value

combines keyword match count
detects exact keyword hits
factors in rule-specific event checks
selects the strongest match per rule before rendering
Suggestion Engine Updates: Extended suggestion evaluation to score each matched rule

preserves existing rule behavior
avoids duplicate suggestions
upgrades or downgrades confidence based on actual evidence in the event stream
CLI Output Formatting: Added colored emoji confidence indicators to suggestion output

High: 🟢
Medium: 🟡
Low: 🔴
confidence label is rendered in a user-facing title-cased format
Testing
Unit Tests: Added confidence-scoring coverage for low, medium, and high specificity matches
Formatting Tests: Verified rendered CLI output includes confidence labels and emoji indicators
Integration Tests: Updated suggestion rendering assertions to validate indicator presence in real suggestion flows
Coverage: Suggestion engine behavior and output formatting paths updated without suppressions
Documentation
No standalone documentation file was added
Output behavior is now reflected by test coverage and implementation changes
Behavior
Users can now quickly distinguish stronger heuristic matches from weaker ones
Suggestions remain heuristic and still include the existing cautionary messaging
Output remains backward compatible in structure while becoming more informative visually
Verification
Decoder suggestion engine tests pass locally
Temporary Go toolchain used for validation was removed after test execution
Code follows existing project style
No unrelated files were changed

Closes #865 