### PR TITLE
feat(wat): add event cross-reference to WASM instruction offsets

### DIFF
--- a/internal/wat/disassembler.go
+++ b/internal/wat/disassembler.go
@@ -16,6 +16,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"strconv"
 	"strings"
 )
 
@@ -292,6 +293,78 @@ func FormatFallback(wasmBytes []byte, failingOffset uint64, contextLines int) st
 	fmt.Fprintf(&b, "\nFailing instruction at offset 0x%x\n", failingOffset)
 
 	return b.String()
+}
+
+// =============================================================================
+// Event cross-referencing
+// =============================================================================
+
+// DiagnosticEventSource is the minimal interface required to cross-reference
+// a diagnostic event against WASM instructions. It matches the WasmInstruction
+// field emitted by the Soroban simulator (a decimal byte-offset string).
+type DiagnosticEventSource interface {
+	// GetWasmInstruction returns the raw WasmInstruction string pointer from
+	// the event, or nil if the event carries no instruction offset.
+	GetWasmInstruction() *string
+}
+
+// EventRef pairs a diagnostic event with the WASM instruction it maps to.
+type EventRef struct {
+	// EventIndex is the position of the event in the original slice.
+	EventIndex int
+	// Offset is the parsed WASM byte offset from the event's WasmInstruction field.
+	Offset uint64
+	// Instruction is the decoded WASM instruction at that offset, or nil if the
+	// offset could not be resolved against the binary.
+	Instruction *Instruction
+}
+
+// CrossReferenceEvents maps each event in events to the WASM instruction at
+// the offset encoded in its WasmInstruction field. Events without a
+// WasmInstruction field are skipped. The returned slice preserves the order of
+// the input events and only contains entries for events that carry an offset.
+//
+// wasmBytes must be a valid WASM module; if it is not, an error is returned
+// before any events are processed.
+func CrossReferenceEvents(wasmBytes []byte, events []DiagnosticEventSource) ([]EventRef, error) {
+	d := NewDisassembler(wasmBytes)
+	if !d.IsValidWasm() {
+		return nil, fmt.Errorf("not a valid WASM module")
+	}
+
+	instructions, err := d.DecodeAll()
+	if err != nil {
+		return nil, fmt.Errorf("decode instructions: %w", err)
+	}
+
+	// Build an offset → instruction index map for O(1) lookup.
+	offsetIndex := make(map[uint64]int, len(instructions))
+	for i, inst := range instructions {
+		offsetIndex[inst.Offset] = i
+	}
+
+	var refs []EventRef
+	for i, ev := range events {
+		raw := ev.GetWasmInstruction()
+		if raw == nil || *raw == "" {
+			continue
+		}
+		offset, err := strconv.ParseUint(*raw, 10, 64)
+		if err != nil {
+			// Unparseable offset — include the ref with a nil instruction so
+			// callers can still see which event had a bad offset.
+			refs = append(refs, EventRef{EventIndex: i, Offset: 0})
+			continue
+		}
+		ref := EventRef{EventIndex: i, Offset: offset}
+		if idx, ok := offsetIndex[offset]; ok {
+			inst := instructions[idx]
+			ref.Instruction = &inst
+		}
+		refs = append(refs, ref)
+	}
+
+	return refs, nil
 }
 
 // =============================================================================

--- a/internal/wat/disassembler_test.go
+++ b/internal/wat/disassembler_test.go
@@ -4,6 +4,7 @@
 package wat
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -567,5 +568,164 @@ func TestDecodeBlockType_Empty(t *testing.T) {
 	bt, n := decodeBlockType([]byte{})
 	if bt != "" || n != 0 {
 		t.Errorf("empty block: got %q, %d", bt, n)
+	}
+}
+
+// =============================================================================
+// CrossReferenceEvents Tests
+// =============================================================================
+
+// testEvent is a minimal DiagnosticEventSource for testing.
+type testEvent struct{ wasmInstruction *string }
+
+func (e *testEvent) GetWasmInstruction() *string { return e.wasmInstruction }
+
+func strPtr(s string) *string { return &s }
+
+func TestCrossReferenceEvents_Basic(t *testing.T) {
+	// Build a WASM with: i32.const 1, i32.add, drop
+	body := []byte{0x41, 0x01, 0x6a, 0x1a}
+	wasm := buildMinimalWasm(body)
+
+	d := NewDisassembler(wasm)
+	instructions, err := d.DecodeAll()
+	if err != nil {
+		t.Fatalf("DecodeAll: %v", err)
+	}
+
+	// Find the i32.add offset.
+	var addOffset uint64
+	for _, inst := range instructions {
+		if inst.Mnemonic == "i32.add" {
+			addOffset = inst.Offset
+			break
+		}
+	}
+
+	events := []DiagnosticEventSource{
+		&testEvent{wasmInstruction: strPtr(strconv.FormatUint(addOffset, 10))},
+	}
+
+	refs, err := CrossReferenceEvents(wasm, events)
+	if err != nil {
+		t.Fatalf("CrossReferenceEvents: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 ref, got %d", len(refs))
+	}
+	if refs[0].Instruction == nil {
+		t.Fatal("expected instruction to be resolved")
+	}
+	if refs[0].Instruction.Mnemonic != "i32.add" {
+		t.Errorf("expected 'i32.add', got %q", refs[0].Instruction.Mnemonic)
+	}
+	if refs[0].EventIndex != 0 {
+		t.Errorf("expected EventIndex 0, got %d", refs[0].EventIndex)
+	}
+}
+
+func TestCrossReferenceEvents_SkipsNilInstruction(t *testing.T) {
+	wasm := buildMinimalWasm([]byte{0x01}) // nop
+	events := []DiagnosticEventSource{
+		&testEvent{wasmInstruction: nil},
+		&testEvent{wasmInstruction: strPtr("")},
+	}
+	refs, err := CrossReferenceEvents(wasm, events)
+	if err != nil {
+		t.Fatalf("CrossReferenceEvents: %v", err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("expected 0 refs for nil/empty instructions, got %d", len(refs))
+	}
+}
+
+func TestCrossReferenceEvents_UnresolvableOffset(t *testing.T) {
+	wasm := buildMinimalWasm([]byte{0x01}) // nop
+	// Offset 9999 won't exist in this tiny module.
+	events := []DiagnosticEventSource{
+		&testEvent{wasmInstruction: strPtr("9999")},
+	}
+	refs, err := CrossReferenceEvents(wasm, events)
+	if err != nil {
+		t.Fatalf("CrossReferenceEvents: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 ref, got %d", len(refs))
+	}
+	if refs[0].Instruction != nil {
+		t.Error("expected nil instruction for unresolvable offset")
+	}
+	if refs[0].Offset != 9999 {
+		t.Errorf("expected offset 9999, got %d", refs[0].Offset)
+	}
+}
+
+func TestCrossReferenceEvents_InvalidWasm(t *testing.T) {
+	_, err := CrossReferenceEvents([]byte{0xFF, 0xFF}, []DiagnosticEventSource{})
+	if err == nil {
+		t.Error("expected error for invalid WASM")
+	}
+}
+
+func TestCrossReferenceEvents_MultipleEvents(t *testing.T) {
+	body := []byte{0x41, 0x01, 0x6a, 0x1a} // i32.const 1, i32.add, drop
+	wasm := buildMinimalWasm(body)
+
+	d := NewDisassembler(wasm)
+	instructions, err := d.DecodeAll()
+	if err != nil {
+		t.Fatalf("DecodeAll: %v", err)
+	}
+
+	// Collect offsets for i32.add and drop.
+	offsets := map[string]uint64{}
+	for _, inst := range instructions {
+		if inst.Mnemonic == "i32.add" || inst.Mnemonic == "drop" {
+			offsets[inst.Mnemonic] = inst.Offset
+		}
+	}
+
+	events := []DiagnosticEventSource{
+		&testEvent{wasmInstruction: nil}, // skipped
+		&testEvent{wasmInstruction: strPtr(strconv.FormatUint(offsets["i32.add"], 10))},
+		&testEvent{wasmInstruction: strPtr(strconv.FormatUint(offsets["drop"], 10))},
+	}
+
+	refs, err := CrossReferenceEvents(wasm, events)
+	if err != nil {
+		t.Fatalf("CrossReferenceEvents: %v", err)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("expected 2 refs, got %d", len(refs))
+	}
+	if refs[0].EventIndex != 1 {
+		t.Errorf("expected EventIndex 1, got %d", refs[0].EventIndex)
+	}
+	if refs[0].Instruction == nil || refs[0].Instruction.Mnemonic != "i32.add" {
+		t.Errorf("expected 'i32.add' for first ref")
+	}
+	if refs[1].EventIndex != 2 {
+		t.Errorf("expected EventIndex 2, got %d", refs[1].EventIndex)
+	}
+	if refs[1].Instruction == nil || refs[1].Instruction.Mnemonic != "drop" {
+		t.Errorf("expected 'drop' for second ref")
+	}
+}
+
+func TestCrossReferenceEvents_UnparsableOffset(t *testing.T) {
+	wasm := buildMinimalWasm([]byte{0x01})
+	events := []DiagnosticEventSource{
+		&testEvent{wasmInstruction: strPtr("not-a-number")},
+	}
+	refs, err := CrossReferenceEvents(wasm, events)
+	if err != nil {
+		t.Fatalf("CrossReferenceEvents: %v", err)
+	}
+	// Should still produce a ref with zero offset and nil instruction.
+	if len(refs) != 1 {
+		t.Fatalf("expected 1 ref, got %d", len(refs))
+	}
+	if refs[0].Instruction != nil {
+		t.Error("expected nil instruction for unparsable offset")
 	}
 }


### PR DESCRIPTION
Closes #1225

---

## Description
Adds `CrossReferenceEvents` to `internal/wat/disassembler.go`, mapping emitted diagnostic events back to their specific byte offset in the WASM binary.

## Changes
- `DiagnosticEventSource` interface — minimal contract for event types carrying a `WasmInstruction` offset string
- `EventRef` struct — pairs an event index with its parsed offset and resolved `Instruction`
- `CrossReferenceEvents(wasmBytes, events)` — decodes instructions once, builds an offset lookup map, and resolves each event to its instruction in O(1) per event

## Testing
Six new tests cover: basic resolution, nil/empty skip, unresolvable offset, invalid WASM, multiple events, and unparseable offset strings.

```
ok  github.com/dotandev/hintents/internal/wat  0.003s
```

## Checklist
- [x] Code follows style guidelines
- [x] Tests added
- [x] No new warnings or errors