### PR TITLE
fix(doctor): validate simulator executable via --version

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -291,24 +291,51 @@ func checkSimulator(verbose bool) DependencyStatus {
 
 	// Also check in PATH
 	if simPath, err := exec.LookPath("erst-sim"); err == nil {
-		dep.Installed = true
-		dep.Path = simPath
-		dep.Version = "in PATH"
-		return dep
+		versionOutput, validationErr := validateSimulatorBinary(simPath)
+		if validationErr == nil {
+			dep.Installed = true
+			dep.Path = simPath
+			dep.Version = strings.TrimSpace(versionOutput)
+			return dep
+		}
+		dep.FixHint = validationErr.Error()
 	}
 
 	// Check relative paths
 	for _, path := range possiblePaths {
 		if _, err := os.Stat(path); err == nil {
 			absPath, _ := filepath.Abs(path)
+			versionOutput, validationErr := validateSimulatorBinary(absPath)
+			if validationErr != nil {
+				dep.FixHint = validationErr.Error()
+				continue
+			}
 			dep.Installed = true
 			dep.Path = absPath
-			dep.Version = "local build"
+			dep.Version = strings.TrimSpace(versionOutput)
 			return dep
 		}
 	}
 
 	return dep
+}
+
+func validateSimulatorBinary(path string) (string, error) {
+	cmd := exec.Command(path, "--version")
+	output, err := cmd.CombinedOutput()
+	text := strings.TrimSpace(string(output))
+	if err != nil {
+		if text == "" {
+			return "", fmt.Errorf("erst-sim version check failed with non-zero exit code: %v", err)
+		}
+		return "", fmt.Errorf("erst-sim version check failed with non-zero exit code: %v (%s)", err, text)
+	}
+
+	if !strings.Contains(text, "erst-sim") {
+		return "", fmt.Errorf("erst-sim validation failed: --version output did not contain \"erst-sim\"")
+	}
+
+	return text, nil
 }
 
 // checkCacheDir verifies the cache directory exists (NEW: Issue #9)


### PR DESCRIPTION
## Summary
- Replace simulator file-existence checks with executable validation using cmd := exec.Command(path, \--version\).
- Require exit code 0 and output containing erst-sim before marking dependency as valid.
- Return clear failure hints for non-zero exits and invalid version output.

## Why
Functional checks prevent false positives where a binary exists but is invalid or not the expected simulator.

Closes #1185