### PR TITLE
changed gas color coding on nodes

### DIFF
--- a/internal/visualizer/callgraph.go
+++ b/internal/visualizer/callgraph.go
@@ -21,6 +21,7 @@ func GenerateCallGraphSVG(root *decoder.CallNode) string {
 	nodeHeight := 80
 	horizontalGap := 40
 	verticalGap := 60
+	legendHeight := 56
 
 	// Track total dimensions and compute positions
 	positions := make(map[*decoder.CallNode][2]int) // node -> [x, y]
@@ -71,7 +72,7 @@ func GenerateCallGraphSVG(root *decoder.CallNode) string {
 
 	// Build SVG
 	var sb strings.Builder
-	fmt.Fprintf(&sb, `<svg viewBox="-20 -20 %d %d" xmlns="http://www.w3.org/2000/svg" font-family="Inter, system-ui, sans-serif">`, totalWidth+40, totalHeight+40)
+	fmt.Fprintf(&sb, `<svg viewBox="-20 -20 %d %d" xmlns="http://www.w3.org/2000/svg" font-family="Inter, system-ui, sans-serif">`, totalWidth+40, totalHeight+40+legendHeight+16)
 
 	// CSS for styling and dark mode
 	sb.WriteString(`
@@ -85,6 +86,12 @@ func GenerateCallGraphSVG(root *decoder.CallNode) string {
 		--link: #8c959f;
 		--cpu: #0969da;
 		--mem: #1a7f37;
+		--gas-low-bg: #e6f4ea;
+		--gas-mid-bg: #fff3cd;
+		--gas-high-bg: #ffeef0;
+		--gas-low-swatch: #1a7f37;
+		--gas-mid-swatch: #d4a017;
+		--gas-high-swatch: #da3633;
 	}
 	@media (prefers-color-scheme: dark) {
 		:root {
@@ -96,8 +103,17 @@ func GenerateCallGraphSVG(root *decoder.CallNode) string {
 			--link: #484f58;
 			--cpu: #58a6ff;
 			--mem: #3fb950;
+			--gas-low-bg: #0d2818;
+			--gas-mid-bg: #2d1f00;
+			--gas-high-bg: #3d0c0c;
+			--gas-low-swatch: #3fb950;
+			--gas-mid-swatch: #e3b341;
+			--gas-high-swatch: #f85149;
 		}
 	}
+	.gas-low rect.node-box { fill: var(--gas-low-bg); }
+	.gas-mid rect.node-box { fill: var(--gas-mid-bg); }
+	.gas-high rect.node-box { fill: var(--gas-high-bg); }
 	rect { transition: fill 0.2s; }
 	rect:hover { fill: var(--bg); stroke-width: 2px; }
 	.node-title { font-weight: 600; font-size: 14px; fill: var(--text-main); }
@@ -132,17 +148,42 @@ func GenerateCallGraphSVG(root *decoder.CallNode) string {
 		}
 
 		fmt.Fprintf(&sb, `
-	<g transform="translate(%d, %d)">
-		<rect width="%d" height="%d" rx="8" fill="var(--node-bg)" stroke="var(--node-border)" />
+	<g class="%s" transform="translate(%d, %d)">
+		<rect class="node-box" width="%d" height="%d" rx="8" stroke="var(--node-border)" />
 		<text x="12" y="24" class="node-title">%s</text>
 		<text x="12" y="40" class="node-sub">%s</text>
 		<text x="12" y="60" class="node-metric" fill="var(--cpu)">CPU: %d</text>
 		<text x="100" y="60" class="node-metric" fill="var(--mem)">Mem: %s</text>
-	</g>`, x, y, nodeWidth, nodeHeight, node.Function, contractShort, node.CPUInstructions, formatBytes(node.MemoryBytes))
+	</g>`, gasLevel(node.CPUInstructions), x, y, nodeWidth, nodeHeight, node.Function, contractShort, node.CPUInstructions, formatBytes(node.MemoryBytes))
 	}
+
+	// Legend footer
+	legendY := totalHeight + 8
+	fmt.Fprintf(&sb, `
+	<g transform="translate(0, %d)">
+		<rect width="320" height="%d" rx="6" fill="var(--node-bg)" stroke="var(--node-border)" />
+		<text x="12" y="16" style="font-size:11px;font-weight:600;fill:var(--text-mute)">Gas Intensity (CPU instructions)</text>
+		<rect x="12" y="26" width="12" height="12" rx="2" fill="var(--gas-low-swatch)" />
+		<text x="28" y="36" style="font-size:10px;fill:var(--text-mute)">Low (&lt;100K)</text>
+		<rect x="112" y="26" width="12" height="12" rx="2" fill="var(--gas-mid-swatch)" />
+		<text x="128" y="36" style="font-size:10px;fill:var(--text-mute)">Medium (100K&#8211;1M)</text>
+		<rect x="248" y="26" width="12" height="12" rx="2" fill="var(--gas-high-swatch)" />
+		<text x="264" y="36" style="font-size:10px;fill:var(--text-mute)">High (&gt;1M)</text>
+	</g>`, legendY, legendHeight)
 
 	sb.WriteString("</svg>")
 	return sb.String()
+}
+
+func gasLevel(cpu uint64) string {
+	switch {
+	case cpu > 1_000_000:
+		return "gas-high"
+	case cpu > 100_000:
+		return "gas-mid"
+	default:
+		return "gas-low"
+	}
 }
 
 func formatBytes(b uint64) string {


### PR DESCRIPTION
## Summary

Closes #1205

- Added gas intensity color coding to callgraph nodes — node backgrounds are tinted green (low, <100K CPU instructions), amber (medium, 100K–1M), or red (high, >1M) via CSS classes on each `<g>` element
- Added a legend footer panel at the bottom of the SVG explaining the three color tiers with labeled swatches
- All new colors are fully dark-mode aware via `@media (prefers-color-scheme: dark)` CSS variable overrides

## Test plan

- [ ] Render a callgraph with nodes spanning all three gas tiers and confirm background tints apply correctly
- [ ] Toggle OS dark mode and verify swatch/tint colors switch to the dark palette
- [ ] Hover over a node and confirm the hover fill override still works regardless of gas tier
- [ ] Render a single-node graph and confirm the legend appears below it without clipping


