### PR TITLE
Final fix branch

### DIFF
--- a/internal/cmd/debug.go
+++ b/internal/cmd/debug.go
@@ -120,8 +120,8 @@ Example:
 	return cmd
 }
 
-func (d *DebugCommand) runDebug(cmd *cobra.Command, args []string) error {
-	txHash := args[0]
+func (d *DebugCommand) runDebug(cmd *cobra.Command, cmdArgs []string) error {
+	txHash := cmdArgs[0]
 
 	token := rpcTokenFlag
 	if token == "" {
@@ -161,12 +161,14 @@ func (d *DebugCommand) runDebug(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Transaction fetched successfully. Envelope size: %d bytes\n", len(resp.EnvelopeXdr))
 
-	// TODO: Use d.Runner for simulation when ready
-	// simReq := &simulator.SimulationRequest{
-	//     EnvelopeXdr: resp.EnvelopeXdr,
-	//     ResultMetaXdr: resp.ResultMetaXdr,
-	// }
-	// simResp, err := d.Runner.Run(simReq)
+	simReq := &simulator.SimulationRequest{
+		EnvelopeXdr:   resp.EnvelopeXdr,
+		ResultMetaXdr: resp.ResultMetaXdr,
+	}
+	_, err = d.Runner.Run(cmd.Context(), simReq)
+	if err != nil {
+		return errors.WrapSimulationFailed(err, txHash)
+	}
 
 	return nil
 }

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -37,6 +37,12 @@ const (
 	DepRPC               DependencyID = "rpc"
 )
 
+const (
+	DirTransactions = "transactions"
+	DirProtocols    = "protocols"
+	DirContracts    = "contracts"
+)
+
 type DependencyStatus struct {
 	ID        DependencyID // NEW: unique identifier for type-safe dispatch
 	Name      string
@@ -334,7 +340,7 @@ func checkCacheDir(verbose bool) DependencyStatus {
 	}
 
 	// Verify subdirectories exist
-	requiredDirs := []string{"transactions", "protocols", "contracts"}
+	requiredDirs := []string{DirTransactions, DirProtocols, DirContracts}
 	for _, subdir := range requiredDirs {
 		path := filepath.Join(cacheDir, subdir)
 		if _, err := os.Stat(path); err != nil {

--- a/internal/cmd/doctor_fixers.go
+++ b/internal/cmd/doctor_fixers.go
@@ -71,7 +71,7 @@ func FixMissingCacheDir(verbose bool) error {
 	}
 
 	// Create subdirectories
-	subdirs := []string{"transactions", "protocols", "contracts"}
+	subdirs := []string{DirTransactions, DirProtocols, DirContracts}
 	for _, subdir := range subdirs {
 		path := filepath.Join(cacheDir, subdir)
 		if err := os.MkdirAll(path, 0755); err != nil {

--- a/internal/config/validators_test.go
+++ b/internal/config/validators_test.go
@@ -168,6 +168,28 @@ func TestLogLevelValidator_InvalidLevel(t *testing.T) {
 	}
 }
 
+// --- MaxTraceDepthValidator ---
+
+func TestMaxTraceDepthValidator_Valid(t *testing.T) {
+	v := MaxTraceDepthValidator{}
+	for _, depth := range []int{1, 50, 500, 1000} {
+		cfg := &Config{MaxTraceDepth: depth}
+		if err := v.Validate(cfg); err != nil {
+			t.Errorf("max_trace_depth %d should be valid: %v", depth, err)
+		}
+	}
+}
+
+func TestMaxTraceDepthValidator_Invalid(t *testing.T) {
+	v := MaxTraceDepthValidator{}
+	for _, depth := range []int{0, -1, 1001, 2000} {
+		cfg := &Config{MaxTraceDepth: depth}
+		if err := v.Validate(cfg); err == nil {
+			t.Errorf("max_trace_depth %d should be invalid", depth)
+		}
+	}
+}
+
 // --- MergeDefaults ---
 
 func TestMergeDefaults_FillsEmptyFields(t *testing.T) {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -68,6 +68,7 @@ var (
 	ErrWasmInvalid          = stdliberrors.New("invalid WASM file")
 	ErrSpecNotFound         = stdliberrors.New("contract spec not found")
 	ErrShellExit            = stdliberrors.New("exit")
+	ErrRegistryConflict     = stdliberrors.New("protocol registry conflict detected")
 )
 
 type LedgerNotFoundError struct {

--- a/internal/protocolreg/registration.go
+++ b/internal/protocolreg/registration.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	ersterrors "github.com/dotandev/hintents/internal/errors"
 )
 
 const (
@@ -113,6 +114,13 @@ func (r *Registrar) Verify() (*VerificationReport, error) {
 }
 
 func (r *Registrar) registerWindows() error {
+	// Detect Protocol Registry Conflicts (Issue #1198)
+	registryOutput, err := runCommand("reg", "query", windowsRegistryKey, "/ve")
+	if err == nil && !strings.Contains(registryOutput, "erst") {
+		// If the key exists (err == nil) but (Default) doesn't contain 'erst', it's a conflict
+		return errors.Join(fmt.Errorf("registry conflict for %s", Scheme), ersterrors.ErrRegistryConflict)
+	}
+
 	commands := [][]string{
 		{"add", windowsRegistryKey, "/ve", "/d", "URL:ERST Protocol", "/f"},
 		{"add", windowsRegistryKey, "/v", "URL Protocol", "/d", "", "/f"},

--- a/internal/protocolreg/registration.go
+++ b/internal/protocolreg/registration.go
@@ -6,12 +6,12 @@ package protocolreg
 import (
 	"errors"
 	"fmt"
+	ersterrors "github.com/dotandev/hintents/internal/errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
-	ersterrors "github.com/dotandev/hintents/internal/errors"
 )
 
 const (


### PR DESCRIPTION
I have successfully resolved the four issues as requested. Below is a summary of the changes and verification results.

Changes Made
Issue #1194: [Style] Constantize Cache Subdirs
Defined constants DirTransactions, DirProtocols, and DirContracts in 
doctor.go
.
Updated 
checkCacheDir
 and 
FixMissingCacheDir
 to use these constants.
Issue #1195: [Cleanup] Remove Legacy TODOs
Cleaned up 
debug.go
 by removing legacy TODOs and commented-out code.
Resolved variable shadowing by renaming the local args parameter to cmdArgs in 
runDebug
.
Implemented the simulation runner integration using d.Runner.Run.
Issue #1197: [Config] Validate MaxTraceDepth
Verified that 
MaxTraceDepth
 validation logic was already present in 
internal/config/validate.go
.
Added comprehensive unit tests for 
MaxTraceDepth
 validation in 
validators_test.go
 to ensure correctness and prevent regressions.
Issue #1198: [Logic] Detect Protocol Registry Conflicts
Added a new sentinel error ErrRegistryConflict in 
errors.go
.
Implemented registry conflict detection in 
registerWindows
 using reg query. The system now detects if the erst scheme key exists but is already claimed by another application.
Verification Results
Automated Tests
Config Validation: go test ./internal/config/... passed, including the new 
MaxTraceDepth
 tests.
CLI Commands: go test ./internal/cmd/... passed, verifying doctor and debug command logic.
Protocol Registry: go test ./internal/protocolreg/... passed.
bash
# Example Test Output
ok      github.com/dotandev/hintents/internal/config    0.018s
ok      github.com/dotandev/hintents/internal/cmd       5.560s
ok      github.com/dotandev/hintents/internal/protocolreg       0.003s
Pull Request Description
This PR resolves the following issues:

#1194: Constantize cache directory subdirectories.
#1195: Remove obsolete TODOs and implement runner pattern in debug command.
#1197: Add validation for max_trace_depth configuration.
#1198: Detect protocol registry conflicts on Windows.
closes #1194 
closes #1195 
closes #1197 
closes #1198 
