### PR TITLE
Implement Centralize SDK Version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,8 @@ COMMIT_SHA?=$(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE?=$(shell date -u +"%Y-%m-%d %H:%M:%S UTC")
 
 # Go build flags
-LDFLAGS=-ldflags "-X 'github.com/dotandev/hintents/internal/cmd.Version=$(VERSION)' \
-                  -X 'github.com/dotandev/hintents/internal/cmd.CommitSHA=$(COMMIT_SHA)' \
-                  -X 'github.com/dotandev/hintents/internal/cmd.BuildDate=$(BUILD_DATE)'"
+LDFLAGS=-ldflags "-X 'github.com/dotandev/hintents/main.buildVersion=$(VERSION)' \
+                  -X 'github.com/dotandev/hintents/main.buildCommitSHA=$(COMMIT_SHA)'"
 
 # Build the main binary
 build:

--- a/cmd/erst/main.go
+++ b/cmd/erst/main.go
@@ -10,12 +10,7 @@ import (
 	"github.com/dotandev/hintents/internal/cmd"
 )
 
-var Version = "dev"
-
 func main() {
-	// Set version in cmd package (used for upgrade banner and async version check)
-	cmd.Version = Version
-
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/docs/update-checker.md
+++ b/docs/update-checker.md
@@ -58,7 +58,7 @@ Upgrade available: v1.2.3 — run 'go install github.com/dotandev/hintents/cmd/e
 To set the version during build:
 
 ```bash
-go build -ldflags "-X main.Version=v1.2.3" -o erst ./cmd/erst
+go build -ldflags "-X main.buildVersion=v1.2.3" -o erst ./cmd/erst
 ```
 
 Without this flag, the version defaults to "dev" and update checking is skipped.

--- a/internal/cmd/debug.go
+++ b/internal/cmd/debug.go
@@ -32,6 +32,7 @@ import (
 	"github.com/dotandev/hintents/internal/telemetry"
 	"github.com/dotandev/hintents/internal/tokenflow"
 	simtypes "github.com/dotandev/hintents/internal/types"
+	"github.com/dotandev/hintents/internal/version"
 	"github.com/dotandev/hintents/internal/visualizer"
 	"github.com/dotandev/hintents/internal/wat"
 	"github.com/dotandev/hintents/internal/watch"
@@ -673,7 +674,7 @@ Local WASM Replay Mode:
 
 		// Persist snapshot registry to disk when --save-snapshots is set.
 		if saveSnapshotsFlag != "" && len(collectedEntries) > 0 {
-			reg := debug.New(Version, txHash, networkFlag, resp.EnvelopeXdr, resp.ResultMetaXdr)
+			reg := debug.New(version.Version, txHash, networkFlag, resp.EnvelopeXdr, resp.ResultMetaXdr)
 			for _, ce := range collectedEntries {
 				reg.Add(ce.ts, snapshot.FromMap(ce.entries))
 			}
@@ -784,7 +785,7 @@ Local WASM Replay Mode:
 			ResultMetaXdr:   resp.ResultMetaXdr,
 			SimRequestJSON:  string(simReqJSON),
 			SimResponseJSON: string(simRespJSON),
-			ErstVersion:     Version,
+			ErstVersion:     version.Version,
 			SchemaVersion:   session.SchemaVersion,
 		}
 		SetCurrentSession(sessionData)

--- a/internal/cmd/offline.go
+++ b/internal/cmd/offline.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dotandev/hintents/internal/errors"
 	"github.com/dotandev/hintents/internal/offline"
 	"github.com/dotandev/hintents/internal/rpc"
+	"github.com/dotandev/hintents/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -89,7 +90,7 @@ func runOfflineGenerate(_ *cobra.Command, args []string) error {
 	meta := offline.EnvelopeMetadata{
 		Description: offlineDescFlag,
 		SourceAddr:  offlineSourceFlag,
-		ErstVersion: Version,
+		ErstVersion: version.Version,
 	}
 
 	ef := offline.NewEnvelopeFile(offlineNetworkFlag, passphrase, envelopeXDR, meta)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dotandev/hintents/internal/localization"
 	"github.com/dotandev/hintents/internal/shutdown"
 	"github.com/dotandev/hintents/internal/updater"
+	"github.com/dotandev/hintents/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -54,7 +55,7 @@ Examples:
 Get started with 'erst debug --help' or visit the documentation.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if VersionFlag {
-			fmt.Println(Version)
+			fmt.Println(version.Version)
 			os.Exit(0)
 		}
 
@@ -70,7 +71,7 @@ Get started with 'erst debug --help' or visit the documentation.`,
 		}
 
 		// Show "Upgrade available" banner from last run's cached check (non-blocking)
-		updater.ShowBannerFromCache(Version)
+		updater.ShowBannerFromCache(version.Version)
 		// Ping version endpoint asynchronously for next run
 		checkForUpdatesAsync()
 
@@ -78,7 +79,7 @@ Get started with 'erst debug --help' or visit the documentation.`,
 	},
 	SilenceUsage:  true,
 	SilenceErrors: true,
-	Version:       Version,
+	Version:       version.Version,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -154,8 +155,8 @@ func executeWithSignals(
 func checkForUpdatesAsync() {
 	// Run update check in background goroutine
 	go func() {
-		// Use the Version variable from version.go
-		checker := updater.NewChecker(Version)
+		// Use the Version variable from version package
+		checker := updater.NewChecker(version.Version)
 		checker.CheckForUpdates()
 	}()
 }

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/dotandev/hintents/internal/updater"
+	"github.com/dotandev/hintents/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -27,7 +28,7 @@ var updateCmd = &cobra.Command{
 You can also specify a target version using the --version flag.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		checker := updater.NewChecker(Version)
+		checker := updater.NewChecker(version.Version)
 
 		targetVersion := updateVersionFlag
 		if targetVersion == "" {

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -9,14 +9,8 @@ import (
 	"runtime/debug"
 	"time"
 
+	"github.com/dotandev/hintents/internal/version"
 	"github.com/spf13/cobra"
-)
-
-var (
-	// Build information populated by ldflags
-	Version   = "0.0.0-dev"
-	CommitSHA = "unknown"
-	BuildDate = "unknown"
 )
 
 type VersionInfo struct {
@@ -47,15 +41,15 @@ var versionCmd = &cobra.Command{
 			fmt.Printf("Build Date:   %s\n", info.BuildDate)
 			fmt.Printf("Go Version:   %s\n", info.GoVersion)
 		}
-		fmt.Printf("erst version %s\n", Version)
+		fmt.Printf("erst version %s\n", version.Version)
 	},
 }
 
 func getVersionInfo() VersionInfo {
 	info := VersionInfo{
-		Version:   Version,
-		CommitSHA: CommitSHA,
-		BuildDate: BuildDate,
+		Version:   version.Version,
+		CommitSHA: version.CommitSHA,
+		BuildDate: version.BuildDate,
 		GoVersion: "unknown",
 	}
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,13 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package version
+
+var (
+	// Version is the SDK version, populated by ldflags during build
+	Version = "0.0.0-dev"
+	// CommitSHA is the git commit SHA, populated by ldflags during build
+	CommitSHA = "unknown"
+	// BuildDate is the build date, populated by ldflags during build
+	BuildDate = "unknown"
+)

--- a/main.go
+++ b/main.go
@@ -14,13 +14,20 @@ import (
 	"github.com/dotandev/hintents/internal/cmd"
 	"github.com/dotandev/hintents/internal/config"
 	"github.com/dotandev/hintents/internal/crashreport"
+	"github.com/dotandev/hintents/internal/version"
 )
 
 // Build-time variables injected via -ldflags.
 var (
-	version   = "dev"
-	commitSHA = "unknown"
+	buildVersion   = "dev"
+	buildCommitSHA = "unknown"
 )
+
+func init() {
+	// Set version from build-time variables
+	version.Version = buildVersion
+	version.CommitSHA = buildCommitSHA
+}
 
 // ─── Example RPC handler ──────────────────────────────────────────────────────
 
@@ -54,8 +61,8 @@ func main() {
 		Enabled:   cfg.CrashReporting,
 		SentryDSN: cfg.CrashSentryDSN,
 		Endpoint:  cfg.CrashEndpoint,
-		Version:   version,
-		CommitSHA: commitSHA,
+		Version:   buildVersion,
+		CommitSHA: buildCommitSHA,
 	})
 
 	// Catch any unrecovered panic, report it, then re-panic.

--- a/test_update_checker.sh
+++ b/test_update_checker.sh
@@ -19,7 +19,7 @@ echo ""
 
 # Build with old version
 echo "2. Building with old version (v0.0.1)..."
-go build -ldflags "-X main.Version=v0.0.1" -o erst_test ./cmd/erst
+go build -ldflags "-X main.buildVersion=v0.0.1" -o erst_test ./cmd/erst
 echo "   [OK] Built"
 echo ""
 
@@ -57,7 +57,7 @@ echo ""
 
 # Test with current version
 echo "6. Building with future version (v999.0.0)..."
-go build -ldflags "-X main.Version=v999.0.0" -o erst_test ./cmd/erst
+go build -ldflags "-X main.buildVersion=v999.0.0" -o erst_test ./cmd/erst
 ./erst_test version > output.txt 2>&1
 
 if grep -q "new version" output.txt; then


### PR DESCRIPTION
Create new package internal/version to centralize version information.
- Move Version, CommitSHA, BuildDate variables to internal/version/version.go
- Update all references in cmd package to use version.Version
- Update build configuration (Makefile, main.go) to inject into centralized package
- Update documentation and test scripts to reflect new build-time variable paths

closes #1188 