### PR TITLE
#1189 [UX] Shorten Registry Paths

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -26,6 +26,25 @@ func joinPath(parts ...string) string {
 	return strings.Join(parts, "/")
 }
 
+// FriendlyPath replaces the user's home directory with ~ for better readability
+func FriendlyPath(path string) string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+
+	// Normalize both paths to use forward slashes for comparison
+	normalizedPath := filepath.ToSlash(path)
+	normalizedHomeDir := filepath.ToSlash(homeDir)
+
+	// Replace home directory with ~
+	if strings.HasPrefix(normalizedPath, normalizedHomeDir) {
+		return "~" + strings.TrimPrefix(normalizedPath, normalizedHomeDir)
+	}
+
+	return path
+}
+
 // DependencyID is a unique identifier for each dependency (Issue #8: type-safe dispatch)
 type DependencyID string
 
@@ -126,7 +145,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		fmt.Println()
 
 		if verbose && dep.Path != "" {
-			fmt.Printf("  Path: %s\n", dep.Path)
+			fmt.Printf("  Path: %s\n", FriendlyPath(dep.Path))
 		}
 
 		if !dep.Installed && dep.FixHint != "" {


### PR DESCRIPTION
closes #1189 

## Changes
- **File Modified:** doctor.go

### What's New
1. **New Helper Function: `FriendlyPath(path string) string`**
   - Replaces the user's home directory path with `~` for better readability
   - Safely handles errors if home directory cannot be determined
   - Uses `filepath.ToSlash()` for cross-platform path normalization
   - Returns the original path unchanged if home directory doesn't match

2. **Integration**
   - Updated the verbose diagnostic output to use `FriendlyPath()` when displaying dependency paths
   - Now when running `erst doctor --verbose`, paths like `/home/user/.erst` will display as `~/.erst`

## Example Output
**Before:**
```
Path: /home/username/.erst
Path: /home/username/.cargo/bin/rustc
```

**After:**
```
Path: ~/.erst
Path: ~/.cargo/bin/rustc
```

## Benefits
- More intuitive and concise path display
- Consistent with standard shell conventions
- Better user experience, especially for verbose diagnostics
- Cross-platform compatible (Windows, Linux, macOS)

## Testing
Run the diagnostic command with verbose flag to see the improvement:
```bash
./erst doctor --verbose
```

Paths will now display with `~` instead of the full home directory path.

## Files Changed
- doctor.go (+18 lines)

 thank you!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!