### PR TITLE
chores: implemented standardixed bearer prefix

### DIFF
--- a/docs/json-rpc.md
+++ b/docs/json-rpc.md
@@ -105,11 +105,7 @@ Get execution traces for a transaction.
 When `--auth-token` is provided, all RPC requests must include authentication:
 
 ```bash
-# Bearer token format
 curl -H "Authorization: Bearer secret123" ...
-
-# Direct token format  
-curl -H "Authorization: secret123" ...
 ```
 
 ## Error Responses

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -108,17 +108,12 @@ func (s *Server) authenticate(r *http.Request) bool {
 	}
 
 	auth := r.Header.Get("Authorization")
-	if auth == "" {
+	if !strings.HasPrefix(auth, "Bearer ") {
 		return false
 	}
 
-	// Support "Bearer <token>" format
-	if strings.HasPrefix(auth, "Bearer ") {
-		token := strings.TrimPrefix(auth, "Bearer ")
-		return token == s.authToken
-	}
-
-	return auth == s.authToken
+	token := strings.TrimPrefix(auth, "Bearer ")
+	return token == s.authToken
 }
 
 // DebugTransaction handles debug_transaction RPC calls

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -129,14 +129,14 @@ func TestServer_Authentication(t *testing.T) {
 		t.Error("Expected authentication to succeed with correct Bearer token")
 	}
 
-	// Test with correct direct token
+	// Test with direct token (must be rejected — Bearer prefix required)
 	req.Header.Set("Authorization", "secret123")
-	if !server.authenticate(req) {
-		t.Error("Expected authentication to succeed with correct direct token")
+	if server.authenticate(req) {
+		t.Error("Expected authentication to fail without Bearer prefix")
 	}
 
 	// Test with wrong token
-	req.Header.Set("Authorization", "wrong-token")
+	req.Header.Set("Authorization", "Bearer wrong-token")
 	if server.authenticate(req) {
 		t.Error("Expected authentication to fail with wrong token")
 	}


### PR DESCRIPTION
PULL REQUEST TEMPLATE
Closes #845

================================================================================
TITLE:
================================================================================

refactor(auth): Unify Authorization header handling across CLI and SDK

================================================================================
DESCRIPTION:
================================================================================

## Overview

Standardizes all HTTP Authorization header handling on the `Bearer` prefix (RFC 6750), removing the bare token fallback that allowed `Authorization: <token>` without a scheme. This eliminates inconsistency between the daemon server (which accepted both formats) and all clients (which already sent `Bearer` exclusively).

## Changes

### Core Implementation

- **`authenticate()` in `server.go`**: Removed bare token fallback path
  - Now strictly requires `Authorization: Bearer <token>` format
  - Simplified control flow — single prefix check instead of branching on two formats
  - No change to behavior when auth is disabled (`authToken == ""`)

- **`authTransport` in `client.go`**: Already compliant — no changes needed
  - Sends `Bearer` prefix on all outbound requests

- **WebSocket auth in `txstream.go`**: Already compliant — no changes needed
  - Sends `Bearer` prefix in upgrade request headers

### Testing

- **`server_test.go`**: Updated `TestServer_Authentication`
  - Bare token test case now asserts rejection (was previously asserting success)
  - Wrong-token test case updated to use `Bearer` prefix for consistency
  - All other test cases unchanged

### Documentation

- **`json-rpc.md`**: Removed bare token format from authentication examples
  - Only `Bearer` token format is now documented
  - Integration examples (Python, JavaScript) already used `Bearer` — unchanged

## Security Properties

- **RFC 6750 Compliance**: All auth headers now follow the Bearer token standard
- **No Silent Fallback**: Bare tokens are rejected explicitly, preventing accidental misconfiguration
- **GitHub PAT Compatibility**: GitHub's API accepts `Bearer` prefix for PATs — no breakage for existing `.env` configurations

## Breaking Changes

Clients sending `Authorization: <raw-token>` (without `Bearer` prefix) to the daemon server will now receive an unauthorized error. All internal clients (`authTransport`, WebSocket, test scripts) already use `Bearer`, so no internal breakage is expected.

**Migration**: Prefix any bare token with `Bearer `:
```diff
- curl -H "Authorization: secret123" ...
+ curl -H "Authorization: Bearer secret123" ...
```

## Verification

- All auth tests updated and passing
- Grep confirms no remaining bare token patterns in client code
- `authTransport`, `txstream.go`, `rpc_test.sh`, and `middleware.spec.ts` all already used `Bearer`
- Documentation reflects the single supported format

## Related Issues

Closes: [REFACTOR] Unify Authorization header handling across CLI and SDK

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [x] Breaking change
- [x] Documentation update

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added/updated
- [x] Documentation updated
- [x] No new linting issues
- [x] Changes verified locally

================================================================================
