### PR TITLE
refactor(visualizer): extract shortenContractID utility

### DIFF
--- a/internal/visualizer/callgraph.go
+++ b/internal/visualizer/callgraph.go
@@ -146,10 +146,7 @@ func GenerateCallGraphSVG(root *decoder.CallNode) string {
 	for node, pos := range positions {
 		x, y := pos[0], pos[1]
 
-		contractShort := node.ContractID
-		if len(contractShort) > 12 {
-			contractShort = contractShort[:6] + "..." + contractShort[len(contractShort)-4:]
-		}
+		contractShort := shortenContractID(node.ContractID)
 
 		fmt.Fprintf(&sb, `
 	<g class="%s" transform="translate(%d, %d)">
@@ -178,6 +175,13 @@ func GenerateCallGraphSVG(root *decoder.CallNode) string {
 
 	sb.WriteString("</svg>")
 	return sb.String()
+}
+
+func shortenContractID(id string) string {
+	if len(id) <= 12 {
+		return id
+	}
+	return id[:6] + "..." + id[len(id)-4:]
 }
 
 func formatElapsedPerCall(node *decoder.CallNode) string {


### PR DESCRIPTION
## Summary
- Extracts `shortenContractID` into a reusable utility function in `internal/visualizer/callgraph.go`
- Cleans up inline contract ID truncation logic in the visualizer

## Test plan
- [ ] Verify contract IDs are still truncated correctly in the call graph visualizer
- [ ] Confirm no regression in visualizer rendering

Closes #1203

