### PR TITLE
feat(sdk): add txstream WebSocket transaction watching - Issue #888

### DIFF
--- a/internal/cmd/debug.go
+++ b/internal/cmd/debug.go
@@ -364,33 +364,36 @@ Local WASM Replay Mode:
 		// Fetch transaction details
 		if watchFlag {
 			spinner := watch.NewSpinner()
-			poller := watch.NewPoller(watch.PollerConfig{
-				InitialInterval: 1 * time.Second,
-				MaxInterval:     10 * time.Second,
-				TimeoutDuration: time.Duration(watchTimeoutFlag) * time.Second,
-			})
-
 			spinner.Start("Waiting for transaction to appear on-chain...")
+			watchCtx, cancelWatch := context.WithTimeout(ctx, time.Duration(watchTimeoutFlag)*time.Second)
+			defer cancelWatch()
 
-			result, err := poller.Poll(ctx, func(pollCtx context.Context) (interface{}, error) {
-				_, pollErr := client.GetTransaction(pollCtx, txHash)
-				if pollErr != nil {
-					return nil, pollErr
-				}
-				return true, nil
-			}, nil)
-
+			statusCh, err := client.WatchTransaction(watchCtx, txHash)
 			if err != nil {
-				spinner.StopWithError("Failed to poll for transaction")
+				spinner.StopWithError("Failed to start transaction watch")
 				return errors.WrapSimulationLogicError(fmt.Sprintf("watch mode error: %v", err))
 			}
 
-			if !result.Found {
+			var finalStatus *rpc.TxStatus
+			for status := range statusCh {
+				if status.IsFinal() {
+					statusCopy := status
+					finalStatus = &statusCopy
+					break
+				}
+			}
+
+			if err := watchCtx.Err(); err != nil {
 				spinner.StopWithError("Transaction not found within timeout")
 				return errors.WrapTransactionNotFound(fmt.Errorf("not found after %d seconds", watchTimeoutFlag))
 			}
 
-			spinner.StopWithMessage("Transaction found! Starting debug...")
+			if finalStatus == nil {
+				spinner.StopWithError("Transaction watch ended unexpectedly")
+				return errors.WrapSimulationLogicError("watch mode ended before a final transaction status was received")
+			}
+
+			spinner.StopWithMessage(fmt.Sprintf("Transaction reached %s. Starting debug...", strings.ToLower(finalStatus.Status)))
 		}
 
 		fmt.Printf("Fetching transaction: %s\n", txHash)

--- a/internal/rpc/client.go
+++ b/internal/rpc/client.go
@@ -463,6 +463,12 @@ func (c *Client) GetTransaction(ctx context.Context, hash string) (*TransactionR
 	return nil, &AllNodesFailedError{Failures: failures}
 }
 
+// WatchTransaction streams transaction status updates until the caller
+// cancels the context or a terminal status is reached.
+func (c *Client) WatchTransaction(ctx context.Context, hash string) (<-chan TxStatus, error) {
+	return NewTxStreamer(c).Stream(ctx, hash)
+}
+
 func (c *Client) getTransactionAttempt(ctx context.Context, hash string) (txResp *TransactionResponse, err error) {
 	timer := c.startMethodTimer(ctx, "rpc.get_transaction", map[string]string{
 		"network": c.GetNetworkName(),

--- a/internal/rpc/txstream.go
+++ b/internal/rpc/txstream.go
@@ -88,11 +88,78 @@ func NewTxStreamer(c *Client) TxStreamer {
 		defer cancel()
 		if probeWebSocket(probeCtx, wsURL, c.token) {
 			logger.Logger.Info("WebSocket streaming enabled", "url", wsURL)
-			return &wsStreamer{client: c, wsURL: wsURL}
+			return &autoFallbackStreamer{
+				client:          c,
+				wsURL:           wsURL,
+				pollingFallback: &pollingStreamer{client: c},
+			}
 		}
 	}
 	logger.Logger.Info("WebSocket not supported, using JSON-RPC polling", "url", c.SorobanURL)
 	return &pollingStreamer{client: c}
+}
+
+// autoFallbackStreamer prefers WebSockets but switches to JSON-RPC polling if
+// the WebSocket stream cannot be established or ends before a terminal status.
+type autoFallbackStreamer struct {
+	client          *Client
+	wsURL           string
+	pollingFallback *pollingStreamer
+}
+
+// Stream implements TxStreamer.
+func (s *autoFallbackStreamer) Stream(ctx context.Context, hash string) (<-chan TxStatus, error) {
+	ws := &wsStreamer{client: s.client, wsURL: s.wsURL}
+	wsCh, err := ws.Stream(ctx, hash)
+	if err != nil {
+		logger.Logger.Warn("WebSocket stream setup failed, falling back to JSON-RPC polling", "hash", hash, "error", err)
+		return s.pollingFallback.Stream(ctx, hash)
+	}
+
+	out := make(chan TxStatus, 8)
+	go func() {
+		defer close(out)
+
+		sawFinal := false
+		for status := range wsCh {
+			if !forwardTxStatus(ctx, out, status) {
+				return
+			}
+			if status.IsFinal() {
+				sawFinal = true
+				return
+			}
+		}
+
+		if sawFinal || ctx.Err() != nil {
+			return
+		}
+
+		logger.Logger.Warn("WebSocket stream ended before a final transaction status, falling back to JSON-RPC polling", "hash", hash)
+
+		pollCh, err := s.pollingFallback.Stream(ctx, hash)
+		if err != nil {
+			logger.Logger.Error("Polling fallback failed to start", "hash", hash, "error", err)
+			return
+		}
+
+		for status := range pollCh {
+			if !forwardTxStatus(ctx, out, status) {
+				return
+			}
+		}
+	}()
+
+	return out, nil
+}
+
+func forwardTxStatus(ctx context.Context, out chan<- TxStatus, status TxStatus) bool {
+	select {
+	case out <- status:
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/rpc/txstream_test.go
+++ b/internal/rpc/txstream_test.go
@@ -539,8 +539,168 @@ func TestNewTxStreamer_PrefersWebSocket_WhenSupportedByServer(t *testing.T) {
 	}
 
 	streamer := NewTxStreamer(client)
-	if _, ok := streamer.(*wsStreamer); !ok {
-		t.Logf("server at %s did not accept WebSocket probe — treating as expected in offline CI", httpURL)
+	if _, ok := streamer.(*autoFallbackStreamer); !ok {
+		t.Fatalf("expected *autoFallbackStreamer when WebSocket is supported, got %T", streamer)
+	}
+}
+
+func TestClientWatchTransaction_UsesWebSocketStreaming(t *testing.T) {
+	srv := newMockWSServer(t, []string{TxStatusPending, TxStatusSuccess})
+	defer srv.Close()
+
+	client, err := NewClient(
+		WithNetwork(Testnet),
+		WithSorobanURL("http://"+srv.Listener.Addr().String()),
+		WithHTTPClient(srv.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	origInterval := wsStreamInterval
+	wsStreamInterval = 20 * time.Millisecond
+	defer func() { wsStreamInterval = origInterval }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ch, err := client.WatchTransaction(ctx, "feedface")
+	if err != nil {
+		t.Fatalf("WatchTransaction: %v", err)
+	}
+
+	var statuses []string
+	for status := range ch {
+		statuses = append(statuses, status.Status)
+	}
+
+	if len(statuses) < 2 {
+		t.Fatalf("expected multiple statuses from WatchTransaction, got %v", statuses)
+	}
+	if got := statuses[len(statuses)-1]; got != TxStatusSuccess {
+		t.Fatalf("final status = %q, want %q", got, TxStatusSuccess)
+	}
+}
+
+func TestClientWatchTransaction_FallsBackWhenWebSocketStreamDrops(t *testing.T) {
+	upgradeCount := 0
+	httpStatuses := []string{TxStatusPending, TxStatusSuccess}
+	httpIdx := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+			upgradeCount++
+
+			key := r.Header.Get("Sec-Websocket-Key")
+			accept := wsAcceptKey(key)
+
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				http.Error(w, "hijacking not supported", http.StatusInternalServerError)
+				return
+			}
+
+			conn, bufrw, err := hj.Hijack()
+			if err != nil {
+				return
+			}
+			defer conn.Close()
+
+			fmt.Fprintf(bufrw,
+				"HTTP/1.1 101 Switching Protocols\r\n"+
+					"Upgrade: websocket\r\n"+
+					"Connection: Upgrade\r\n"+
+					"Sec-WebSocket-Accept: %s\r\n"+
+					"\r\n",
+				accept,
+			)
+			if err := bufrw.Flush(); err != nil {
+				return
+			}
+
+			// First upgrade is the probe. On the actual stream, return one
+			// PENDING update and then drop the connection so polling can resume.
+			if upgradeCount == 1 {
+				return
+			}
+
+			msg, err := wsReadFrame(bufrw.Reader)
+			if err != nil {
+				return
+			}
+
+			var req jsonrpcRequest
+			if err := json.Unmarshal(msg, &req); err != nil {
+				return
+			}
+
+			resp := fmt.Sprintf(
+				`{"jsonrpc":"2.0","id":%d,"result":{"status":%q,"ledger":123}}`,
+				req.ID, TxStatusPending,
+			)
+			if err := wsWriteFrameUnmasked(conn, []byte(resp)); err != nil {
+				t.Errorf("wsWriteFrameUnmasked: %v", err)
+			}
+			return
+		}
+
+		if r.Method != http.MethodPost {
+			http.Error(w, "expected POST", http.StatusMethodNotAllowed)
+			return
+		}
+
+		if httpIdx >= len(httpStatuses) {
+			httpIdx = len(httpStatuses) - 1
+		}
+		status := httpStatuses[httpIdx]
+		httpIdx++
+
+		resp := fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"result":{"status":%q,"ledger":456}}`, status)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, resp)
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(
+		WithNetwork(Testnet),
+		WithSorobanURL(srv.URL),
+		WithHTTPClient(srv.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	origWSInterval := wsStreamInterval
+	origPollInterval := pollStreamInterval
+	wsStreamInterval = 20 * time.Millisecond
+	pollStreamInterval = 20 * time.Millisecond
+	defer func() {
+		wsStreamInterval = origWSInterval
+		pollStreamInterval = origPollInterval
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ch, err := client.WatchTransaction(ctx, "decafbad")
+	if err != nil {
+		t.Fatalf("WatchTransaction: %v", err)
+	}
+
+	var statuses []string
+	for status := range ch {
+		statuses = append(statuses, status.Status)
+	}
+
+	if len(statuses) < 2 {
+		t.Fatalf("expected fallback statuses, got %v", statuses)
+	}
+	if got := statuses[len(statuses)-1]; got != TxStatusSuccess {
+		t.Fatalf("final status = %q, want %q", got, TxStatusSuccess)
+	}
+	if upgradeCount < 2 {
+		t.Fatalf("expected probe and watch WebSocket upgrades, got %d", upgradeCount)
 	}
 }
 


### PR DESCRIPTION

## Overview

Implements SDK support for WebSocket-based transaction watching via `txstream`, with automatic fallback to long-polling when WebSocket streaming is unavailable or drops mid-stream.

## Changes

### Core Implementation

- **WatchTransaction API**: Added `WatchTransaction(ctx, hash)` to the RPC client
  - Exposes transaction status streaming as a first-class SDK method
  - Returns streamed transaction status updates until a terminal state is reached
  - Keeps the streaming behavior encapsulated behind the client API

- **txstream WebSocket Support**: Extended the transaction streaming path to prefer WebSockets
  - Uses WebSocket `txstream` when the Soroban RPC endpoint supports upgrade
  - Preserves existing polling behavior for providers without WebSocket support
  - Keeps provider detection fast with a short probe timeout

- **Automatic Fallback**: Added resilient fallback behavior
  - Falls back to JSON-RPC polling if WebSocket connection setup fails
  - Falls back to polling if the WebSocket stream drops before a final transaction status is received
  - Prevents watch flows from failing early due to transient WebSocket issues

### CLI Integration

- **Debug Watch Flow**: Updated `debug --watch` to use the new streaming API
  - Replaced direct long-polling-only watch behavior with `client.WatchTransaction(...)`
  - Continues waiting until a final transaction state is observed
  - Preserves timeout handling and user-facing watch messages

### Testing

- **Streaming Tests**: Added coverage for the new transaction watching behavior
  - Verifies `WatchTransaction` uses WebSocket streaming when supported
  - Verifies fallback to polling when the live WebSocket stream drops
  - Updates factory expectations to reflect the new auto-fallback streamer wrapper

- **Regression Safety**: Confirmed targeted packages pass
  - `go test ./internal/rpc ./internal/watch ./internal/cmd`

## Verification

- WebSocket transaction streaming is implemented in the SDK
- Automatic fallback to long-polling is implemented for connection/setup failures and dropped streams
- Targeted streaming-related test packages pass locally

## Related Issues

Closes #888

## Type of Change

- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added/updated
- [x] Documentation updated not required for this change
- [x] No new linting issues in touched code
- [x] Changes verified locally

## Local Verification Commands

```bash
# Confirm branch
git branch --show-current

# Run targeted validation for the txstream/watch work
go test ./internal/rpc ./internal/watch ./internal/cmd

# Optional broader verification
go build -o erst ./cmd/erst
go test ./...
```