### PR TITLE
feat(authtrace): track address-based authorization metadata

### DIFF
--- a/internal/authtrace/types.go
+++ b/internal/authtrace/types.go
@@ -36,6 +36,7 @@ type KeyWeight struct {
 
 type SignerInfo struct {
 	AccountID      string        `json:"account_id"`
+	Address        string        `json:"address,omitempty"` // Soroban account/contract address form.
 	SignerKey      string        `json:"signer_key"`
 	SignerType     SignatureType `json:"signer_type"`
 	Weight         uint32        `json:"weight"`
@@ -52,6 +53,7 @@ type AuthEvent struct {
 	Timestamp     int64             `json:"timestamp"`
 	EventType     string            `json:"event_type"`
 	AccountID     string            `json:"account_id"`
+	Address       string            `json:"address,omitempty"` // Supports account and contract addresses.
 	SignerKey     string            `json:"signer_key,omitempty"`
 	SignatureType SignatureType     `json:"signature_type,omitempty"`
 	Weight        uint32            `json:"weight,omitempty"`


### PR DESCRIPTION
## Summary
- Extend auth trace structures with optional address fields for signer and event records.
- Support account and contract address forms without breaking existing account-id behavior.
- Keep new fields immediately consumable by reporter paths through existing shared structs.

## Why
Soroban authorization flows include both account and contract address identities that should be preserved in trace output.

Closes #1215