### PR TITLE
fix: use forward slashes in config and registry paths to avoid Window…

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -22,6 +22,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func joinPath(parts ...string) string {
+	return strings.Join(parts, "/")
+}
+
 // DependencyID is a unique identifier for each dependency (Issue #8: type-safe dispatch)
 type DependencyID string
 
@@ -322,7 +326,7 @@ func checkCacheDir(verbose bool) DependencyStatus {
 		return dep
 	}
 
-	cacheDir := filepath.Join(homeDir, ".erst")
+	cacheDir := joinPath(homeDir, ".erst")
 
 	// Check if cache directory exists
 	if _, err := os.Stat(cacheDir); err != nil {
@@ -336,7 +340,7 @@ func checkCacheDir(verbose bool) DependencyStatus {
 	// Verify subdirectories exist
 	requiredDirs := []string{"transactions", "protocols", "contracts"}
 	for _, subdir := range requiredDirs {
-		path := filepath.Join(cacheDir, subdir)
+		path := joinPath(cacheDir, subdir)
 		if _, err := os.Stat(path); err != nil {
 			dep.FixHint = fmt.Sprintf("Missing subdirectory: %s", subdir)
 			return dep
@@ -364,7 +368,7 @@ func checkProtocolRegistry(verbose bool) DependencyStatus {
 		return dep
 	}
 
-	registryFile := filepath.Join(homeDir, ".erst", "protocols", "registered.json")
+	registryFile := joinPath(homeDir, ".erst", "protocols", "registered.json")
 
 	// Check if registry file exists and is valid
 	if _, err := os.Stat(registryFile); err != nil {
@@ -435,7 +439,7 @@ func checkConfigTOML(verbose bool) DependencyStatus {
 
 	paths := []string{
 		".erst.toml",
-		filepath.Join(os.ExpandEnv("$HOME"), ".erst.toml"),
+		joinPath(os.ExpandEnv("$HOME"), ".erst.toml"),
 		"/etc/erst/config.toml",
 	}
 

--- a/internal/cmd/doctor_test.go
+++ b/internal/cmd/doctor_test.go
@@ -416,20 +416,51 @@ func TestCheckDeepLink_VerbosePath(t *testing.T) {
 	}
 }
 
-// TestBuildDeepLinkFixHint_Empty verifies the fallback message when no steps
+// TestBuildDeepLinkFixHint_NilSteps verifies the fallback message when nil steps
 // are provided.
-func TestBuildDeepLinkFixHint_Empty(t *testing.T) {
+func TestBuildDeepLinkFixHint_NilSteps(t *testing.T) {
 	hint := buildDeepLinkFixHint(nil)
 	if hint == "" {
 		t.Error("buildDeepLinkFixHint(nil) must return a non-empty fallback hint")
 	}
 }
 
-// TestBuildDeepLinkFixHint_UsesFirstStep verifies that the first step is used.
-func TestBuildDeepLinkFixHint_UsesFirstStep(t *testing.T) {
-	steps := []string{"step one", "step two"}
+// TestBuildDeepLinkFixHint_OneStep verifies that the only step is returned.
+func TestBuildDeepLinkFixHint_OneStep(t *testing.T) {
+	steps := []string{"step one"}
 	hint := buildDeepLinkFixHint(steps)
 	if hint != "step one" {
 		t.Errorf("buildDeepLinkFixHint() = %q, want %q", hint, "step one")
+	}
+}
+
+// TestBuildDeepLinkFixHint_FiveSteps verifies that the first step is returned.
+func TestBuildDeepLinkFixHint_FiveSteps(t *testing.T) {
+	steps := []string{"step one", "step two", "step three", "step four", "step five"}
+	hint := buildDeepLinkFixHint(steps)
+	if hint != "step one" {
+		t.Errorf("buildDeepLinkFixHint() = %q, want %q", hint, "step one")
+	}
+}
+
+// TestBuildDeepLinkFixHint_AlwaysReturnsMeaningfulString verifies that all
+// cases (nil, 1 step, 5 steps) always return a meaningful (non-empty) string.
+func TestBuildDeepLinkFixHint_AlwaysReturnsMeaningfulString(t *testing.T) {
+	cases := []struct {
+		name  string
+		steps []string
+	}{
+		{"nil steps", nil},
+		{"one step", []string{"do this first"}},
+		{"five steps", []string{"step 1", "step 2", "step 3", "step 4", "step 5"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hint := buildDeepLinkFixHint(tc.steps)
+			if hint == "" {
+				t.Errorf("buildDeepLinkFixHint(%v) returned empty string, want non-empty", tc.steps)
+			}
+		})
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,9 +8,14 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/dotandev/hintents/internal/errors"
 )
+
+func joinPath(parts ...string) string {
+	return strings.Join(parts, "/")
+}
 
 // -- Interfaces --
 
@@ -89,7 +94,7 @@ var defaultConfig = &Config{
 	Network:        NetworkTestnet,
 	SimulatorPath:  "",
 	LogLevel:       "info",
-	CachePath:      filepath.Join(os.ExpandEnv("$HOME"), ".erst", "cache"),
+	CachePath:      joinPath(os.ExpandEnv("$HOME"), ".erst", "cache"),
 	RequestTimeout: defaultRequestTimeout,
 	MaxCacheSize:   0,
 	MaxTraceDepth:  50,
@@ -212,7 +217,7 @@ func GetGeneralConfigPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(home, ".erst", "config.json"), nil
+	return joinPath(home, ".erst", "config.json"), nil
 }
 
 func LoadConfig() (*Config, error) {


### PR DESCRIPTION
closes #1190

                                                                                                                                                                                                                                          Summary                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 - Replace filepath.Join with joinPath helper that uses forward slashes for config files and registry entries                                                                                                                                - This prevents mixed slash errors (e.g., C:\Users/...) on Windows where filepath.Join uses backslashes                                                                                                                                                                                                                                                                                                                                                                                 Files changed                                                                                                                                                                                                                                                                                                                                                                                                                                                                           - internal/config/config.go: Fixed paths for CachePath (line 92) and config.json (line 215)                                                                                                                                                 - internal/cmd/doctor.go: Fixed paths for cache directory, subdirectories, protocol registry file, and TOML config                                                                                                                          - internal/cmd/doctor_test.go: Added test cases for nil, 1 step, and 5 steps scenarios to verify buildDeepLinkFixHint always returns a meaningful string                                                                                                               