### PR TITLE
[#892] [CLI] Implement erst search for finding contracts by symbol or ID

### DIFF
--- a/internal/cmd/search.go
+++ b/internal/cmd/search.go
@@ -5,6 +5,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,6 +20,7 @@ var (
 	searchLimitFlag      int
 	searchNetworkFlag    string
 	searchHorizonURLFlag string
+	searchMaxPagesFlag   int
 )
 
 var searchCmd = &cobra.Command{
@@ -29,7 +32,12 @@ var searchCmd = &cobra.Command{
 The query is matched against:
   - contract symbol (when available from Horizon metadata)
   - creator/sponsor account address
-  - partial contract ID`,
+  - partial contract ID
+
+Search walks Horizon contract pages with a bounded scan (see --max-pages). Results can be
+incomplete on large networks; a warning is printed when the scan stops before the catalog ends.
+
+For a full Stellar account strkey (56 characters starting with G), Horizon sponsor= filtering is used when supported.`,
 	Example: `  # Find token contracts by symbol
   erst search usdc --network testnet
 
@@ -37,7 +45,10 @@ The query is matched against:
   erst search GABCDEF... --network testnet
 
   # Find contracts by partial contract ID
-  erst search CAXYZ --network testnet`,
+  erst search CAXYZ --network testnet
+
+  # Increase page walk limit (default scales with ERST_CONTRACT_SEARCH_MAX_PAGES)
+  erst search usdc --network testnet --max-pages 50`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		network := strings.TrimSpace(searchNetworkFlag)
@@ -64,23 +75,36 @@ The query is matched against:
 			}
 		}
 
-		results, err := rpc.SearchContracts(cmd.Context(), rpc.SearchContractsOptions{
+		maxPages := searchMaxPagesFlag
+		if maxPages == 0 {
+			if v := strings.TrimSpace(os.Getenv("ERST_CONTRACT_SEARCH_MAX_PAGES")); v != "" {
+				if n, err := strconv.Atoi(v); err == nil && n > 0 {
+					maxPages = n
+				}
+			}
+		}
+
+		res, err := rpc.SearchContracts(cmd.Context(), rpc.SearchContractsOptions{
 			Query:      args[0],
 			HorizonURL: horizonURL,
 			Limit:      searchLimitFlag,
 			Timeout:    time.Duration(cfg.RequestTimeout) * time.Second,
+			MaxPages:   maxPages,
 		})
 		if err != nil {
 			return fmt.Errorf("search failed: %w", err)
 		}
 
-		if len(results) == 0 {
+		if len(res.Results) == 0 {
 			fmt.Println("No matching contracts found.")
+			if res.IncompleteScan {
+				printContractSearchIncompleteWarning(res)
+			}
 			return nil
 		}
 
-		fmt.Printf("Found %d matching contracts on %s:\n", len(results), network)
-		for _, contract := range results {
+		fmt.Printf("Found %d matching contracts on %s:\n", len(res.Results), network)
+		for _, contract := range res.Results {
 			fmt.Println("--------------------------------------------------")
 			fmt.Printf("Contract ID: %s\n", contract.ID)
 			if contract.Symbol != "" {
@@ -97,13 +121,23 @@ The query is matched against:
 			}
 		}
 		fmt.Println("--------------------------------------------------")
+
+		if res.IncompleteScan {
+			printContractSearchIncompleteWarning(res)
+		}
 		return nil
 	},
+}
+
+func printContractSearchIncompleteWarning(res *rpc.SearchContractsResult) {
+	fmt.Fprintf(os.Stderr, "Warning: contract search stopped after scanning %d contract row(s) from Horizon; additional matches may exist on the network (scan budget ≤ %d rows). Increase --max-pages or set ERST_CONTRACT_SEARCH_MAX_PAGES.\n",
+		res.ScannedRecords, res.MaxScanBudget)
 }
 
 func init() {
 	searchCmd.Flags().IntVar(&searchLimitFlag, "limit", 10, "Maximum number of results to return")
 	searchCmd.Flags().StringVarP(&searchNetworkFlag, "network", "n", string(rpc.Testnet), "Stellar network to search (testnet, mainnet, futurenet)")
+	searchCmd.Flags().IntVar(&searchMaxPagesFlag, "max-pages", 0, "Maximum Horizon pages to scan (0 = default or ERST_CONTRACT_SEARCH_MAX_PAGES)")
 	searchCmd.Flags().StringVar(&searchHorizonURLFlag, "horizon-url", "", "Override Horizon URL (advanced)")
 	_ = searchCmd.Flags().MarkHidden("horizon-url")
 	_ = searchCmd.RegisterFlagCompletionFunc("network", completeNetworkFlag)

--- a/internal/cmd/search_test.go
+++ b/internal/cmd/search_test.go
@@ -42,7 +42,8 @@ func TestSearchCommand_EmptyQueryRejectedByRPCLayer(t *testing.T) {
 	searchHorizonURLFlag = "http://127.0.0.1:1"
 
 	// Ensure we call RunE directly (cobra args validation is tested separately).
-	err := searchCmd.RunEContext(context.Background(), searchCmd, []string{""})
+	searchCmd.SetContext(context.Background())
+	err := searchCmd.RunE(searchCmd, []string{""})
 	if err == nil {
 		t.Fatal("expected empty query to fail")
 	}

--- a/internal/rpc/contract_search.go
+++ b/internal/rpc/contract_search.go
@@ -16,23 +16,48 @@ import (
 )
 
 const (
-	defaultContractSearchLimit = 20
-	maxContractSearchPages     = 5
+	defaultContractSearchLimit    = 20
+	defaultContractSearchPages      = 20
+	defaultContractSearchPageSize   = 200
+	maxContractSearchPagesHardCap   = 500
+	stellarStrkeyAccountMinLen      = 56
 )
 
+// SearchContractsOptions configures contract discovery against Horizon /contracts.
 type SearchContractsOptions struct {
 	Query      string
 	HorizonURL string
 	Limit      int
 	Timeout    time.Duration
+	// MaxPages is the maximum number of Horizon pages to walk (each page is up to PageSize records).
+	// Zero means default (defaultContractSearchPages).
+	MaxPages int
+	// PageSize is the Horizon "limit" per page (max 200). Zero means defaultContractSearchPageSize.
+	PageSize int
 }
 
+// ContractSummary is a normalized contract row from Horizon contract list JSON.
 type ContractSummary struct {
 	ID                 string
 	Symbol             string
 	Creator            string
 	LastModifiedLedger int64
 	LastModifiedTime   string
+}
+
+// SearchContractsResult is returned by SearchContracts. It includes match rows plus
+// scan metadata so callers can warn when results may be incomplete at scale.
+type SearchContractsResult struct {
+	Results []ContractSummary
+	// IncompleteScan is true when pagination stopped due to MaxPages while Horizon still
+	// advertised a next page — matches may exist beyond the scanned window.
+	IncompleteScan bool
+	// ScannedRecords is the number of contract rows examined across all pages (client-side filter input size).
+	ScannedRecords int
+	// MaxScanBudget is MaxPages * PageSize (upper bound on rows fetched from Horizon for this search).
+	MaxScanBudget int
+	// ServerSponsorFilter is true when the request used Horizon's sponsor= filter (account-shaped query).
+	ServerSponsorFilter bool
 }
 
 type horizonContractsPage struct {
@@ -46,7 +71,9 @@ type horizonContractsPage struct {
 	} `json:"_links"`
 }
 
-func SearchContracts(ctx context.Context, options SearchContractsOptions) ([]ContractSummary, error) {
+// SearchContracts walks Horizon /contracts pages, applies client-side matching for symbol / partial ID,
+// and uses sponsor= when the query looks like a full Stellar account (strkey) for server-side filtering.
+func SearchContracts(ctx context.Context, options SearchContractsOptions) (*SearchContractsResult, error) {
 	query := strings.TrimSpace(options.Query)
 	if query == "" {
 		return nil, fmt.Errorf("query cannot be empty")
@@ -62,36 +89,75 @@ func SearchContracts(ctx context.Context, options SearchContractsOptions) ([]Con
 		limit = defaultContractSearchLimit
 	}
 
+	maxPages := options.MaxPages
+	if maxPages <= 0 {
+		maxPages = defaultContractSearchPages
+	}
+	if maxPages > maxContractSearchPagesHardCap {
+		maxPages = maxContractSearchPagesHardCap
+	}
+
+	pageSize := options.PageSize
+	if pageSize <= 0 {
+		pageSize = defaultContractSearchPageSize
+	}
+	if pageSize > 200 {
+		pageSize = 200
+	}
+
 	timeout := options.Timeout
 	if timeout <= 0 {
 		timeout = 15 * time.Second
 	}
 
+	useSponsor := looksLikeStellarAccountStrkey(query)
 	client := &http.Client{Timeout: timeout}
-	nextURL := buildContractsURL(horizonURL)
+	nextURL := buildContractsURL(horizonURL, query, pageSize, useSponsor)
 	results := make([]ContractSummary, 0, limit)
+	scanned := 0
+	var lastNext string
 
-	for page := 0; page < maxContractSearchPages && nextURL != ""; page++ {
-		pageResults, next, err := fetchContractPage(ctx, client, nextURL, query, limit-len(results))
+	for page := 0; page < maxPages && nextURL != ""; page++ {
+		pageResults, next, nRecords, err := fetchContractPage(ctx, client, nextURL, query, limit-len(results))
 		if err != nil {
 			return nil, err
 		}
+		scanned += nRecords
+		lastNext = next
 		results = append(results, pageResults...)
 		if len(results) >= limit {
-			return results[:limit], nil
+			// Filled the user's --limit; if Horizon still has more pages, matches may exist beyond this window.
+			hitLimitWithMore := strings.TrimSpace(next) != ""
+			return &SearchContractsResult{
+				Results:             results[:limit],
+				IncompleteScan:      hitLimitWithMore,
+				ScannedRecords:      scanned,
+				MaxScanBudget:       maxPages * pageSize,
+				ServerSponsorFilter: useSponsor,
+			}, nil
 		}
 		nextURL = next
 	}
 
-	return results, nil
+	incomplete := strings.TrimSpace(lastNext) != ""
+	return &SearchContractsResult{
+		Results:             results,
+		IncompleteScan:      incomplete,
+		ScannedRecords:      scanned,
+		MaxScanBudget:       maxPages * pageSize,
+		ServerSponsorFilter: useSponsor,
+	}, nil
 }
 
-func buildContractsURL(horizonURL string) string {
+func buildContractsURL(horizonURL, query string, pageSize int, sponsorFilter bool) string {
 	u, _ := url.Parse(horizonURL)
 	u.Path = path.Join(u.Path, "contracts")
 	values := u.Query()
-	values.Set("limit", strconv.Itoa(200))
+	values.Set("limit", strconv.Itoa(pageSize))
 	values.Set("order", "desc")
+	if sponsorFilter && looksLikeStellarAccountStrkey(query) {
+		values.Set("sponsor", query)
+	}
 	u.RawQuery = values.Encode()
 	return u.String()
 }
@@ -102,27 +168,28 @@ func fetchContractPage(
 	pageURL string,
 	query string,
 	remaining int,
-) ([]ContractSummary, string, error) {
+) ([]ContractSummary, string, int, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL, nil)
 	if err != nil {
-		return nil, "", fmt.Errorf("build request: %w", err)
+		return nil, "", 0, fmt.Errorf("build request: %w", err)
 	}
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, "", fmt.Errorf("fetch contracts: %w", err)
+		return nil, "", 0, fmt.Errorf("fetch contracts: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return nil, "", fmt.Errorf("contracts endpoint returned HTTP %d", resp.StatusCode)
+		return nil, "", 0, fmt.Errorf("contracts endpoint returned HTTP %d", resp.StatusCode)
 	}
 
 	var page horizonContractsPage
 	if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
-		return nil, "", fmt.Errorf("decode contracts response: %w", err)
+		return nil, "", 0, fmt.Errorf("decode contracts response: %w", err)
 	}
 
+	nRecords := len(page.Embedded.Records)
 	matches := make([]ContractSummary, 0, remaining)
 	for _, raw := range page.Embedded.Records {
 		summary := normalizeContractSummary(raw)
@@ -134,7 +201,8 @@ func fetchContractPage(
 		}
 	}
 
-	return matches, page.Links.Next.Href, nil
+	next := page.Links.Next.Href
+	return matches, next, nRecords, nil
 }
 
 func normalizeContractSummary(raw map[string]any) ContractSummary {
@@ -160,6 +228,25 @@ func matchesQuery(summary ContractSummary, query string) bool {
 		}
 	}
 	return false
+}
+
+// looksLikeStellarAccountStrkey returns true for a classic account strkey (G…, 56 chars).
+func looksLikeStellarAccountStrkey(s string) bool {
+	s = strings.TrimSpace(s)
+	if len(s) != stellarStrkeyAccountMinLen {
+		return false
+	}
+	if s[0] != 'G' {
+		return false
+	}
+	for i := 1; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' || c >= '2' && c <= '7' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func stringValue(v any) string {

--- a/internal/rpc/contract_search_test.go
+++ b/internal/rpc/contract_search_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -52,8 +53,8 @@ func TestSearchContracts_MatchesBySymbolCreatorAndPartialID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("search by symbol failed: %v", err)
 	}
-	if len(bySymbol) != 1 || bySymbol[0].ID != "CAAA111" {
-		t.Fatalf("unexpected symbol results: %+v", bySymbol)
+	if len(bySymbol.Results) != 1 || bySymbol.Results[0].ID != "CAAA111" {
+		t.Fatalf("unexpected symbol results: %+v", bySymbol.Results)
 	}
 
 	byCreator, err := SearchContracts(ctx, SearchContractsOptions{
@@ -64,8 +65,8 @@ func TestSearchContracts_MatchesBySymbolCreatorAndPartialID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("search by creator failed: %v", err)
 	}
-	if len(byCreator) != 1 || byCreator[0].ID != "CBBB222" {
-		t.Fatalf("unexpected creator results: %+v", byCreator)
+	if len(byCreator.Results) != 1 || byCreator.Results[0].ID != "CBBB222" {
+		t.Fatalf("unexpected creator results: %+v", byCreator.Results)
 	}
 
 	byPartialID, err := SearchContracts(ctx, SearchContractsOptions{
@@ -76,8 +77,8 @@ func TestSearchContracts_MatchesBySymbolCreatorAndPartialID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("search by id failed: %v", err)
 	}
-	if len(byPartialID) != 1 || byPartialID[0].ID != "CAAA111" {
-		t.Fatalf("unexpected partial id results: %+v", byPartialID)
+	if len(byPartialID.Results) != 1 || byPartialID.Results[0].ID != "CAAA111" {
+		t.Fatalf("unexpected partial id results: %+v", byPartialID.Results)
 	}
 }
 
@@ -106,7 +107,92 @@ func TestSearchContracts_RespectsLimit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("search failed: %v", err)
 	}
-	if len(results) != 2 {
-		t.Fatalf("expected 2 results, got %d", len(results))
+	if len(results.Results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results.Results))
+	}
+}
+
+func TestSearchContracts_IncompleteScanWhenNextLinkPresent(t *testing.T) {
+	nextURL := ""
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"_embedded": map[string]any{
+				"records": []map[string]any{
+					{"id": "CX1", "symbol": "NOPE", "creator": "G1"},
+				},
+			},
+			"_links": map[string]any{
+				"next": map[string]any{"href": nextURL},
+			},
+		})
+	}))
+	defer server.Close()
+	nextURL = server.URL + "/contracts?cursor=abc"
+
+	res, err := SearchContracts(context.Background(), SearchContractsOptions{
+		Query:      "missing",
+		HorizonURL: server.URL,
+		Limit:      5,
+		MaxPages:   1,
+	})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	if !res.IncompleteScan {
+		t.Fatal("expected IncompleteScan when next link is set and max pages reached")
+	}
+	if res.ScannedRecords != 1 {
+		t.Fatalf("ScannedRecords = %d, want 1", res.ScannedRecords)
+	}
+}
+
+func TestSearchContracts_SponsorServerFilterForAccountStrkey(t *testing.T) {
+	account := "G" + strings.Repeat("A", 55)
+	var sawSponsor string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawSponsor = r.URL.Query().Get("sponsor")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"_embedded": map[string]any{
+				"records": []map[string]any{
+					{"id": "CC1", "symbol": "X", "creator": account, "sponsor": account},
+				},
+			},
+			"_links": map[string]any{
+				"next": map[string]any{"href": ""},
+			},
+		})
+	}))
+	defer server.Close()
+
+	res, err := SearchContracts(context.Background(), SearchContractsOptions{
+		Query:      account,
+		HorizonURL: server.URL,
+		Limit:      10,
+	})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	if sawSponsor != account {
+		t.Fatalf("sponsor query param = %q, want %q", sawSponsor, account)
+	}
+	if !res.ServerSponsorFilter {
+		t.Fatal("expected ServerSponsorFilter true")
+	}
+	if len(res.Results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(res.Results))
+	}
+}
+
+func TestLooksLikeStellarAccountStrkey(t *testing.T) {
+	acct := "G" + strings.Repeat("A", 55)
+	if !looksLikeStellarAccountStrkey(acct) {
+		t.Fatal("expected valid account strkey shape")
+	}
+	contract := "C" + strings.Repeat("A", 55)
+	if looksLikeStellarAccountStrkey(contract) {
+		t.Fatal("contract strkey must not match account check")
+	}
+	if looksLikeStellarAccountStrkey("GSHORT") {
+		t.Fatal("short string must not match")
 	}
 }


### PR DESCRIPTION
## Summary
- implement `erst search <query>` for contract discovery by symbol, creator address, or partial contract ID
- add Horizon contract search client in `internal/rpc` with pagination, filtering, and summary normalization
- add command and RPC tests covering matching behavior and limits

## Related Issues
Closes #892

## Testing
- Unable to run local Go tests/build in this environment because `go`/`gofmt` are not installed in PATH.