### PR TITLE
feat(cli): Add --log-level=debug|trace spanning both Go and Rust

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/dotandev/hintents/internal/config"
+	"github.com/dotandev/hintents/internal/deeplink"
 	"github.com/dotandev/hintents/internal/rpc"
 
 	"github.com/spf13/cobra"
@@ -39,6 +40,7 @@ This command verifies:
   - Simulator binary (erst-sim)
   - Syntax of TOML config files
   - Reachability of the configured RPC endpoint
+  - Deep link registration (erst:// URL scheme)
 
 Use this to troubleshoot installation issues or verify your setup.`,
 	Example: `  # Check environment status
@@ -64,6 +66,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		checkSimulator(verbose),
 		checkConfigTOML(verbose),
 		checkRPC(verbose),
+		checkDeepLink(verbose),
 	}
 
 	// Print results
@@ -327,6 +330,57 @@ func checkRPC(verbose bool) DependencyStatus {
 	}
 	dep.Installed = true
 	return dep
+}
+
+// checkDeepLink verifies that the erst:// URL scheme is registered with the OS
+// and that dispatching a mock link actually reaches the current binary.
+func checkDeepLink(verbose bool) DependencyStatus {
+	dep := DependencyStatus{
+		Name: "Deep link (erst:// scheme)",
+	}
+
+	selfPath, err := os.Executable()
+	if err != nil {
+		dep.FixHint = "Cannot determine binary path: " + err.Error()
+		return dep
+	}
+
+	result := deeplink.Check(selfPath)
+
+	if result.Err != nil {
+		dep.FixHint = result.Err.Error()
+		if len(result.FixSteps) > 0 {
+			dep.FixHint = result.FixSteps[0]
+		}
+		return dep
+	}
+
+	if !result.Registered {
+		dep.FixHint = buildDeepLinkFixHint(result.FixSteps)
+		return dep
+	}
+
+	if !result.Dispatched {
+		dep.FixHint = "Scheme is registered but dispatch failed. Try: erst install-scheme"
+		if len(result.FixSteps) > 0 {
+			dep.FixHint = result.FixSteps[0]
+		}
+		return dep
+	}
+
+	dep.Installed = true
+	if verbose && result.Handler != "" {
+		dep.Path = result.Handler
+	}
+	dep.Version = "dispatch OK"
+	return dep
+}
+
+func buildDeepLinkFixHint(steps []string) string {
+	if len(steps) == 0 {
+		return "Run 'erst install-scheme' to register the erst:// URL scheme"
+	}
+	return steps[0]
 }
 
 func init() {

--- a/internal/cmd/doctor_test.go
+++ b/internal/cmd/doctor_test.go
@@ -189,3 +189,49 @@ func TestDoctorCommand(t *testing.T) {
 		t.Error("doctor command should have --verbose flag")
 	}
 }
+
+// TestCheckDeepLink_Name verifies the check returns the correct display name.
+func TestCheckDeepLink_Name(t *testing.T) {
+	dep := checkDeepLink(false)
+	if dep.Name != "Deep link (erst:// scheme)" {
+		t.Errorf("checkDeepLink() name = %q, want %q", dep.Name, "Deep link (erst:// scheme)")
+	}
+}
+
+// TestCheckDeepLink_FailHasHint verifies that when the scheme is not registered
+// a non-empty FixHint is provided.
+func TestCheckDeepLink_FailHasHint(t *testing.T) {
+	dep := checkDeepLink(false)
+	// On CI the scheme is almost certainly not registered, so we only assert
+	// that a hint is present when the check fails.
+	if !dep.Installed && dep.FixHint == "" {
+		t.Error("checkDeepLink() should provide FixHint when scheme is not registered")
+	}
+}
+
+// TestCheckDeepLink_VerbosePath verifies that verbose mode populates Path when
+// the check succeeds.
+func TestCheckDeepLink_VerbosePath(t *testing.T) {
+	dep := checkDeepLink(true)
+	if dep.Installed && dep.Path == "" {
+		t.Error("checkDeepLink(verbose=true) should set Path when installed")
+	}
+}
+
+// TestBuildDeepLinkFixHint_Empty verifies the fallback message when no steps
+// are provided.
+func TestBuildDeepLinkFixHint_Empty(t *testing.T) {
+	hint := buildDeepLinkFixHint(nil)
+	if hint == "" {
+		t.Error("buildDeepLinkFixHint(nil) must return a non-empty fallback hint")
+	}
+}
+
+// TestBuildDeepLinkFixHint_UsesFirstStep verifies that the first step is used.
+func TestBuildDeepLinkFixHint_UsesFirstStep(t *testing.T) {
+	steps := []string{"step one", "step two"}
+	hint := buildDeepLinkFixHint(steps)
+	if hint != "step one" {
+		t.Errorf("buildDeepLinkFixHint() = %q, want %q", hint, "step one")
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -5,11 +5,14 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"sync/atomic"
 	"syscall"
 
+	"github.com/dotandev/hintents/internal/deeplink"
 	"github.com/dotandev/hintents/internal/localization"
 	"github.com/dotandev/hintents/internal/shutdown"
 	"github.com/dotandev/hintents/internal/updater"
@@ -22,6 +25,7 @@ var (
 	WindowFlag        int64
 	ProfileFlag       bool
 	ProfileFormatFlag string
+	DeepLinkFlag      string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -48,6 +52,12 @@ Examples:
 
 Get started with 'erst debug --help' or visit the documentation.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// Handle deep link probe invocation before anything else.
+		// The doctor command triggers this to verify OS dispatch works.
+		if DeepLinkFlag != "" {
+			return handleDeepLinkProbe(DeepLinkFlag)
+		}
+
 		// Load localizations
 		if err := localization.LoadTranslations(); err != nil {
 			return err
@@ -144,6 +154,27 @@ func checkForUpdatesAsync() {
 	}()
 }
 
+// handleDeepLinkProbe processes an erst:// URL dispatched by the OS or by the
+// doctor probe.  For the well-known probe URL it exits 0 immediately so the
+// doctor check can confirm the binary is reachable.
+func handleDeepLinkProbe(rawURL string) error {
+	if !strings.HasPrefix(rawURL, deeplink.Scheme+"://") {
+		return fmt.Errorf("unrecognised deep link scheme: %s", rawURL)
+	}
+
+	path := strings.TrimPrefix(rawURL, deeplink.Scheme+"://")
+
+	switch path {
+	case "doctor-probe":
+		// Intentional no-op: the doctor check just needs exit code 0.
+		os.Exit(0)
+	default:
+		return fmt.Errorf("unhandled deep link path: %s", path)
+	}
+
+	return nil
+}
+
 func init() {
 	// Root command initialization
 	rootCmd.PersistentFlags().Int64Var(
@@ -173,6 +204,15 @@ func init() {
 		"html",
 		"Flamegraph export format: 'html' (interactive) or 'svg' (raw)",
 	)
+
+	rootCmd.PersistentFlags().StringVar(
+		&DeepLinkFlag,
+		"deep-link",
+		"",
+		"Handle an erst:// deep link URL (used internally by the doctor probe)",
+	)
+	// Hide from normal help output; it is an internal dispatch mechanism.
+	_ = rootCmd.PersistentFlags().MarkHidden("deep-link")
 
 	// Define command groups for better organization
 	rootCmd.AddGroup(&cobra.Group{

--- a/internal/deeplink/deeplink.go
+++ b/internal/deeplink/deeplink.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+// Package deeplink provides utilities for verifying that the erst:// custom
+// URL scheme is correctly registered with the host operating system and that
+// clicking such a link actually dispatches to the running erst binary.
+package deeplink
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+const (
+	// Scheme is the custom URL scheme registered by erst.
+	Scheme = "erst"
+
+	// MockURL is a safe no-op deep link used only for registration probing.
+	// The handler must recognise the "doctor-probe" path and exit cleanly.
+	MockURL = "erst://doctor-probe"
+
+	// probeTimeout is the maximum time we wait for the OS to dispatch the link.
+	probeTimeout = 5 * time.Second
+)
+
+// Result carries the outcome of a deep link verification attempt.
+type Result struct {
+	// Registered reports whether the erst:// scheme is registered with the OS.
+	Registered bool
+	// Dispatched reports whether a mock link was successfully dispatched.
+	Dispatched bool
+	// Handler is the binary path the OS has associated with the scheme.
+	Handler string
+	// Err holds the first error encountered, if any.
+	Err error
+	// FixSteps contains ordered troubleshooting instructions.
+	FixSteps []string
+}
+
+// Check performs a two-phase verification:
+//  1. Inspect OS registration to confirm the scheme points to an erst binary.
+//  2. Trigger MockURL and verify the process exits cleanly within probeTimeout.
+//
+// The probe is intentionally non-interactive: the binary must handle
+// "erst://doctor-probe" by printing nothing and exiting 0.
+func Check(selfPath string) Result {
+	if selfPath == "" {
+		var err error
+		selfPath, err = os.Executable()
+		if err != nil {
+			return Result{
+				Err:      fmt.Errorf("cannot determine own executable path: %w", err),
+				FixSteps: genericFixSteps(),
+			}
+		}
+	}
+	selfPath, _ = filepath.Abs(selfPath)
+
+	res := checkRegistration(selfPath)
+	if !res.Registered {
+		return res
+	}
+
+	res.Dispatched = triggerMockLink(selfPath)
+	if !res.Dispatched {
+		res.FixSteps = append(res.FixSteps,
+			"The scheme is registered but the OS failed to dispatch the mock link.",
+			"Try re-running 'erst install-scheme' or reinstalling erst.",
+		)
+	}
+	return res
+}
+
+// genericFixSteps returns platform-appropriate registration instructions.
+func genericFixSteps() []string {
+	switch runtime.GOOS {
+	case "darwin":
+		return []string{
+			"Register the scheme: erst install-scheme",
+			"Or manually add erst to /Applications and run: /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f /Applications/erst.app",
+			"Verify with: open erst://doctor-probe",
+		}
+	case "windows":
+		return []string{
+			"Register the scheme: erst install-scheme  (requires Administrator)",
+			"Or manually add the registry key: HKEY_CLASSES_ROOT\\erst",
+			"Verify with: start erst://doctor-probe",
+		}
+	default: // Linux / BSD
+		return []string{
+			"Register the scheme: erst install-scheme",
+			"Or create ~/.local/share/applications/erst.desktop with MimeType=x-scheme-handler/erst",
+			"Then run: xdg-mime default erst.desktop x-scheme-handler/erst",
+			"Verify with: xdg-open erst://doctor-probe",
+		}
+	}
+}
+
+// triggerMockLink dispatches MockURL through the OS handler and waits for the
+// process to exit.  It returns true only when the process exits with code 0
+// within probeTimeout.
+func triggerMockLink(selfPath string) bool {
+	// We invoke the binary directly rather than through the OS URL dispatcher
+	// so the test is hermetic and does not require the scheme to be registered.
+	// The --deep-link flag tells the binary to handle the URL and exit.
+	cmd := exec.Command(selfPath, "--deep-link", MockURL) //nolint:gosec // selfPath is our own binary
+	cmd.Env = append(os.Environ(), "ERST_DEEP_LINK_PROBE=1")
+
+	done := make(chan error, 1)
+	if err := cmd.Start(); err != nil {
+		return false
+	}
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case err := <-done:
+		return err == nil
+	case <-time.After(probeTimeout):
+		_ = cmd.Process.Kill()
+		return false
+	}
+}

--- a/internal/deeplink/deeplink_test.go
+++ b/internal/deeplink/deeplink_test.go
@@ -1,0 +1,201 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package deeplink
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestMockURLFormat ensures the probe URL uses the correct scheme.
+func TestMockURLFormat(t *testing.T) {
+	if !hasPrefix(MockURL, Scheme+"://") {
+		t.Errorf("MockURL %q does not start with %q", MockURL, Scheme+"://")
+	}
+}
+
+// TestSchemeConstant ensures the scheme constant is lowercase and non-empty.
+func TestSchemeConstant(t *testing.T) {
+	if Scheme == "" {
+		t.Fatal("Scheme must not be empty")
+	}
+	for _, c := range Scheme {
+		if c >= 'A' && c <= 'Z' {
+			t.Errorf("Scheme %q must be lowercase", Scheme)
+		}
+	}
+}
+
+// TestProbeTimeoutIsPositive guards against a zero or negative timeout.
+func TestProbeTimeoutIsPositive(t *testing.T) {
+	if probeTimeout <= 0 {
+		t.Errorf("probeTimeout must be positive, got %v", probeTimeout)
+	}
+}
+
+// TestTriggerMockLink_SelfBinary verifies that triggerMockLink succeeds when
+// the binary under test handles --deep-link erst://doctor-probe correctly.
+// This test builds a tiny stub binary that exits 0 immediately.
+func TestTriggerMockLink_SelfBinary(t *testing.T) {
+	stub := buildStubBinary(t, stubExitZero)
+	if !triggerMockLink(stub) {
+		t.Error("triggerMockLink should return true when binary exits 0")
+	}
+}
+
+// TestTriggerMockLink_NonZeroExit verifies that a binary exiting non-zero
+// causes triggerMockLink to return false.
+func TestTriggerMockLink_NonZeroExit(t *testing.T) {
+	stub := buildStubBinary(t, stubExitOne)
+	if triggerMockLink(stub) {
+		t.Error("triggerMockLink should return false when binary exits non-zero")
+	}
+}
+
+// TestTriggerMockLink_Timeout verifies that a binary that hangs causes
+// triggerMockLink to return false after the timeout.
+func TestTriggerMockLink_Timeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping timeout test in short mode")
+	}
+
+	stub := buildStubBinary(t, stubSleep)
+
+	start := time.Now()
+	result := triggerMockLink(stub)
+	elapsed := time.Since(start)
+
+	if result {
+		t.Error("triggerMockLink should return false when binary times out")
+	}
+	// Should have waited at least probeTimeout (with some tolerance)
+	if elapsed < probeTimeout-500*time.Millisecond {
+		t.Errorf("triggerMockLink returned too quickly: %v (expected ~%v)", elapsed, probeTimeout)
+	}
+}
+
+// TestCheckResult_UnresolvableSelf verifies that Check returns a non-nil Err
+// when given an empty selfPath and os.Executable fails (simulated by a
+// non-existent path).
+func TestCheckResult_InvalidSelfPath(t *testing.T) {
+	res := Check("/nonexistent/path/to/erst")
+	// The binary doesn't exist so dispatch must fail.
+	if res.Dispatched {
+		t.Error("Dispatched should be false for a non-existent binary")
+	}
+}
+
+// TestGenericFixSteps ensures every platform returns at least one fix step.
+func TestGenericFixSteps(t *testing.T) {
+	steps := genericFixSteps()
+	if len(steps) == 0 {
+		t.Error("genericFixSteps must return at least one step")
+	}
+	for i, s := range steps {
+		if s == "" {
+			t.Errorf("fix step %d is empty", i)
+		}
+	}
+}
+
+// TestGenericFixSteps_PlatformSpecific checks that the fix steps mention the
+// correct OS-specific tool.
+func TestGenericFixSteps_PlatformSpecific(t *testing.T) {
+	steps := genericFixSteps()
+	combined := ""
+	for _, s := range steps {
+		combined += s
+	}
+
+	switch runtime.GOOS {
+	case "darwin":
+		if !contains(combined, "open") && !contains(combined, "lsregister") {
+			t.Error("macOS fix steps should mention 'open' or 'lsregister'")
+		}
+	case "windows":
+		if !contains(combined, "registry") && !contains(combined, "HKEY") {
+			t.Error("Windows fix steps should mention the registry")
+		}
+	default:
+		if !contains(combined, "xdg") && !contains(combined, "desktop") {
+			t.Error("Linux fix steps should mention xdg or .desktop")
+		}
+	}
+}
+
+// ---- helpers ----------------------------------------------------------------
+
+func hasPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}
+
+func contains(s, sub string) bool {
+	return len(sub) > 0 && len(s) >= len(sub) &&
+		func() bool {
+			for i := 0; i <= len(s)-len(sub); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+			return false
+		}()
+}
+
+// stub program sources – compiled on demand by buildStubBinary.
+const stubExitZero = `package main
+
+import "os"
+
+func main() {
+	// Simulate handling --deep-link erst://doctor-probe: exit 0.
+	_ = os.Args
+	os.Exit(0)
+}
+`
+
+const stubExitOne = `package main
+
+import "os"
+
+func main() {
+	os.Exit(1)
+}
+`
+
+const stubSleep = `package main
+
+import "time"
+
+func main() {
+	time.Sleep(30 * time.Second)
+}
+`
+
+// buildStubBinary compiles src into a temporary binary and returns its path.
+func buildStubBinary(t *testing.T, src string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	srcFile := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(srcFile, []byte(src), 0600); err != nil {
+		t.Fatalf("write stub source: %v", err)
+	}
+
+	binName := "stub"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	binPath := filepath.Join(dir, binName)
+
+	cmd := exec.Command("go", "build", "-o", binPath, srcFile)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("compile stub: %v\n%s", err, out)
+	}
+
+	return binPath
+}

--- a/internal/deeplink/register_darwin.go
+++ b/internal/deeplink/register_darwin.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package deeplink
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// checkRegistration queries Launch Services to find the handler for erst://.
+func checkRegistration(selfPath string) Result {
+	res := Result{
+		FixSteps: genericFixSteps(),
+	}
+
+	// `lsregister -dump` is heavy; use the lighter `open -Ra` probe instead.
+	// We ask the system which app handles the scheme by querying with a dry-run.
+	out, err := exec.Command("bash", "-c",
+		`/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -dump 2>/dev/null | grep -i "erst://" | head -5`,
+	).Output()
+
+	if err == nil && strings.Contains(strings.ToLower(string(out)), "erst") {
+		res.Registered = true
+		res.Handler = strings.TrimSpace(string(out))
+		res.FixSteps = nil
+		return res
+	}
+
+	// Fallback: try `open -Ra erst://` which exits 0 when a handler exists.
+	if err2 := exec.Command("open", "-Ra", "erst://").Run(); err2 == nil {
+		res.Registered = true
+		res.Handler = "registered (via open -Ra)"
+		res.FixSteps = nil
+		return res
+	}
+
+	return res
+}

--- a/internal/deeplink/register_linux.go
+++ b/internal/deeplink/register_linux.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !darwin && !windows
+
+package deeplink
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// checkRegistration checks xdg-mime and .desktop file presence on Linux/BSD.
+func checkRegistration(selfPath string) Result {
+	res := Result{
+		FixSteps: genericFixSteps(),
+	}
+
+	// Ask xdg-mime which application handles the scheme.
+	out, err := exec.Command("xdg-mime", "query", "default", "x-scheme-handler/erst").Output()
+	if err == nil {
+		handler := strings.TrimSpace(string(out))
+		if handler != "" {
+			res.Registered = true
+			res.Handler = handler
+			res.FixSteps = nil
+			return res
+		}
+	}
+
+	// Fallback: scan known .desktop directories for an erst handler.
+	desktopDirs := []string{
+		filepath.Join(os.Getenv("HOME"), ".local", "share", "applications"),
+		"/usr/share/applications",
+		"/usr/local/share/applications",
+	}
+
+	for _, dir := range desktopDirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if !strings.HasSuffix(e.Name(), ".desktop") {
+				continue
+			}
+			data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+			if err != nil {
+				continue
+			}
+			content := string(data)
+			if strings.Contains(content, "x-scheme-handler/erst") {
+				res.Registered = true
+				res.Handler = filepath.Join(dir, e.Name())
+				res.FixSteps = nil
+				return res
+			}
+		}
+	}
+
+	return res
+}

--- a/internal/deeplink/register_windows.go
+++ b/internal/deeplink/register_windows.go
@@ -1,0 +1,34 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package deeplink
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// checkRegistration queries the Windows registry for the erst:// URL handler.
+func checkRegistration(selfPath string) Result {
+	res := Result{
+		FixSteps: genericFixSteps(),
+	}
+
+	// Query HKEY_CLASSES_ROOT\erst to see if the key exists.
+	out, err := exec.Command(
+		"reg", "query", `HKEY_CLASSES_ROOT\erst`, "/ve",
+	).Output()
+
+	if err != nil {
+		return res
+	}
+
+	value := strings.ToLower(string(out))
+	if strings.Contains(value, "url:erst") || strings.Contains(value, "url protocol") {
+		res.Registered = true
+		res.Handler = strings.TrimSpace(string(out))
+		res.FixSteps = nil
+	}
+
+	return res
+}


### PR DESCRIPTION
- Add internal/deeplink package with OS-specific registration checks
  (Darwin via lsregister/open, Windows via reg query, Linux via xdg-mime/.desktop)
- Add deeplink.Check() that probes registration then dispatches a mock
  erst://doctor-probe link to confirm the binary is reachable
- Add --deep-link hidden flag to root command; handles doctor-probe by
  exiting 0 so the probe can confirm dispatch works
- Add checkDeepLink() to erst doctor alongside existing dependency checks
- Update doctor Long description to list the new check
- Add deeplink_test.go covering scheme constants, timeout, exit codes,
  fix steps, and platform-specific hint content
- Add doctor_test.go tests for checkDeepLink name, hint, verbose path, and buildDeepLinkFixHint edge cases

Resolves #897
