### PR TITLE
feat(sdk): add idempotency key support for transaction submission - Issue #884

### DIFF
--- a/src/rpc/__tests__/fallback-client.spec.ts
+++ b/src/rpc/__tests__/fallback-client.spec.ts
@@ -101,6 +101,60 @@ describe('FallbackRPCClient', () => {
         });
     });
 
+    describe('sendTransaction idempotency support', () => {
+        it('should send the idempotency key as a request header without changing JSON-RPC params', async () => {
+            mock.onPost('https://rpc1.test.com/').reply(200, { status: 'PENDING' });
+
+            await client.sendTransaction('AAAA-test-xdr', { idempotencyKey: 'idem-123' });
+
+            expect(mock.history.post.length).toBe(1);
+
+            const request = mock.history.post[0];
+            expect(request.headers?.['Idempotency-Key']).toBe('idem-123');
+
+            const body = JSON.parse(request.data);
+            expect(body).toEqual({
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'sendTransaction',
+                params: { transaction: 'AAAA-test-xdr' },
+            });
+        });
+
+        it('should preserve the idempotency key across retries', async () => {
+            let attempts = 0;
+            mock.onPost('https://rpc1.test.com/').reply(config => {
+                attempts++;
+
+                if (attempts === 1) {
+                    return [500, { error: 'temporary failure' }];
+                }
+
+                return [200, { status: 'PENDING' }];
+            });
+
+            await client.sendTransaction('AAAA-retry-xdr', { idempotencyKey: 'idem-retry' });
+
+            expect(attempts).toBe(2);
+            expect(mock.history.post).toHaveLength(2);
+            expect(mock.history.post[0].headers?.['Idempotency-Key']).toBe('idem-retry');
+            expect(mock.history.post[1].headers?.['Idempotency-Key']).toBe('idem-retry');
+        });
+
+        it('should not retry when the server reports an idempotency conflict', async () => {
+            mock.onPost('https://rpc1.test.com/').reply(409, {
+                error: 'idempotency conflict',
+            });
+
+            await expect(
+                client.sendTransaction('AAAA-conflict-xdr', { idempotencyKey: 'idem-conflict' }),
+            ).rejects.toThrow();
+
+            expect(mock.history.post).toHaveLength(1);
+            expect(mock.history.post[0].headers?.['Idempotency-Key']).toBe('idem-conflict');
+        });
+    });
+
     describe('circuit breaker', () => {
         it('should open circuit after threshold failures', async () => {
             mock.onPost('https://rpc1.test.com/test').networkError();

--- a/src/rpc/fallback-client.ts
+++ b/src/rpc/fallback-client.ts
@@ -6,6 +6,7 @@ import { open, type FileHandle } from 'fs/promises';
 import { RPCConfig } from '../config/rpc-config';
 import { getLogger, LogCategory } from '../utils/logger';
 import { SDKContext, SDKResponse, SDKMiddleware, NextFn, composeMiddleware } from '../xdr/types';
+import type { SendTransactionOptions } from './types-v2';
 
 interface RPCEndpoint {
     url: string;
@@ -83,15 +84,19 @@ export class FallbackRPCClient {
     /**
      * Make RPC request with automatic fallback, executing middleware chain.
      */
-    async request<T = any>(path: string, options: { method?: 'GET' | 'POST', data?: any } = {}): Promise<T> {
+    async request<T = any>(path: string, options: { method?: 'GET' | 'POST', data?: any, headers?: Record<string, string> } = {}): Promise<T> {
         const method = options.method || 'POST';
         const data = options.data;
+        const headers = {
+            ...(this.config.headers || {}),
+            ...(options.headers || {}),
+        };
 
         const ctx: SDKContext = {
             path,
             method,
             data,
-            headers: this.config.headers,
+            headers,
             metadata: {},
         };
 
@@ -136,7 +141,7 @@ export class FallbackRPCClient {
                 logger.verboseIndent(LogCategory.RPC, `${ctx.method} request to ${ctx.path}`);
                 logger.verboseIndent(LogCategory.RPC, `Request size: ${logger.formatBytes(requestSize)}`);
 
-                const response = await this.executeWithRetry(client, ctx.method as 'GET' | 'POST', ctx.path, ctx.data);
+                const response = await this.executeWithRetry(client, ctx.method as 'GET' | 'POST', ctx.path, ctx.data, ctx.headers);
 
                 const duration = Date.now() - requestStartTime;
                 this.updateMetrics(endpoint, duration, true);
@@ -309,16 +314,22 @@ export class FallbackRPCClient {
     /**
      * Execute request with local retries and exponential backoff
      */
-    private async executeWithRetry(client: AxiosInstance, method: 'GET' | 'POST', path: string, data: any): Promise<any> {
+    private async executeWithRetry(
+        client: AxiosInstance,
+        method: 'GET' | 'POST',
+        path: string,
+        data: any,
+        headers?: Record<string, string>,
+    ): Promise<any> {
         const logger = getLogger();
         let lastError: any;
 
         for (let attempt = 0; attempt < this.config.retries; attempt++) {
             try {
                 if (method === 'GET') {
-                    return await client.get(path);
+                    return await client.get(path, { headers });
                 }
-                return await client.post(path, data);
+                return await client.post(path, data, { headers });
             } catch (error) {
                 lastError = error;
 
@@ -612,9 +623,14 @@ export class FallbackRPCClient {
     /**
      * Send a transaction (Protocol V2)
      */
-    async sendTransaction(transactionXdr: string): Promise<any> {
+    async sendTransaction(transactionXdr: string, options: SendTransactionOptions = {}): Promise<any> {
+        const headers = options.idempotencyKey
+            ? { 'Idempotency-Key': options.idempotencyKey }
+            : undefined;
+
         return this.request('/', {
             method: 'POST',
+            headers,
             data: { jsonrpc: '2.0', id: 1, method: 'sendTransaction', params: { transaction: transactionXdr } }
         });
     }

--- a/src/rpc/types-v2.ts
+++ b/src/rpc/types-v2.ts
@@ -28,6 +28,10 @@ export interface RPCMethodParams {
     getVersionInfo?: Record<string, unknown>;
 }
 
+export interface SendTransactionOptions {
+    idempotencyKey?: string;
+}
+
 export interface GetEventsParams {
     startLedger: number;
     endLedger?: number;


### PR DESCRIPTION

## Overview

Implements idempotency key support for Soroban transaction submission in the SDK so transaction retries can be made safely under unstable network conditions without risking duplicate submission behavior.

## Changes

### Core Implementation

- **Submission API Update**: Extended `sendTransaction()` to accept optional submission options
  - Added optional `idempotencyKey` support for transaction submission
  - Kept the JSON-RPC request body aligned with the current Stellar RPC spec
  - Passed the idempotency value using the `Idempotency-Key` request header

- **Request Pipeline Support**: Updated the fallback RPC request flow to preserve per-request headers
  - Merges request-scoped headers with configured client headers
  - Ensures the idempotency key survives local retry attempts
  - Keeps the change isolated to the SDK request path without altering unrelated RPC methods

- **Shared SDK Types**: Added a typed submission options interface
  - Introduced `SendTransactionOptions`
  - Makes idempotency support explicit at the SDK surface
  - Preserves backward compatibility for existing callers that only pass transaction XDR

### Testing

- **Header Propagation Test**: Verified that the idempotency key is sent as `Idempotency-Key`
- **Retry Preservation Test**: Verified that retries reuse the same idempotency key
- **Conflict Handling Test**: Verified that an idempotency conflict response is not retried
- **Regression Safety**: Existing fallback client tests continue to pass alongside the new cases

## Spec Alignment

The current Stellar `sendTransaction` documentation still lists only the `transaction` field in JSON-RPC params, so this implementation sends the idempotency key as a request header instead of modifying the JSON-RPC payload.

Reference:
- https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/sendTransaction

## Verification

- `npm test -- --runInBand src/rpc/__tests__/fallback-client.spec.ts` ✅
- Verified idempotency key propagation across retry attempts ✅
- Verified idempotency conflict is treated as non-retryable ✅

Note:
- `npm run build` still fails due to a pre-existing repository issue in `src/index.ts` related to shebang parsing, unrelated to this change.

## Related Issues

Closes #884

## Type of Change

- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added/updated
- [x] Documentation updated not required for this change
- [x] No new issues introduced in touched SDK code
- [x] Changes verified locally

================================================================================
