### PR TITLE
feat: implement ledger entry mocking CLI and API

### DIFF
--- a/internal/cmd/debug.go
+++ b/internal/cmd/debug.go
@@ -42,42 +42,42 @@ import (
 )
 
 var (
-	networkFlag         string
-	rpcURLFlag          string
-	rpcTokenFlag        string
-	tracingEnabled      bool
-	otlpExporterURL     string
-	generateTrace       bool
-	traceOutputFile     string
-	snapshotFlag        string
-	compareNetworkFlag  string
-	verbose             bool
-	wasmPath            string
-	args                []string
+	networkFlag          string
+	rpcURLFlag           string
+	rpcTokenFlag         string
+	tracingEnabled       bool
+	otlpExporterURL      string
+	generateTrace        bool
+	traceOutputFile      string
+	snapshotFlag         string
+	compareNetworkFlag   string
+	verbose              bool
+	wasmPath             string
+	args                 []string
 	mockLedgerEntryFlags []string
 	mockLedgerManifest   string
-	themeFlag           string
-	noCacheFlag         bool
-	demoMode            bool
-	watchFlag           bool
-	watchTimeoutFlag    int
-	hotReloadFlag       bool
-	hotReloadInterval   time.Duration
-	snapshotsFlag       bool
-	protocolVersionFlag uint32
-	auditKeyFlag        string
-	publishIPFSFlag     bool
-	publishArweaveFlag  bool
-	ipfsNodeFlag        string
-	arweaveGatewayFlag  string
-	arweaveWalletFlag   string
-	mockTimeFlag        int64
-	mockBaseFeeFlag     uint32
-	mockGasPriceFlag    uint64
-	exportSVGFlag       string
-	loadSnapshotsFlag   string
-	saveSnapshotsFlag   string
-	wasmBase64          string
+	themeFlag            string
+	noCacheFlag          bool
+	demoMode             bool
+	watchFlag            bool
+	watchTimeoutFlag     int
+	hotReloadFlag        bool
+	hotReloadInterval    time.Duration
+	snapshotsFlag        bool
+	protocolVersionFlag  uint32
+	auditKeyFlag         string
+	publishIPFSFlag      bool
+	publishArweaveFlag   bool
+	ipfsNodeFlag         string
+	arweaveGatewayFlag   string
+	arweaveWalletFlag    string
+	mockTimeFlag         int64
+	mockBaseFeeFlag      uint32
+	mockGasPriceFlag     uint64
+	exportSVGFlag        string
+	loadSnapshotsFlag    string
+	saveSnapshotsFlag    string
+	wasmBase64           string
 )
 
 // DebugCommand holds dependencies for the debug command

--- a/internal/cmd/debug.go
+++ b/internal/cmd/debug.go
@@ -54,6 +54,8 @@ var (
 	verbose             bool
 	wasmPath            string
 	args                []string
+	mockLedgerEntryFlags []string
+	mockLedgerManifest   string
 	themeFlag           string
 	noCacheFlag         bool
 	demoMode            bool
@@ -463,6 +465,11 @@ Local WASM Replay Mode:
 			}
 		}
 
+		overrideEntries, err := loadMockLedgerOverrides()
+		if err != nil {
+			return err
+		}
+
 		var lastSimResp *simulator.SimulationResponse
 
 		// Collected per-timestamp states written to disk when --save-snapshots is set.
@@ -501,6 +508,11 @@ Local WASM Replay Mode:
 					} else {
 						logger.Logger.Info("Extracted ledger entries for simulation", "count", len(ledgerEntries))
 					}
+				}
+
+				if len(overrideEntries) > 0 {
+					ledgerEntries = simulator.MergeLedgerOverrides(ledgerEntries, overrideEntries)
+					fmt.Printf("Applied %d mock ledger override entries\n", len(overrideEntries))
 				}
 
 				if saveSnapshotsFlag != "" {
@@ -565,6 +577,10 @@ Local WASM Replay Mode:
 							return
 						}
 					}
+					if len(overrideEntries) > 0 {
+						entries = simulator.MergeLedgerOverrides(entries, overrideEntries)
+						fmt.Printf("Applied %d mock ledger override entries to primary comparison\n", len(overrideEntries))
+					}
 					primaryReq := &simulator.SimulationRequest{
 						EnvelopeXdr:     resp.EnvelopeXdr,
 						ResultMetaXdr:   resp.ResultMetaXdr,
@@ -606,8 +622,13 @@ Local WASM Replay Mode:
 						}
 					}
 
+					if len(overrideEntries) > 0 {
+						entries = simulator.MergeLedgerOverrides(entries, overrideEntries)
+						fmt.Printf("Applied %d mock ledger override entries to compare comparison\n", len(overrideEntries))
+					}
+
 					compareReq := &simulator.SimulationRequest{
-						EnvelopeXdr:     resp.EnvelopeXdr,
+						EnvelopeXdr:     compareResp.EnvelopeXdr,
 						ResultMetaXdr:   compareResp.ResultMetaXdr,
 						LedgerEntries:   entries,
 						Timestamp:       ts,
@@ -918,8 +939,38 @@ func newLocalWasmSimulationRequest(forceNoCache bool) *simulator.SimulationReque
 	return req
 }
 
+func loadMockLedgerOverrides() (map[string]string, error) {
+	var overrides map[string]string
+	if mockLedgerManifest != "" {
+		manifestOverrides, err := simulator.LoadLedgerOverrideManifest(mockLedgerManifest)
+		if err != nil {
+			return nil, errors.WrapValidationError(fmt.Sprintf("failed to load mock ledger manifest: %v", err))
+		}
+		overrides = simulator.MergeLedgerOverrides(overrides, manifestOverrides)
+	}
+
+	if len(mockLedgerEntryFlags) > 0 {
+		flagOverrides, err := simulator.ParseLedgerOverrideFlags(mockLedgerEntryFlags)
+		if err != nil {
+			return nil, errors.WrapValidationError(fmt.Sprintf("failed to parse mock ledger entries: %v", err))
+		}
+		overrides = simulator.MergeLedgerOverrides(overrides, flagOverrides)
+	}
+
+	return overrides, nil
+}
+
 func runLocalWasmReplayOnce(ctx context.Context, runner simulator.RunnerInterface, forceNoCache bool) error {
 	req := newLocalWasmSimulationRequest(forceNoCache)
+
+	overrideEntries, err := loadMockLedgerOverrides()
+	if err != nil {
+		return err
+	}
+	if len(overrideEntries) > 0 {
+		req.LedgerEntries = simulator.MergeLedgerOverrides(req.LedgerEntries, overrideEntries)
+		fmt.Printf("Applied %d mock ledger override entries for local replay\n", len(overrideEntries))
+	}
 
 	// Run simulation
 	fmt.Printf("%s Executing contract locally...\n", visualizer.Symbol("play"))
@@ -1502,6 +1553,8 @@ func init() {
 	debugCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
 	debugCmd.Flags().StringVar(&wasmPath, "wasm", "", "Path to local WASM file for local replay (no network required)")
 	debugCmd.Flags().StringSliceVar(&args, "args", []string{}, "Mock arguments for local replay (JSON array of strings)")
+	debugCmd.Flags().StringSliceVar(&mockLedgerEntryFlags, "mock-ledger-entry", []string{}, "Override ledger entries before simulation using key:value; repeatable")
+	debugCmd.Flags().StringVar(&mockLedgerManifest, "mock-ledger-manifest", "", "Path to a JSON manifest containing ledger_entries for override state")
 	debugCmd.Flags().BoolVar(&noCacheFlag, "no-cache", false, "Disable local ledger state caching")
 	debugCmd.Flags().BoolVar(&demoMode, "demo", false, "Print sample output (no network) - for testing color detection")
 	debugCmd.Flags().BoolVar(&watchFlag, "watch", false, "Poll for transaction on-chain before debugging")

--- a/internal/cmd/debug_test.go
+++ b/internal/cmd/debug_test.go
@@ -192,6 +192,12 @@ func TestDebugCommand_Setup(t *testing.T) {
 	mockGasPrice := debugCmd.Flags().Lookup("mock-gas-price")
 	assert.NotNil(t, mockGasPrice)
 
+	mockLedgerEntry := debugCmd.Flags().Lookup("mock-ledger-entry")
+	assert.NotNil(t, mockLedgerEntry)
+
+	mockLedgerManifest := debugCmd.Flags().Lookup("mock-ledger-manifest")
+	assert.NotNil(t, mockLedgerManifest)
+
 	snapshots := debugCmd.Flags().Lookup("snapshots")
 	assert.NotNil(t, snapshots)
 	assert.Equal(t, "false", snapshots.DefValue)

--- a/internal/simulator/mock.go
+++ b/internal/simulator/mock.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+// Issue #1273: Ledger Entry Mocking CLI & API
+package simulator
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type LedgerOverrideManifest struct {
+	LedgerEntries map[string]string `json:"ledger_entries,omitempty"`
+}
+
+func LoadLedgerOverrideManifest(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var manifest LedgerOverrideManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, err
+	}
+
+	return manifest.LedgerEntries, nil
+}
+
+func ParseLedgerOverrideFlags(entries []string) (map[string]string, error) {
+	overrides := make(map[string]string)
+	for _, entry := range entries {
+		parts := strings.SplitN(entry, ":", 2)
+		if len(parts) != 2 || parts[0] == "" {
+			return nil, fmt.Errorf("invalid ledger override format: %q, expected key:value", entry)
+		}
+		overrides[parts[0]] = parts[1]
+	}
+
+	return overrides, nil
+}
+
+func MergeLedgerOverrides(base map[string]string, overrides map[string]string) map[string]string {
+	if len(overrides) == 0 {
+		return base
+	}
+
+	if base == nil {
+		base = make(map[string]string)
+	}
+
+	for key, value := range overrides {
+		base[key] = value
+	}
+
+	return base
+}

--- a/internal/simulator/mock_test.go
+++ b/internal/simulator/mock_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package simulator
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseLedgerOverrideFlags(t *testing.T) {
+	overrides, err := ParseLedgerOverrideFlags([]string{
+		"key1:value1",
+		"anotherKey:YmFzZTY0dGVzdA==",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "value1", overrides["key1"])
+	assert.Equal(t, "YmFzZTY0dGVzdA==", overrides["anotherKey"])
+}
+
+func TestParseLedgerOverrideFlags_InvalidFormat(t *testing.T) {
+	_, err := ParseLedgerOverrideFlags([]string{"invalid-format"})
+	assert.Error(t, err)
+}
+
+func TestLoadLedgerOverrideManifest(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "ledger_override.json")
+	override := LedgerOverrideManifest{
+		LedgerEntries: map[string]string{
+			"keyA": "valueA",
+		},
+	}
+	data, err := json.MarshalIndent(override, "", "  ")
+	assert.NoError(t, err)
+	assert.NoError(t, os.WriteFile(tmpFile, data, 0644))
+
+	entries, err := LoadLedgerOverrideManifest(tmpFile)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(entries))
+	assert.Equal(t, "valueA", entries["keyA"])
+}
+
+func TestMergeLedgerOverrides(t *testing.T) {
+	base := map[string]string{"a": "1", "b": "2"}
+	overrides := map[string]string{"b": "over", "c": "3"}
+	merged := MergeLedgerOverrides(base, overrides)
+	assert.Equal(t, "1", merged["a"])
+	assert.Equal(t, "over", merged["b"])
+	assert.Equal(t, "3", merged["c"])
+}


### PR DESCRIPTION
### Description
This PR provides a structured way for developers to mock or override ledger state before a simulation via CLI flags or a JSON manifest. This enables testing "what-if" scenarios, such as simulating contract behavior with specific balances or administrative states that don't exist on the live network.

### Changes Made
- Added `internal/simulator/mock.go` to handle parsing and merging of ledger override manifests and CLI flags.
- Added comprehensive unit tests in `internal/simulator/mock_test.go`.
- Updated `internal/cmd/debug.go` to accept `--mock-ledger-entry` and `--mock-ledger-manifest` flags.
- Integrated the override logic into the local WASM replay and network transaction debugging flows.

Closes #1273