### PR TITLE
[Security] HSM PIN Redaction in Logs

### DIFF
--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -180,6 +180,19 @@ level=INFO msg="Simulation completed" tx_hash=abc123 status=success duration_ms=
 
 ## Best Practices
 
+### Security
+
+**HSM PIN Redaction**: The logging system automatically redacts HSM PIN values from all log output to prevent sensitive credentials from appearing in logs. Any occurrence of `ERST_PKCS11_PIN` followed by a value will be replaced with `ERST_PKCS11_PIN=*****`. This applies to both text and JSON log formats.
+
+Example:
+```
+# Before redaction
+ERST_PKCS11_PIN=1234
+
+# After redaction
+ERST_PKCS11_PIN=*****
+```
+
 ### Development
 
 Use `debug` or `trace` level during development:
@@ -333,6 +346,9 @@ logger.Logger.Error("error message", "key", "value")
 
 // Get Rust-compatible log level
 rustLevel := logger.GetRustLogLevel() // Returns "debug", "info", etc.
+
+// Redact sensitive PIN values from strings
+redacted := logger.RedactPIN("ERST_PKCS11_PIN=1234") // Returns "ERST_PKCS11_PIN=*****"
 ```
 
 ### Rust Logger (env_logger)

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 )
@@ -17,6 +18,30 @@ var (
 	level  = new(slog.LevelVar)
 	mu     sync.Mutex
 )
+
+// RedactPIN replaces any HSM PIN values in the input string with "*****".
+// This is used to prevent sensitive credentials from appearing in logs.
+func RedactPIN(s string) string {
+	// Pattern 1: ERST_PKCS11_PIN=1234 or ERST_PKCS11_PIN: 1234
+	pattern1 := regexp.MustCompile(`ERST_PKCS11_PIN[=:]\s*[^\s"']+`)
+	s = pattern1.ReplaceAllString(s, "ERST_PKCS11_PIN=*****")
+
+	// Pattern 2: JSON-style "pin": "1234" or 'pin': '1234'
+	pattern2 := regexp.MustCompile(`(["']pin["']\s*[:=]\s*["'])([^"']+)`)
+	s = pattern2.ReplaceAllString(s, `$1*****`)
+
+	return s
+}
+
+// redactingWriter wraps an io.Writer and redacts PIN values from all output.
+type redactingWriter struct {
+	w io.Writer
+}
+
+func (rw *redactingWriter) Write(p []byte) (n int, err error) {
+	redacted := RedactPIN(string(p))
+	return rw.w.Write([]byte(redacted))
+}
 
 // Custom log levels
 const (
@@ -97,6 +122,9 @@ func initLogger(lvl slog.Level, w io.Writer, useJSON bool) {
 
 	level.Set(lvl)
 
+	// Wrap the writer with redactingWriter to scrub PIN values
+	w = &redactingWriter{w: w}
+
 	var handler slog.Handler
 	if useJSON {
 		handler = slog.NewJSONHandler(w, &slog.HandlerOptions{
@@ -143,6 +171,8 @@ func (h *TextHandler) Enabled(ctx context.Context, level slog.Level) bool {
 }
 
 func (h *TextHandler) Handle(ctx context.Context, record slog.Record) error {
+	// Use the underlying handler directly - redaction happens at the string level
+	// through the RedactPIN function which can be called by loggers when needed
 	return h.handler.Handle(ctx, record)
 }
 

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -396,3 +396,111 @@ func TestLogLevelHierarchy(t *testing.T) {
 		})
 	}
 }
+
+func TestRedactPIN(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "ERST_PKCS11_PIN=1234",
+			expected: "ERST_PKCS11_PIN=*****",
+		},
+		{
+			input:    "ERST_PKCS11_PIN=12345678",
+			expected: "ERST_PKCS11_PIN=*****",
+		},
+		{
+			input:    "ERST_PKCS11_PIN: 1234",
+			expected: "ERST_PKCS11_PIN=*****",
+		},
+		{
+			input:    "Config: ERST_PKCS11_PIN=secret123",
+			expected: "Config: ERST_PKCS11_PIN=*****",
+		},
+		{
+			input:    "No PIN here",
+			expected: "No PIN here",
+		},
+		{
+			input:    "ERST_PKCS11_MODULE=/usr/lib/softhsm2.so ERST_PKCS11_PIN=1234",
+			expected: "ERST_PKCS11_MODULE=/usr/lib/softhsm2.so ERST_PKCS11_PIN=*****",
+		},
+		{
+			input:    "\"pin\": \"1234\"",
+			expected: "\"pin\": \"*****\"",
+		},
+		{
+			input:    "'pin': '1234'",
+			expected: "'pin': '*****'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := RedactPIN(tt.input)
+			if result != tt.expected {
+				t.Errorf("RedactPIN(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRedactingWriter(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "ERST_PKCS11_PIN=1234\n",
+			expected: "ERST_PKCS11_PIN=*****\n",
+		},
+		{
+			input:    "Connecting with ERST_PKCS11_PIN=secret\n",
+			expected: "Connecting with ERST_PKCS11_PIN=*****\n",
+		},
+		{
+			input:    "No PIN in this log\n",
+			expected: "No PIN in this log\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			rw := &redactingWriter{w: buf}
+
+			_, err := rw.Write([]byte(tt.input))
+			if err != nil {
+				t.Fatalf("Write() error = %v", err)
+			}
+
+			result := buf.String()
+			if result != tt.expected {
+				t.Errorf("redactingWriter.Write(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestLoggerRedactsPIN(t *testing.T) {
+	buf := &bytes.Buffer{}
+	SetOutput(buf, false)
+	SetLevel(slog.LevelDebug)
+
+	Logger.Info("HSM config", "ERST_PKCS11_PIN", "1234")
+	Logger.Info("Config loaded", "config", "ERST_PKCS11_PIN=secret123")
+
+	output := buf.String()
+
+	// Verify PIN is redacted
+	if strings.Contains(output, "1234") {
+		t.Error("PIN value should be redacted from logs")
+	}
+	if strings.Contains(output, "secret123") {
+		t.Error("PIN value should be redacted from logs")
+	}
+	if !strings.Contains(output, "*****") {
+		t.Error("Redaction marker should appear in logs")
+	}
+}


### PR DESCRIPTION
Implement automatic redaction of HSM PIN values from all log output to prevent sensitive credentials from appearing in logs.

- Add RedactPIN() function to replace ERST_PKCS11_PIN values with *****
- Implement redactingWriter wrapper to apply redaction at io.Writer level
- Modify initLogger() to wrap all output with redacting writer
- Add comprehensive tests for PIN redaction functionality
- Update LOGGING.md with security documentation

closes #1180

