### PR TITLE
feat: add memory snapshot comparison command

### DIFF
--- a/internal/cmd/snapshot_diff.go
+++ b/internal/cmd/snapshot_diff.go
@@ -1,0 +1,270 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dotandev/hintents/internal/errors"
+	"github.com/dotandev/hintents/internal/snapshot"
+	"github.com/dotandev/hintents/internal/visualizer"
+	"github.com/spf13/cobra"
+)
+
+var (
+	snapshotDiffAFlag       string
+	snapshotDiffBFlag       string
+	snapshotDiffOffsetFlag  int
+	snapshotDiffLengthFlag  int
+	snapshotDiffContextFlag int
+)
+
+var snapshotDiffCmd = &cobra.Command{
+	Use:     "snapshot-diff",
+	GroupID: "utility",
+	Short:   "Compare linear memory between two snapshots",
+	Long: `Compare linear memory dumps from two snapshot files (Snapshot A and Snapshot B)
+and display the differences in a side-by-side HEX/ASCII format.
+
+This command is useful for debugging state-related bugs by seeing how memory
+changes between two points in contract execution.
+
+Examples:
+  # Compare two snapshots
+  erst snapshot-diff --snapshot-a before.json --snapshot-b after.json
+
+  # Compare a specific memory region
+  erst snapshot-diff --snapshot-a before.json --snapshot-b after.json --offset 0x100 --length 256
+
+  # Show more context around changes
+  erst snapshot-diff --snapshot-a before.json --snapshot-b after.json --context 32`,
+	RunE: runSnapshotDiff,
+}
+
+func init() {
+	snapshotDiffCmd.Flags().StringVar(&snapshotDiffAFlag, "snapshot-a", "", "First snapshot file (Snapshot A)")
+	snapshotDiffCmd.Flags().StringVar(&snapshotDiffBFlag, "snapshot-b", "", "Second snapshot file (Snapshot B)")
+	snapshotDiffCmd.Flags().IntVar(&snapshotDiffOffsetFlag, "offset", -1, "Start offset to compare (default: compare all)")
+	snapshotDiffCmd.Flags().IntVar(&snapshotDiffLengthFlag, "length", 0, "Number of bytes to compare (default: all from offset)")
+	snapshotDiffCmd.Flags().IntVar(&snapshotDiffContextFlag, "context", 16, "Bytes of context to show around changes")
+	rootCmd.AddCommand(snapshotDiffCmd)
+}
+
+func runSnapshotDiff(cmd *cobra.Command, args []string) error {
+	if snapshotDiffAFlag == "" {
+		return errors.WrapCliArgumentRequired("snapshot-a")
+	}
+	if snapshotDiffBFlag == "" {
+		return errors.WrapCliArgumentRequired("snapshot-b")
+	}
+
+	snapA, err := snapshot.Load(snapshotDiffAFlag)
+	if err != nil {
+		return errors.WrapValidationError(fmt.Sprintf("failed to load snapshot A: %v", err))
+	}
+
+	snapB, err := snapshot.Load(snapshotDiffBFlag)
+	if err != nil {
+		return errors.WrapValidationError(fmt.Sprintf("failed to load snapshot B: %v", err))
+	}
+
+	memA, err := snapA.DecodeLinearMemory()
+	if err != nil {
+		return errors.WrapValidationError(fmt.Sprintf("failed to decode memory from snapshot A: %v", err))
+	}
+
+	memB, err := snapB.DecodeLinearMemory()
+	if err != nil {
+		return errors.WrapValidationError(fmt.Sprintf("failed to decode memory from snapshot B: %v", err))
+	}
+
+	if len(memA) == 0 && len(memB) == 0 {
+		fmt.Println("Neither snapshot contains linear memory data.")
+		return nil
+	}
+
+	printDiffHeader(snapshotDiffAFlag, snapshotDiffBFlag, len(memA), len(memB))
+
+	var diffResult *snapshot.MemoryDiffResult
+	if snapshotDiffOffsetFlag >= 0 {
+		length := snapshotDiffLengthFlag
+		if length <= 0 {
+			maxLen := len(memA)
+			if len(memB) > maxLen {
+				maxLen = len(memB)
+			}
+			length = maxLen - snapshotDiffOffsetFlag
+		}
+		diffResult = snapshot.DiffMemoryFull(memA, memB, snapshotDiffOffsetFlag, length)
+	} else {
+		diffResult = snapshot.DiffMemory(memA, memB, snapshotDiffContextFlag)
+	}
+
+	if diffResult.TotalChanged == 0 {
+		fmt.Printf("\n%s Memory contents are identical\n", visualizer.Success())
+		return nil
+	}
+
+	fmt.Printf("\n%s Found %d changed bytes in %d region(s)\n\n",
+		visualizer.Warning(), diffResult.TotalChanged, len(diffResult.ChangedRegions))
+
+	for i, region := range diffResult.ChangedRegions {
+		printRegionDiff(i+1, &region)
+	}
+
+	printDiffSummary(diffResult)
+	return nil
+}
+
+func printDiffHeader(pathA, pathB string, sizeA, sizeB int) {
+	sep := strings.Repeat("─", 78)
+	fmt.Println()
+	fmt.Println(visualizer.Colorize("╔"+strings.Repeat("═", 78)+"╗", "cyan"))
+	fmt.Printf(visualizer.Colorize("║", "cyan")+"  MEMORY SNAPSHOT COMPARISON%s"+visualizer.Colorize("║", "cyan")+"\n", strings.Repeat(" ", 50))
+	fmt.Println(visualizer.Colorize("╚"+strings.Repeat("═", 78)+"╝", "cyan"))
+	fmt.Println()
+
+	fmt.Printf("  Snapshot A: %s (%d bytes)\n", pathA, sizeA)
+	fmt.Printf("  Snapshot B: %s (%d bytes)\n", pathB, sizeB)
+	fmt.Println(visualizer.Colorize("  "+sep, "dim"))
+}
+
+func printRegionDiff(regionNum int, region *snapshot.MemoryRegion) {
+	fmt.Printf("%s Region #%d: offset 0x%08x, length %d bytes\n",
+		visualizer.Colorize("──", "cyan"), regionNum, region.Offset, region.Length)
+	fmt.Println()
+
+	printDiffTable(region)
+	fmt.Println()
+}
+
+func printDiffTable(region *snapshot.MemoryRegion) {
+	fmt.Printf("  %-10s  %-48s  %-48s\n", "OFFSET", "SNAPSHOT A (HEX + ASCII)", "SNAPSHOT B (HEX + ASCII)")
+	fmt.Printf("  %s\n", strings.Repeat("-", 110))
+
+	for i := 0; i < region.Length; i += 16 {
+		offset := region.Offset + i
+
+		endA := i + 16
+		if endA > len(region.BytesA) {
+			endA = len(region.BytesA)
+		}
+		endB := i + 16
+		if endB > len(region.BytesB) {
+			endB = len(region.BytesB)
+		}
+
+		lineA := region.BytesA[i:endA]
+		lineB := region.BytesB[i:endB]
+
+		hexA, asciiA := formatHexAscii(lineA)
+		hexB, asciiB := formatHexAscii(lineB)
+
+		// Highlight differences
+		hexAColored, hexBColored := colorizeHexDiff(lineA, lineB, hexA, hexB)
+		asciiAColored, asciiBColored := colorizeAsciiDiff(lineA, lineB, asciiA, asciiB)
+
+		fmt.Printf("  0x%08x  %s |%s|  %s |%s|\n",
+			offset, hexAColored, asciiAColored, hexBColored, asciiBColored)
+	}
+}
+
+func formatHexAscii(data []byte) (string, string) {
+	hexParts := make([]string, 16)
+	ascii := make([]byte, len(data))
+
+	for i := 0; i < 16; i++ {
+		if i < len(data) {
+			b := data[i]
+			hexParts[i] = fmt.Sprintf("%02x", b)
+			if b >= 32 && b <= 126 {
+				ascii[i] = b
+			} else {
+				ascii[i] = '.'
+			}
+		} else {
+			hexParts[i] = "  "
+		}
+	}
+
+	return strings.Join(hexParts, " "), string(ascii)
+}
+
+func colorizeHexDiff(a, b []byte, hexA, hexB string) (string, string) {
+	partsA := strings.Split(hexA, " ")
+	partsB := strings.Split(hexB, " ")
+
+	for i := 0; i < 16; i++ {
+		var byteA, byteB byte
+		if i < len(a) {
+			byteA = a[i]
+		}
+		if i < len(b) {
+			byteB = b[i]
+		}
+
+		if i < len(a) && i < len(b) && byteA != byteB {
+			partsA[i] = visualizer.Colorize(partsA[i], "red")
+			partsB[i] = visualizer.Colorize(partsB[i], "green")
+		} else if i >= len(a) && i < len(b) {
+			partsB[i] = visualizer.Colorize(partsB[i], "green")
+		} else if i < len(a) && i >= len(b) {
+			partsA[i] = visualizer.Colorize(partsA[i], "red")
+		}
+	}
+
+	return strings.Join(partsA, " "), strings.Join(partsB, " ")
+}
+
+func colorizeAsciiDiff(a, b []byte, asciiA, asciiB string) (string, string) {
+	resultA := make([]byte, 0, len(asciiA)*10)
+	resultB := make([]byte, 0, len(asciiB)*10)
+
+	for i := 0; i < len(asciiA) || i < len(asciiB); i++ {
+		var charA, charB byte = ' ', ' '
+		if i < len(asciiA) {
+			charA = asciiA[i]
+		}
+		if i < len(asciiB) {
+			charB = asciiB[i]
+		}
+
+		var byteA, byteB byte
+		if i < len(a) {
+			byteA = a[i]
+		}
+		if i < len(b) {
+			byteB = b[i]
+		}
+
+		if i < len(a) && i < len(b) && byteA != byteB {
+			resultA = append(resultA, []byte(visualizer.Colorize(string(charA), "red"))...)
+			resultB = append(resultB, []byte(visualizer.Colorize(string(charB), "green"))...)
+		} else if i >= len(a) && i < len(b) {
+			resultA = append(resultA, ' ')
+			resultB = append(resultB, []byte(visualizer.Colorize(string(charB), "green"))...)
+		} else if i < len(a) && i >= len(b) {
+			resultA = append(resultA, []byte(visualizer.Colorize(string(charA), "red"))...)
+			resultB = append(resultB, ' ')
+		} else {
+			resultA = append(resultA, charA)
+			resultB = append(resultB, charB)
+		}
+	}
+
+	return string(resultA), string(resultB)
+}
+
+func printDiffSummary(result *snapshot.MemoryDiffResult) {
+	sep := strings.Repeat("─", 78)
+	fmt.Println(visualizer.Colorize(sep, "dim"))
+	fmt.Println()
+	fmt.Printf("  %s Summary\n", visualizer.Colorize("──", "bold"))
+	fmt.Printf("  Snapshot A size: %d bytes\n", result.SizeA)
+	fmt.Printf("  Snapshot B size: %d bytes\n", result.SizeB)
+	fmt.Printf("  Total changed:   %s bytes\n", visualizer.Colorize(fmt.Sprintf("%d", result.TotalChanged), "yellow"))
+	fmt.Printf("  Changed regions: %d\n", len(result.ChangedRegions))
+	fmt.Println()
+}

--- a/internal/cmd/snapshot_diff_test.go
+++ b/internal/cmd/snapshot_diff_test.go
@@ -1,0 +1,231 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dotandev/hintents/internal/snapshot"
+)
+
+func TestSnapshotDiffIdentical(t *testing.T) {
+	tempDir := t.TempDir()
+
+	memory := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05}
+	encodedMem := base64.StdEncoding.EncodeToString(memory)
+
+	snapA := &snapshot.Snapshot{
+		LedgerEntries: []snapshot.LedgerEntryTuple{{"key", "val"}},
+		LinearMemory:  encodedMem,
+	}
+	snapB := &snapshot.Snapshot{
+		LedgerEntries: []snapshot.LedgerEntryTuple{{"key", "val"}},
+		LinearMemory:  encodedMem,
+	}
+
+	pathA := filepath.Join(tempDir, "a.json")
+	pathB := filepath.Join(tempDir, "b.json")
+
+	writeSnapshot(t, pathA, snapA)
+	writeSnapshot(t, pathB, snapB)
+
+	snapshotDiffAFlag = pathA
+	snapshotDiffBFlag = pathB
+	snapshotDiffOffsetFlag = -1
+	snapshotDiffLengthFlag = 0
+	snapshotDiffContextFlag = 16
+
+	output := captureOutput(t, func() {
+		err := runSnapshotDiff(nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "identical") {
+		t.Errorf("expected 'identical' in output, got: %s", output)
+	}
+}
+
+func TestSnapshotDiffWithChanges(t *testing.T) {
+	tempDir := t.TempDir()
+
+	memoryA := []byte{0x00, 0x01, 0x02, 0x03}
+	memoryB := []byte{0x00, 0xFF, 0x02, 0xAA}
+
+	snapA := &snapshot.Snapshot{
+		LedgerEntries: []snapshot.LedgerEntryTuple{},
+		LinearMemory:  base64.StdEncoding.EncodeToString(memoryA),
+	}
+	snapB := &snapshot.Snapshot{
+		LedgerEntries: []snapshot.LedgerEntryTuple{},
+		LinearMemory:  base64.StdEncoding.EncodeToString(memoryB),
+	}
+
+	pathA := filepath.Join(tempDir, "a.json")
+	pathB := filepath.Join(tempDir, "b.json")
+
+	writeSnapshot(t, pathA, snapA)
+	writeSnapshot(t, pathB, snapB)
+
+	snapshotDiffAFlag = pathA
+	snapshotDiffBFlag = pathB
+	snapshotDiffOffsetFlag = -1
+	snapshotDiffLengthFlag = 0
+	snapshotDiffContextFlag = 16
+
+	output := captureOutput(t, func() {
+		err := runSnapshotDiff(nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "changed") {
+		t.Errorf("expected 'changed' in output, got: %s", output)
+	}
+	if !strings.Contains(output, "2") {
+		t.Errorf("expected change count in output, got: %s", output)
+	}
+}
+
+func TestSnapshotDiffMissingFileA(t *testing.T) {
+	snapshotDiffAFlag = ""
+	snapshotDiffBFlag = "b.json"
+
+	err := runSnapshotDiff(nil, nil)
+	if err == nil {
+		t.Fatal("expected error for missing snapshot-a flag")
+	}
+}
+
+func TestSnapshotDiffMissingFileB(t *testing.T) {
+	snapshotDiffAFlag = "a.json"
+	snapshotDiffBFlag = ""
+
+	err := runSnapshotDiff(nil, nil)
+	if err == nil {
+		t.Fatal("expected error for missing snapshot-b flag")
+	}
+}
+
+func TestSnapshotDiffNoMemory(t *testing.T) {
+	tempDir := t.TempDir()
+
+	snapA := &snapshot.Snapshot{LedgerEntries: []snapshot.LedgerEntryTuple{}}
+	snapB := &snapshot.Snapshot{LedgerEntries: []snapshot.LedgerEntryTuple{}}
+
+	pathA := filepath.Join(tempDir, "a.json")
+	pathB := filepath.Join(tempDir, "b.json")
+
+	writeSnapshot(t, pathA, snapA)
+	writeSnapshot(t, pathB, snapB)
+
+	snapshotDiffAFlag = pathA
+	snapshotDiffBFlag = pathB
+	snapshotDiffOffsetFlag = -1
+	snapshotDiffLengthFlag = 0
+	snapshotDiffContextFlag = 16
+
+	output := captureOutput(t, func() {
+		err := runSnapshotDiff(nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "Neither snapshot contains linear memory") {
+		t.Errorf("expected no memory message, got: %s", output)
+	}
+}
+
+func TestSnapshotDiffWithOffset(t *testing.T) {
+	tempDir := t.TempDir()
+
+	memoryA := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}
+	memoryB := []byte{0x00, 0x01, 0xFF, 0xFF, 0x04, 0x05, 0x06, 0x07}
+
+	snapA := &snapshot.Snapshot{
+		LedgerEntries: []snapshot.LedgerEntryTuple{},
+		LinearMemory:  base64.StdEncoding.EncodeToString(memoryA),
+	}
+	snapB := &snapshot.Snapshot{
+		LedgerEntries: []snapshot.LedgerEntryTuple{},
+		LinearMemory:  base64.StdEncoding.EncodeToString(memoryB),
+	}
+
+	pathA := filepath.Join(tempDir, "a.json")
+	pathB := filepath.Join(tempDir, "b.json")
+
+	writeSnapshot(t, pathA, snapA)
+	writeSnapshot(t, pathB, snapB)
+
+	snapshotDiffAFlag = pathA
+	snapshotDiffBFlag = pathB
+	snapshotDiffOffsetFlag = 2
+	snapshotDiffLengthFlag = 4
+	snapshotDiffContextFlag = 16
+
+	output := captureOutput(t, func() {
+		err := runSnapshotDiff(nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "0x00000002") {
+		t.Errorf("expected offset 0x00000002 in output, got: %s", output)
+	}
+}
+
+func TestFormatHexAscii(t *testing.T) {
+	data := []byte{0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x00, 0x7f}
+	hex, ascii := formatHexAscii(data)
+
+	if !strings.HasPrefix(hex, "48 65 6c 6c 6f 00 7f") {
+		t.Errorf("unexpected hex: %s", hex)
+	}
+	if !strings.HasPrefix(ascii, "Hello..") {
+		t.Errorf("unexpected ascii: %s", ascii)
+	}
+}
+
+func writeSnapshot(t *testing.T, path string, snap *snapshot.Snapshot) {
+	t.Helper()
+	data, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal snapshot: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("failed to write snapshot: %v", err)
+	}
+}
+
+func captureOutput(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe error: %v", err)
+	}
+	os.Stdout = w
+
+	fn()
+
+	w.Close()
+	os.Stdout = orig
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("copy error: %v", err)
+	}
+	return buf.String()
+}

--- a/internal/snapshot/memory_diff.go
+++ b/internal/snapshot/memory_diff.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package snapshot
+
+// MemoryRegion represents a contiguous region of changed bytes.
+type MemoryRegion struct {
+	Offset int
+	Length int
+	BytesA []byte
+	BytesB []byte
+}
+
+// MemoryDiffResult holds the comparison result between two memory dumps.
+type MemoryDiffResult struct {
+	SizeA          int
+	SizeB          int
+	TotalChanged   int
+	ChangedRegions []MemoryRegion
+}
+
+// DiffMemory compares two byte slices and returns regions that differ.
+// It uses a chunked approach for efficiency with large memory segments.
+// Adjacent changed bytes within mergeThreshold are merged into single regions.
+func DiffMemory(a, b []byte, mergeThreshold int) *MemoryDiffResult {
+	if mergeThreshold <= 0 {
+		mergeThreshold = 16
+	}
+
+	result := &MemoryDiffResult{
+		SizeA: len(a),
+		SizeB: len(b),
+	}
+
+	maxLen := len(a)
+	if len(b) > maxLen {
+		maxLen = len(b)
+	}
+
+	if maxLen == 0 {
+		return result
+	}
+
+	var regions []MemoryRegion
+	var currentRegion *MemoryRegion
+	gapCount := 0
+
+	for i := 0; i < maxLen; i++ {
+		var byteA, byteB byte
+		var aValid, bValid bool
+
+		if i < len(a) {
+			byteA = a[i]
+			aValid = true
+		}
+		if i < len(b) {
+			byteB = b[i]
+			bValid = true
+		}
+
+		differs := (aValid != bValid) || (byteA != byteB)
+
+		if differs {
+			result.TotalChanged++
+
+			if currentRegion == nil {
+				currentRegion = &MemoryRegion{
+					Offset: i,
+					BytesA: []byte{},
+					BytesB: []byte{},
+				}
+			} else if gapCount > 0 {
+				// Fill gap with unchanged bytes to maintain continuous region
+				for j := i - gapCount; j < i; j++ {
+					if j < len(a) {
+						currentRegion.BytesA = append(currentRegion.BytesA, a[j])
+					} else {
+						currentRegion.BytesA = append(currentRegion.BytesA, 0)
+					}
+					if j < len(b) {
+						currentRegion.BytesB = append(currentRegion.BytesB, b[j])
+					} else {
+						currentRegion.BytesB = append(currentRegion.BytesB, 0)
+					}
+				}
+			}
+
+			if aValid {
+				currentRegion.BytesA = append(currentRegion.BytesA, byteA)
+			} else {
+				currentRegion.BytesA = append(currentRegion.BytesA, 0)
+			}
+			if bValid {
+				currentRegion.BytesB = append(currentRegion.BytesB, byteB)
+			} else {
+				currentRegion.BytesB = append(currentRegion.BytesB, 0)
+			}
+
+			currentRegion.Length = len(currentRegion.BytesA)
+			gapCount = 0
+		} else if currentRegion != nil {
+			gapCount++
+			if gapCount > mergeThreshold {
+				regions = append(regions, *currentRegion)
+				currentRegion = nil
+				gapCount = 0
+			}
+		}
+	}
+
+	if currentRegion != nil {
+		regions = append(regions, *currentRegion)
+	}
+
+	result.ChangedRegions = regions
+	return result
+}
+
+// DiffMemoryFull compares two byte slices and returns byte-by-byte differences
+// for a specified range. Used for detailed inspection of specific offsets.
+func DiffMemoryFull(a, b []byte, offset, length int) *MemoryDiffResult {
+	if offset < 0 {
+		offset = 0
+	}
+
+	maxLen := len(a)
+	if len(b) > maxLen {
+		maxLen = len(b)
+	}
+
+	if offset >= maxLen {
+		return &MemoryDiffResult{SizeA: len(a), SizeB: len(b)}
+	}
+
+	end := offset + length
+	if end > maxLen {
+		end = maxLen
+	}
+
+	var sliceA, sliceB []byte
+	if offset < len(a) {
+		endA := end
+		if endA > len(a) {
+			endA = len(a)
+		}
+		sliceA = a[offset:endA]
+	}
+	if offset < len(b) {
+		endB := end
+		if endB > len(b) {
+			endB = len(b)
+		}
+		sliceB = b[offset:endB]
+	}
+
+	// Pad to equal length
+	regionLen := end - offset
+	paddedA := make([]byte, regionLen)
+	paddedB := make([]byte, regionLen)
+	copy(paddedA, sliceA)
+	copy(paddedB, sliceB)
+
+	totalChanged := 0
+	for i := 0; i < regionLen; i++ {
+		if paddedA[i] != paddedB[i] {
+			totalChanged++
+		}
+	}
+
+	return &MemoryDiffResult{
+		SizeA:        len(a),
+		SizeB:        len(b),
+		TotalChanged: totalChanged,
+		ChangedRegions: []MemoryRegion{
+			{
+				Offset: offset,
+				Length: regionLen,
+				BytesA: paddedA,
+				BytesB: paddedB,
+			},
+		},
+	}
+}

--- a/internal/snapshot/memory_diff_test.go
+++ b/internal/snapshot/memory_diff_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package snapshot
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestDiffMemoryIdentical(t *testing.T) {
+	a := []byte{0x00, 0x01, 0x02, 0x03}
+	b := []byte{0x00, 0x01, 0x02, 0x03}
+
+	result := DiffMemory(a, b, 16)
+
+	if result.TotalChanged != 0 {
+		t.Errorf("expected 0 changed bytes, got %d", result.TotalChanged)
+	}
+	if len(result.ChangedRegions) != 0 {
+		t.Errorf("expected 0 regions, got %d", len(result.ChangedRegions))
+	}
+}
+
+func TestDiffMemorySingleChange(t *testing.T) {
+	a := []byte{0x00, 0x01, 0x02, 0x03}
+	b := []byte{0x00, 0xFF, 0x02, 0x03}
+
+	result := DiffMemory(a, b, 16)
+
+	if result.TotalChanged != 1 {
+		t.Errorf("expected 1 changed byte, got %d", result.TotalChanged)
+	}
+	if len(result.ChangedRegions) != 1 {
+		t.Fatalf("expected 1 region, got %d", len(result.ChangedRegions))
+	}
+	if result.ChangedRegions[0].Offset != 1 {
+		t.Errorf("expected offset 1, got %d", result.ChangedRegions[0].Offset)
+	}
+}
+
+func TestDiffMemoryMultipleRegions(t *testing.T) {
+	a := make([]byte, 100)
+	b := make([]byte, 100)
+	copy(b, a)
+
+	// Change bytes at positions 5 and 80 (far apart)
+	b[5] = 0xFF
+	b[80] = 0xAA
+
+	result := DiffMemory(a, b, 16)
+
+	if result.TotalChanged != 2 {
+		t.Errorf("expected 2 changed bytes, got %d", result.TotalChanged)
+	}
+	if len(result.ChangedRegions) != 2 {
+		t.Errorf("expected 2 regions due to large gap, got %d", len(result.ChangedRegions))
+	}
+}
+
+func TestDiffMemoryMergeAdjacentChanges(t *testing.T) {
+	a := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05}
+	b := []byte{0xFF, 0xFF, 0x02, 0x03, 0xFF, 0xFF}
+
+	result := DiffMemory(a, b, 16)
+
+	if result.TotalChanged != 4 {
+		t.Errorf("expected 4 changed bytes, got %d", result.TotalChanged)
+	}
+	// With merge threshold of 16, these should be merged into one region
+	if len(result.ChangedRegions) != 1 {
+		t.Errorf("expected 1 merged region, got %d", len(result.ChangedRegions))
+	}
+}
+
+func TestDiffMemoryDifferentSizes(t *testing.T) {
+	a := []byte{0x00, 0x01, 0x02}
+	b := []byte{0x00, 0x01, 0x02, 0x03, 0x04}
+
+	result := DiffMemory(a, b, 16)
+
+	if result.SizeA != 3 {
+		t.Errorf("expected SizeA 3, got %d", result.SizeA)
+	}
+	if result.SizeB != 5 {
+		t.Errorf("expected SizeB 5, got %d", result.SizeB)
+	}
+	if result.TotalChanged != 2 {
+		t.Errorf("expected 2 changed bytes (extra in B), got %d", result.TotalChanged)
+	}
+}
+
+func TestDiffMemoryEmpty(t *testing.T) {
+	result := DiffMemory(nil, nil, 16)
+
+	if result.TotalChanged != 0 {
+		t.Errorf("expected 0 changed bytes, got %d", result.TotalChanged)
+	}
+}
+
+func TestDiffMemoryFullRange(t *testing.T) {
+	a := []byte{0x00, 0x01, 0x02, 0x03, 0x04}
+	b := []byte{0x00, 0xFF, 0x02, 0xFF, 0x04}
+
+	result := DiffMemoryFull(a, b, 0, 5)
+
+	if result.TotalChanged != 2 {
+		t.Errorf("expected 2 changed bytes, got %d", result.TotalChanged)
+	}
+	if len(result.ChangedRegions) != 1 {
+		t.Fatalf("expected 1 full region, got %d", len(result.ChangedRegions))
+	}
+	if result.ChangedRegions[0].Offset != 0 {
+		t.Errorf("expected offset 0, got %d", result.ChangedRegions[0].Offset)
+	}
+	if result.ChangedRegions[0].Length != 5 {
+		t.Errorf("expected length 5, got %d", result.ChangedRegions[0].Length)
+	}
+}
+
+func TestDiffMemoryFullPartialRange(t *testing.T) {
+	a := []byte{0x00, 0x01, 0x02, 0x03, 0x04}
+	b := []byte{0x00, 0xFF, 0x02, 0xFF, 0x04}
+
+	result := DiffMemoryFull(a, b, 1, 2)
+
+	if len(result.ChangedRegions) != 1 {
+		t.Fatalf("expected 1 region, got %d", len(result.ChangedRegions))
+	}
+	if result.ChangedRegions[0].Offset != 1 {
+		t.Errorf("expected offset 1, got %d", result.ChangedRegions[0].Offset)
+	}
+	if !bytes.Equal(result.ChangedRegions[0].BytesA, []byte{0x01, 0x02}) {
+		t.Errorf("unexpected BytesA: %v", result.ChangedRegions[0].BytesA)
+	}
+	if !bytes.Equal(result.ChangedRegions[0].BytesB, []byte{0xFF, 0x02}) {
+		t.Errorf("unexpected BytesB: %v", result.ChangedRegions[0].BytesB)
+	}
+}
+
+func TestDiffMemoryFullOutOfBounds(t *testing.T) {
+	a := []byte{0x00, 0x01}
+	b := []byte{0x00, 0x01}
+
+	result := DiffMemoryFull(a, b, 100, 10)
+
+	if len(result.ChangedRegions) != 0 {
+		t.Errorf("expected no regions for out of bounds, got %d", len(result.ChangedRegions))
+	}
+}


### PR DESCRIPTION
Closes #883
## Summary

- Adds `erst snapshot-diff` command for comparing linear memory between two snapshot files
- Implements efficient memory diffing that merges adjacent changed regions
- Displays side-by-side HEX/ASCII output with color-coded differences

## Root Cause

The debugger lacked the ability to compare memory state at different execution points, making it difficult to debug state-related bugs in contracts.

## Fix Implemented

Added four new files:
- `internal/snapshot/memory_diff.go` - Memory comparison logic with chunked diffing
- `internal/snapshot/memory_diff_test.go` - Unit tests
- `internal/cmd/snapshot_diff.go` - CLI command with flags for snapshot-a, snapshot-b, offset, length, context
- `internal/cmd/snapshot_diff_test.go` - CLI tests

Usage:
```bash
# Compare two snapshots
erst snapshot-diff --snapshot-a before.json --snapshot-b after.json

# Compare specific memory region
erst snapshot-diff --snapshot-a before.json --snapshot-b after.json --offset 0x100 --length 256