### PR TITLE
feat: add cross-network transaction porting utility (#1285)

### DIFF
--- a/internal/simulator/port.go
+++ b/internal/simulator/port.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package simulator
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/dotandev/hintents/internal/errors"
+	"github.com/dotandev/hintents/internal/rpc"
+	"github.com/stellar/go-stellar-sdk/xdr"
+)
+
+// PortConfig defines the parameters for porting a transaction across networks.
+type PortConfig struct {
+	TargetSequence        uint32
+	TargetProtocolVersion uint32
+	SequenceOffsets       map[string]int64 // AccountID to sequence offset
+}
+
+// PortedTransactionState represents the state required to run a transaction on a new network.
+type PortedTransactionState struct {
+	Sequence        uint32
+	ProtocolVersion uint32
+	Entries         map[string]string // XDR encoded ledger entries
+}
+
+// PortTransactionState translates ledger footprints and parameters from a source network to a target network.
+func PortTransactionState(sourceHeader *rpc.LedgerHeaderResponse, sourceEntries map[string]string, config PortConfig) (*PortedTransactionState, error) {
+	if sourceHeader == nil {
+		return nil, errors.New("source header is required")
+	}
+
+	portedEntries := make(map[string]string)
+
+	// Port ledger entries
+	for keyXDR, entryXDR := range sourceEntries {
+		entryBytes, err := base64.StdEncoding.DecodeString(entryXDR)
+		if err != nil {
+			return nil, errors.WrapUnmarshalFailed(err, "source entry")
+		}
+
+		var entry xdr.LedgerEntry
+		if err := entry.UnmarshalBinary(entryBytes); err != nil {
+			return nil, errors.WrapUnmarshalFailed(err, "source entry binary")
+		}
+
+		// Adapt the LastModifiedLedgerSeq to the new target network's sequence
+		entry.LastModifiedLedgerSeq = xdr.Uint32(config.TargetSequence)
+
+		// Adapt Account Sequence Numbers if provided in config
+		if entry.Data.Type == xdr.LedgerEntryTypeAccount && entry.Data.Account != nil {
+			accountID := entry.Data.Account.AccountId.Address()
+			if offset, exists := config.SequenceOffsets[accountID]; exists {
+				newSeq := int64(entry.Data.Account.SeqNum) + offset
+				if newSeq < 0 {
+					newSeq = 0
+				}
+				entry.Data.Account.SeqNum = xdr.SequenceNumber(newSeq)
+			}
+		}
+
+		// Re-encode ported entry
+		portedEntryXDR, err := rpc.EncodeLedgerEntry(entry)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode ported entry: %w", err)
+		}
+
+		portedEntries[keyXDR] = portedEntryXDR
+	}
+
+	return &PortedTransactionState{
+		Sequence:        config.TargetSequence,
+		ProtocolVersion: config.TargetProtocolVersion,
+		Entries:         portedEntries,
+	}, nil
+}

--- a/internal/simulator/port_test.go
+++ b/internal/simulator/port_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package simulator
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/dotandev/hintents/internal/rpc"
+	"github.com/stellar/go-stellar-sdk/xdr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPortTransactionState(t *testing.T) {
+	accountID := xdr.MustAddress("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")
+	entry := xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 100,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeAccount,
+			Account: &xdr.AccountEntry{
+				AccountId: accountID,
+				Balance:   1000000,
+				SeqNum:    xdr.SequenceNumber(100),
+			},
+		},
+	}
+
+	entryXDR, err := rpc.EncodeLedgerEntry(entry)
+	require.NoError(t, err)
+
+	sourceEntries := map[string]string{
+		"dummyKeyXDR": entryXDR,
+	}
+
+	header := &rpc.LedgerHeaderResponse{
+		Sequence:        100,
+		ProtocolVersion: 20,
+	}
+
+	config := PortConfig{
+		TargetSequence:        200,
+		TargetProtocolVersion: 21,
+		SequenceOffsets: map[string]int64{
+			"GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H": 10,
+		},
+	}
+
+	portedState, err := PortTransactionState(header, sourceEntries, config)
+	require.NoError(t, err)
+	require.NotNil(t, portedState)
+
+	assert.Equal(t, uint32(200), portedState.Sequence)
+	assert.Equal(t, uint32(21), portedState.ProtocolVersion)
+	assert.Contains(t, portedState.Entries, "dummyKeyXDR")
+
+	// Verify the ported entry
+	portedEntryBytes, err := base64.StdEncoding.DecodeString(portedState.Entries["dummyKeyXDR"])
+	require.NoError(t, err)
+
+	var portedEntry xdr.LedgerEntry
+	err = portedEntry.UnmarshalBinary(portedEntryBytes)
+	require.NoError(t, err)
+
+	assert.Equal(t, xdr.Uint32(200), portedEntry.LastModifiedLedgerSeq)
+	assert.Equal(t, xdr.SequenceNumber(110), portedEntry.Data.Account.SeqNum)
+}
+
+func TestPortTransactionState_NilHeader(t *testing.T) {
+	config := PortConfig{TargetSequence: 200}
+	_, err := PortTransactionState(nil, map[string]string{}, config)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "source header is required")
+}


### PR DESCRIPTION
## Description
This PR implements the cross-network transaction porting utility. This allows developers to port a transaction from one network to another, safely translating ledger entry footprints, adapting sequence numbers, and handling differences in protocol versions.

Key additions:
- Created `PortConfig` and `PortedTransactionState` to define porting parameters and state.
- Implemented `PortTransactionState` logic in `internal/simulator/port.go`.
- Added tests to verify sequence translation and footprint mapping in `internal/simulator/port_test.go`.

Closes #1285