### PR TITLE
Implement LRU cache eviction for source map cache

### DIFF
--- a/erst.example.toml
+++ b/erst.example.toml
@@ -22,6 +22,11 @@ log_level = "info"
 # Cache directory for storing traces and snapshots
 # cache_path = "~/.erst/cache"
 
+# Maximum source map cache size (e.g., 500MB, 1GB)
+# When exceeded, oldest entries are automatically evicted
+# Examples: "500MB", "1GB", 524288000 (bytes)
+# max_cache_size = "500MB"
+
 # Opt-in anonymous crash reporting.
 # When enabled, fatal panics and unhandled errors send a minimal report
 # (error message, stack trace, OS/arch, version) to the maintainer.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,10 @@ type Config struct {
 	LogLevel          string   `json:"log_level,omitempty"`
 	CachePath         string   `json:"cache_path,omitempty"`
 	RPCToken          string   `json:"rpc_token,omitempty"`
+	// MaxCacheSize is the maximum size of the source map cache in bytes.
+	// Set via max_cache_size in config (e.g., "500MB" or bytes).
+	// Defaults to no limit (cache grows indefinitely).
+	MaxCacheSize int64 `json:"max_cache_size,omitempty"`
 	// CrashReporting enables opt-in anonymous crash reporting.
 	// Set via crash_reporting = true in config or ERST_CRASH_REPORTING=true.
 	CrashReporting bool `json:"crash_reporting,omitempty"`
@@ -92,6 +96,7 @@ var defaultConfig = &Config{
 	LogLevel:       "info",
 	CachePath:      filepath.Join(os.ExpandEnv("$HOME"), ".erst", "cache"),
 	RequestTimeout: defaultRequestTimeout,
+	MaxCacheSize:   0,
 }
 
 // -- Core Functions --
@@ -122,6 +127,7 @@ func DefaultConfig() *Config {
 		LogLevel:       defaultConfig.LogLevel,
 		CachePath:      defaultConfig.CachePath,
 		RequestTimeout: defaultConfig.RequestTimeout,
+		MaxCacheSize:   defaultConfig.MaxCacheSize,
 	}
 }
 
@@ -133,6 +139,7 @@ func NewConfig(rpcUrl string, network Network) *Config {
 		LogLevel:       defaultConfig.LogLevel,
 		CachePath:      defaultConfig.CachePath,
 		RequestTimeout: defaultConfig.RequestTimeout,
+		MaxCacheSize:   defaultConfig.MaxCacheSize,
 	}
 }
 
@@ -282,6 +289,12 @@ func (envParser) Parse(cfg *Config) error {
 	}
 	if v := os.Getenv("ERST_RPC_TOKEN"); v != "" {
 		cfg.RPCToken = v
+	}
+	if v := os.Getenv("ERST_MAX_CACHE_SIZE"); v != "" {
+		n, err := parseSize(v)
+		if err == nil && n > 0 {
+			cfg.MaxCacheSize = n
+		}
 	}
 	if v := os.Getenv("ERST_CRASH_ENDPOINT"); v != "" {
 		cfg.CrashEndpoint = v

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -31,6 +31,13 @@ func loadFromEnv(cfg *Config) error {
 	if v := os.Getenv("ERST_RPC_TOKEN"); v != "" {
 		cfg.RPCToken = v
 	}
+	if v := os.Getenv("ERST_MAX_CACHE_SIZE"); v != "" {
+		n, err := parseSize(v)
+		if err != nil {
+			return errors.WrapValidationError("ERST_MAX_CACHE_SIZE must be a valid size (e.g., 500MB)")
+		}
+		cfg.MaxCacheSize = n
+	}
 	if v := os.Getenv("ERST_CRASH_ENDPOINT"); v != "" {
 		cfg.CrashEndpoint = v
 	}
@@ -168,6 +175,12 @@ func (c *Config) parseTOML(content string) error {
 				return errors.WrapValidationError("request_timeout must be an integer")
 			}
 			c.RequestTimeout = n
+		case "max_cache_size":
+			n, err := parseSize(value)
+			if err != nil {
+				return errors.WrapValidationError("max_cache_size must be a valid size (e.g., 500MB)")
+			}
+			c.MaxCacheSize = n
 		}
 	}
 
@@ -182,4 +195,41 @@ func getEnv(key, defaultValue string) string {
 		return value
 	}
 	return defaultValue
+}
+
+func parseSize(value string) (int64, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, nil
+	}
+
+	var multiplier int64 = 1
+	lowerValue := strings.ToLower(value)
+
+	if strings.HasSuffix(lowerValue, "kb") {
+		multiplier = 1024
+		value = strings.TrimSuffix(value, "kb")
+	} else if strings.HasSuffix(lowerValue, "mb") {
+		multiplier = 1024 * 1024
+		value = strings.TrimSuffix(value, "mb")
+	} else if strings.HasSuffix(lowerValue, "gb") {
+		multiplier = 1024 * 1024 * 1024
+		value = strings.TrimSuffix(value, "gb")
+	} else if strings.HasSuffix(lowerValue, "k") {
+		multiplier = 1000
+		value = strings.TrimSuffix(value, "k")
+	} else if strings.HasSuffix(lowerValue, "m") {
+		multiplier = 1000 * 1000
+		value = strings.TrimSuffix(value, "m")
+	} else if strings.HasSuffix(lowerValue, "g") {
+		multiplier = 1000 * 1000 * 1000
+		value = strings.TrimSuffix(value, "g")
+	}
+
+	n, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return n * multiplier, nil
 }

--- a/simulator/src/source_map_cache.rs
+++ b/simulator/src/source_map_cache.rs
@@ -96,21 +96,46 @@ pub struct SourceMapCacheEntry {
 /// Source map cache manager
 pub struct SourceMapCache {
     cache_dir: PathBuf,
+    max_cache_size: Option<u64>,
 }
 
 impl SourceMapCache {
     /// Creates a new SourceMapCache with the default cache directory
     pub fn new() -> Result<Self, String> {
         let cache_dir = Self::get_default_cache_dir()?;
-        Ok(Self { cache_dir })
+        Ok(Self {
+            cache_dir,
+            max_cache_size: None,
+        })
     }
 
     /// Creates a new SourceMapCache with a custom cache directory
     pub fn with_cache_dir(cache_dir: PathBuf) -> Result<Self, String> {
-        // Ensure the cache directory exists
         fs::create_dir_all(&cache_dir)
             .map_err(|e| format!("Failed to create cache directory: {}", e))?;
-        Ok(Self { cache_dir })
+        Ok(Self {
+            cache_dir,
+            max_cache_size: None,
+        })
+    }
+
+    /// Creates a new SourceMapCache with a custom cache directory and max cache size
+    pub fn with_cache_dir_and_max_size(
+        cache_dir: PathBuf,
+        max_cache_size: u64,
+    ) -> Result<Self, String> {
+        fs::create_dir_all(&cache_dir)
+            .map_err(|e| format!("Failed to create cache directory: {}", e))?;
+        Ok(Self {
+            cache_dir,
+            max_cache_size: Some(max_cache_size),
+        })
+    }
+
+    /// Sets the max cache size for this cache instance
+    pub fn with_max_cache_size(mut self, max_size: u64) -> Self {
+        self.max_cache_size = Some(max_size);
+        self
     }
 
     /// Gets the default cache directory (~/.erst/cache/sourcemaps)
@@ -262,6 +287,56 @@ impl SourceMapCache {
         write_result?;
 
         println!("Cached source map for WASM: {}", &entry.wasm_hash[..8]);
+
+        if let Some(max_size) = self.max_cache_size {
+            self.evict_if_needed(max_size)?;
+        }
+
+        Ok(())
+    }
+
+    /// Evicts oldest cache entries if current size exceeds max_size
+    fn evict_if_needed(&self, max_size: u64) -> Result<(), String> {
+        let current_size = self.get_cache_size()?;
+        if current_size <= max_size {
+            return Ok(());
+        }
+
+        let entries = self.list_cached()?;
+        if entries.is_empty() {
+            return Ok(());
+        }
+
+        let mut sorted_entries = entries;
+        sorted_entries.sort_by_key(|e| e.created_at);
+
+        let mut freed_space = 0u64;
+        let target_free = current_size - max_size + (max_size / 4);
+
+        for entry in sorted_entries {
+            if freed_space >= target_free {
+                break;
+            }
+
+            let cache_path = self.cache_dir.join(format!("{}.bin", entry.wasm_hash));
+            let lock_path = SourceMapCache::get_lock_path(&cache_path);
+
+            if cache_path.exists() {
+                if let Ok(metadata) = fs::metadata(&cache_path) {
+                    freed_space += metadata.len();
+                }
+                if let Err(e) = fs::remove_file(&cache_path) {
+                    eprintln!("Failed to remove cache file {:?}: {}", cache_path, e);
+                } else {
+                    println!("Evicted cache entry: {}", &entry.wasm_hash[..8]);
+                }
+            }
+
+            if lock_path.exists() {
+                let _ = fs::remove_file(&lock_path);
+            }
+        }
+
         Ok(())
     }
 
@@ -548,5 +623,184 @@ mod tests {
         let list = cache.list_cached().unwrap();
         assert_eq!(list.len(), 1);
         assert_eq!(list[0].wasm_hash, wasm_hash);
+    }
+
+    #[test]
+    fn test_eviction_triggers_correctly() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache =
+            SourceMapCache::with_cache_dir_and_max_size(temp_dir.path().to_path_buf(), 5000)
+                .unwrap();
+
+        let wasm_bytes1 = vec![0x00, 0x61, 0x73, 0x6d, 0x01];
+        let wasm_hash1 = SourceMapCache::compute_wasm_hash(&wasm_bytes1);
+
+        let mut mappings1 = HashMap::new();
+        mappings1.insert(
+            0x1234,
+            SourceLocation {
+                file: "test1.rs".to_string(),
+                line: 1,
+                column: Some(1),
+                column_end: None,
+                github_link: None,
+            },
+        );
+
+        let entry1 = SourceMapCacheEntry {
+            wasm_hash: wasm_hash1.clone(),
+            has_symbols: true,
+            mappings: mappings1,
+            created_at: 1000,
+        };
+
+        cache.store(entry1).unwrap();
+
+        let size1 = cache.get_cache_size().unwrap();
+        assert!(size1 > 0, "Cache should have some size");
+
+        let wasm_bytes2 = vec![0x00, 0x61, 0x73, 0x6d, 0x02];
+        let wasm_hash2 = SourceMapCache::compute_wasm_hash(&wasm_bytes2);
+
+        let mut mappings2 = HashMap::new();
+        for i in 0..50u64 {
+            mappings2.insert(
+                i,
+                SourceLocation {
+                    file: "test2.rs".to_string(),
+                    line: i as u32,
+                    column: Some(i as u32),
+                    column_end: None,
+                    github_link: None,
+                },
+            );
+        }
+
+        let entry2 = SourceMapCacheEntry {
+            wasm_hash: wasm_hash2.clone(),
+            has_symbols: true,
+            mappings: mappings2,
+            created_at: 2000,
+        };
+
+        cache.store(entry2).unwrap();
+
+        let list = cache.list_cached().unwrap();
+        assert!(
+            list.len() <= 2,
+            "Should have at most 2 entries after eviction"
+        );
+
+        if list.len() == 1 {
+            assert_eq!(list[0].wasm_hash, wasm_hash2);
+        }
+    }
+
+    #[test]
+    fn test_eviction_removes_oldest_entries() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache = SourceMapCache::with_cache_dir_and_max_size(temp_dir.path().to_path_buf(), 200)
+            .unwrap();
+
+        for i in 0..5u64 {
+            let wasm_bytes = vec![0x00, 0x61, 0x73, 0x6d, i as u8];
+            let wasm_hash = SourceMapCache::compute_wasm_hash(&wasm_bytes);
+
+            let mut mappings = HashMap::new();
+            for j in 0..10u64 {
+                mappings.insert(
+                    j,
+                    SourceLocation {
+                        file: format!("test{}.rs", i),
+                        line: j as u32,
+                        column: Some(j as u32),
+                        column_end: None,
+                        github_link: None,
+                    },
+                );
+            }
+
+            let entry = SourceMapCacheEntry {
+                wasm_hash,
+                has_symbols: true,
+                mappings,
+                created_at: 1000 + i,
+            };
+
+            cache.store(entry).unwrap();
+        }
+
+        let list = cache.list_cached().unwrap();
+        assert!(list.len() < 5, "Should have evicted some entries");
+
+        if !list.is_empty() {
+            let min_created_at = list.iter().map(|e| e.created_at).min().unwrap();
+            assert!(
+                min_created_at > 1000,
+                "Oldest entries should have been evicted"
+            );
+        }
+    }
+
+    #[test]
+    fn test_with_max_cache_size_builder() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache = SourceMapCache::with_cache_dir(temp_dir.path().to_path_buf())
+            .unwrap()
+            .with_max_cache_size(500);
+
+        let wasm_bytes = vec![0x00, 0x61, 0x73, 0x6d];
+        let wasm_hash = SourceMapCache::compute_wasm_hash(&wasm_bytes);
+
+        let entry = SourceMapCacheEntry {
+            wasm_hash,
+            has_symbols: true,
+            mappings: HashMap::new(),
+            created_at: 1234567890,
+        };
+
+        cache.store(entry).unwrap();
+
+        let list = cache.list_cached().unwrap();
+        assert_eq!(list.len(), 1);
+    }
+
+    #[test]
+    fn test_no_eviction_when_max_size_not_set() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache = SourceMapCache::with_cache_dir(temp_dir.path().to_path_buf()).unwrap();
+
+        for i in 0..3u64 {
+            let wasm_bytes = vec![0x00, 0x61, 0x73, 0x6d, i as u8];
+            let wasm_hash = SourceMapCache::compute_wasm_hash(&wasm_bytes);
+
+            let mut mappings = HashMap::new();
+            mappings.insert(
+                0,
+                SourceLocation {
+                    file: "test.rs".to_string(),
+                    line: 1,
+                    column: Some(1),
+                    column_end: None,
+                    github_link: None,
+                },
+            );
+
+            let entry = SourceMapCacheEntry {
+                wasm_hash,
+                has_symbols: true,
+                mappings,
+                created_at: 1000 + i,
+            };
+
+            cache.store(entry).unwrap();
+        }
+
+        let list = cache.list_cached().unwrap();
+        assert_eq!(
+            list.len(),
+            3,
+            "No eviction should occur without max_size set"
+        );
     }
 }


### PR DESCRIPTION
Closes #869 

- Add LRU eviction policy to source_map_cache.rs
- Add max_cache_size config option to erst.toml and Go config
- Support size suffixes (KB, MB, GB) in config
- Add eviction tests to verify oldest entries are removed
- Automatically delete .bin and .lock files when limit exceeded

PULL REQUEST TEMPLATE

================================================================================
TITLE:
================================================================================


## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added/updated
- [x] Documentation updated
- [x] No new linting issues
- [x] Changes verified locally

================================================================================
