### PR TITLE
Audit: Add rationale comments to all //nolint directives

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -140,7 +140,7 @@ func assertNotContains(t *testing.T, label, haystack, needle string) {
 	}
 }
 
-func assertEmpty(t *testing.T, label, s string) { //nolint:unused
+func assertEmpty(t *testing.T, label, s string) { //nolint:unused // Reserved for future test use
 	t.Helper()
 	if strings.TrimSpace(s) != "" {
 		t.Errorf("%s: expected empty, got:\n%s", label, s)

--- a/internal/abi/printer.go
+++ b/internal/abi/printer.go
@@ -263,7 +263,7 @@ func formatFunction(fn xdr.ScSpecFunctionV0) string {
 }
 
 // FormatTypeDef returns a human-readable string for an ScSpecTypeDef.
-func FormatTypeDef(td xdr.ScSpecTypeDef) string { //nolint:gocyclo
+func FormatTypeDef(td xdr.ScSpecTypeDef) string { //nolint:gocyclo // Large switch statement handling all possible ScSpecTypeDef types
 	switch td.Type {
 	case xdr.ScSpecTypeScSpecTypeVal:
 		return "Val"

--- a/internal/bridge/streaming.go
+++ b/internal/bridge/streaming.go
@@ -78,7 +78,7 @@ func (s *StreamingRunner) RunStreaming(ctx context.Context, reqJSON []byte) (*St
 	}
 
 	// exec.CommandContext cancels the process when ctx expires.
-	cmd := exec.CommandContext(ctx, s.BinaryPath) //nolint:gosec // path is caller-supplied trusted binary
+	cmd := exec.CommandContext(ctx, s.BinaryPath) //nolint:gosec // path is a trusted simulator binary from configuration
 	cmd.Stdin = bytes.NewReader(reqJSON)
 
 	stdoutPipe, err := cmd.StdoutPipe()

--- a/internal/cmd/debug_test.go
+++ b/internal/cmd/debug_test.go
@@ -349,7 +349,7 @@ func TestExtractLedgerKeys(t *testing.T) {
 	assert.True(t, found, "Key not found in extracted keys")
 }
 
-func buildTestEnvelopeXdr(t *testing.T) string { //nolint:unused
+func buildTestEnvelopeXdr(t *testing.T) string { //nolint:unused // Reserved for future test use
 	t.Helper()
 
 	sourceAccount := xdr.MustAddress("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H")

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -67,7 +67,7 @@ the preferred RPC URL and network passphrase.`,
 			return err
 		}
 
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Initialized Erst project scaffold in %s\n", targetDir) //nolint:errcheck
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Initialized Erst project scaffold in %s\n", targetDir) //nolint:errcheck // Terminal output, write failure is non-critical
 		printInitSuccessBanner(cmd.OutOrStdout())
 		return nil
 	},
@@ -97,8 +97,8 @@ func runInitWizard(cmd *cobra.Command, opts *initScaffoldOptions) error {
 	reader := bufio.NewReader(cmd.InOrStdin())
 	out := cmd.OutOrStdout()
 
-	_, _ = fmt.Fprintln(out, "Erst init setup wizard")          //nolint:errcheck
-	_, _ = fmt.Fprintln(out, "Press Enter to accept defaults.") //nolint:errcheck
+	_, _ = fmt.Fprintln(out, "Erst init setup wizard")          //nolint:errcheck // Terminal output, write failure is non-critical
+	_, _ = fmt.Fprintln(out, "Press Enter to accept defaults.") //nolint:errcheck // Terminal output, write failure is non-critical
 
 	rpcURL, err := promptWithDefault(reader, out, "Preferred Soroban RPC URL", defaultRPCURLForNetwork(opts.Network, opts.RPCURL))
 	if err != nil {
@@ -116,7 +116,7 @@ func runInitWizard(cmd *cobra.Command, opts *initScaffoldOptions) error {
 }
 
 func promptWithDefault(reader *bufio.Reader, out io.Writer, prompt, defaultValue string) (string, error) {
-	_, _ = fmt.Fprintf(out, "%s [%s]: ", prompt, defaultValue) //nolint:errcheck
+	_, _ = fmt.Fprintf(out, "%s [%s]: ", prompt, defaultValue) //nolint:errcheck // Terminal output, write failure is non-critical
 	input, err := reader.ReadString('\n')
 	if err != nil && !errors.Is(err, io.EOF) {
 		return "", err
@@ -296,7 +296,7 @@ func printInitSuccessBanner(out io.Writer) {
 │ 3. Run Doctor                       │
 └─────────────────────────────────────┘
 `
-	_, _ = fmt.Fprint(out, banner) //nolint:errcheck
+	_, _ = fmt.Fprint(out, banner) //nolint:errcheck // Terminal output, write failure is non-critical
 }
 
 func isValidInitNetwork(network string) bool {

--- a/internal/cmd/resource_lookup.go
+++ b/internal/cmd/resource_lookup.go
@@ -123,7 +123,7 @@ func resolveSessionInput(ctx context.Context, store *session.Store, input string
 
 // suggestSessionID returns the closest session ID for a failed lookup.
 // Kept for backward compatibility; new callers should use resolveSessionInput.
-func suggestSessionID(ctx context.Context, store *session.Store, input string) (string, error) { //nolint:unused
+func suggestSessionID(ctx context.Context, store *session.Store, input string) (string, error) { //nolint:unused // Kept for backward compatibility
 	sessions, err := store.List(ctx, sessionLookupListLimit)
 	if err != nil {
 		return "", err

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -12,7 +12,7 @@ import (
 	"github.com/dotandev/hintents/internal/errors"
 )
 
-func loadFromEnv(cfg *Config) error { //nolint:unused
+func loadFromEnv(cfg *Config) error { //nolint:unused // Reserved for future config loading from environment
 	if v := os.Getenv("ERST_RPC_URL"); v != "" {
 		cfg.RpcUrl = v
 	}

--- a/internal/dce/dce_test.go
+++ b/internal/dce/dce_test.go
@@ -115,7 +115,7 @@ func (b *testModuleBuilder) addTable() *testModuleBuilder {
 }
 
 // addMemory adds a memory section.
-func (b *testModuleBuilder) addMemory() *testModuleBuilder { //nolint:unused
+func (b *testModuleBuilder) addMemory() *testModuleBuilder { //nolint:unused // Reserved for future test use
 	// 1 memory, limits: min=1, no max
 	b.memories = []byte{0x01, 0x00, 0x01}
 	return b

--- a/internal/deeplink/deeplink.go
+++ b/internal/deeplink/deeplink.go
@@ -107,7 +107,7 @@ func triggerMockLink(selfPath string) bool {
 	// We invoke the binary directly rather than through the OS URL dispatcher
 	// so the test is hermetic and does not require the scheme to be registered.
 	// The --deep-link flag tells the binary to handle the URL and exit.
-	cmd := exec.Command(selfPath, "--deep-link", MockURL) //nolint:gosec // selfPath is our own binary
+	cmd := exec.Command(selfPath, "--deep-link", MockURL) //nolint:gosec // selfPath is our own trusted binary
 	cmd.Env = append(os.Environ(), "ERST_DEEP_LINK_PROBE=1")
 
 	done := make(chan error, 1)

--- a/internal/rpc/txstream.go
+++ b/internal/rpc/txstream.go
@@ -241,7 +241,7 @@ func (s *wsStreamer) poll(ctx context.Context, conn *wsConn, hash string, id int
 		return true
 	}
 
-	_ = conn.raw.SetWriteDeadline(time.Now().Add(5 * time.Second)) //nolint:errcheck
+	_ = conn.raw.SetWriteDeadline(time.Now().Add(5 * time.Second)) //nolint:errcheck // Best-effort write deadline for WebSocket frame
 	if err := wsWriteFrame(conn.raw, reqBytes); err != nil {
 		logger.Logger.Warn("ws streamer: write frame", "error", err)
 		return true

--- a/internal/rpc/txstream_test.go
+++ b/internal/rpc/txstream_test.go
@@ -177,7 +177,7 @@ func TestWsFrameRoundTrip(t *testing.T) {
 func TestWsWriteFrame_CloseFrame(t *testing.T) {
 	pr, pw := io.Pipe()
 	go func() {
-		_ = wsWriteFrame(pw, nil) //nolint:errcheck
+		_ = wsWriteFrame(pw, nil) //nolint:errcheck // Test code, pipe write failure is not critical
 		_ = pw.Close()
 	}()
 
@@ -392,12 +392,12 @@ func newMockWSServer(t *testing.T, statuses []string) *httptest.Server {
 
 		// Service JSON-RPC requests until the client closes.
 		for {
-			_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
+			_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck // Mock WebSocket server, deadline set failure is not critical
 			msg, err := wsReadFrame(bufrw.Reader)
 			if err != nil {
 				return
 			}
-			_ = conn.SetReadDeadline(time.Time{}) //nolint:errcheck
+			_ = conn.SetReadDeadline(time.Time{}) //nolint:errcheck // Mock WebSocket server, deadline clear failure is not critical
 
 			var req jsonrpcRequest
 			if err := json.Unmarshal(msg, &req); err != nil {
@@ -415,12 +415,12 @@ func newMockWSServer(t *testing.T, statuses []string) *httptest.Server {
 				req.ID, status,
 			)
 
-			_ = conn.SetWriteDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
+			_ = conn.SetWriteDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck // Mock WebSocket server, deadline set failure is not critical
 			// Server sends unmasked frames — use a simple writer that skips masking.
 			if err := wsWriteFrameUnmasked(conn, []byte(resp)); err != nil {
 				return
 			}
-			_ = conn.SetWriteDeadline(time.Time{}) //nolint:errcheck
+			_ = conn.SetWriteDeadline(time.Time{}) //nolint:errcheck // Mock WebSocket server, deadline clear failure is not critical
 
 			if status == TxStatusSuccess || status == TxStatusFailed {
 				return
@@ -923,7 +923,7 @@ func TestWsReadMessage_SingleFrame(t *testing.T) {
 	want := []byte(`{"status":"PENDING"}`)
 	pr, pw := io.Pipe()
 	go func() {
-		_ = wsWriteFrameUnmasked(pw, want) //nolint:errcheck
+		_ = wsWriteFrameUnmasked(pw, want) //nolint:errcheck // Test code, pipe write failure is not critical
 		_ = pw.Close()
 	}()
 
@@ -1067,12 +1067,12 @@ func newMockWSServerFull(t *testing.T) *httptest.Server {
 		}
 
 		for {
-			_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
+			_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck // Mock WebSocket server, deadline set failure is not critical
 			msg, err := wsReadFrame(bufrw.Reader)
 			if err != nil {
 				return
 			}
-			_ = conn.SetReadDeadline(time.Time{}) //nolint:errcheck
+			_ = conn.SetReadDeadline(time.Time{}) //nolint:errcheck // Mock WebSocket server, deadline clear failure is not critical
 
 			var req jsonrpcRequest
 			if err := json.Unmarshal(msg, &req); err != nil {
@@ -1102,11 +1102,11 @@ func newMockWSServerFull(t *testing.T) *httptest.Server {
 				)
 			}
 
-			_ = conn.SetWriteDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
+			_ = conn.SetWriteDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck // Mock WebSocket server, deadline set failure is not critical
 			if err := wsWriteFrameUnmasked(conn, []byte(resp)); err != nil {
 				return
 			}
-			_ = conn.SetWriteDeadline(time.Time{}) //nolint:errcheck
+			_ = conn.SetWriteDeadline(time.Time{}) //nolint:errcheck // Mock WebSocket server, deadline clear failure is not critical
 
 			if callN >= 2 {
 				return

--- a/internal/rpc/verification.go
+++ b/internal/rpc/verification.go
@@ -17,7 +17,7 @@ import (
 // validateLedgerKeyXDR decodes a base64-encoded XDR LedgerKey, validates its structure,
 // and emits a debug log with the key's SHA-256 hash and type. It is the canonical
 // integrity check shared by VerifyLedgerEntryHash and VerifyLedgerEntries.
-func validateLedgerKeyXDR(keyB64 string) error { //nolint:unused
+func validateLedgerKeyXDR(keyB64 string) error { //nolint:unused // Reserved for future ledger entry validation
 	keyBytes, err := base64.StdEncoding.DecodeString(keyB64)
 	if err != nil {
 		return errors.WrapValidationError(fmt.Sprintf("failed to decode ledger key: %v", err))

--- a/internal/signer/pkcs11.go
+++ b/internal/signer/pkcs11.go
@@ -14,20 +14,20 @@ import (
 
 // PKCS#11 constants matching the Cryptoki specification.
 const (
-	ckfSerialSession = 0x04 //nolint:unused
-	ckuUser          = 1    //nolint:unused
+	ckfSerialSession = 0x04 //nolint:unused // PKCS#11 constant reserved for future implementation
+	ckuUser          = 1    //nolint:unused // PKCS#11 constant reserved for future implementation
 
-	ckoPrivateKey = 0x03 //nolint:unused
-	ckoPublicKey  = 0x02 //nolint:unused
+	ckoPrivateKey = 0x03 //nolint:unused // PKCS#11 constant reserved for future implementation
+	ckoPublicKey  = 0x02 //nolint:unused // PKCS#11 constant reserved for future implementation
 
-	ckaClass   = 0x00  //nolint:unused
-	ckaKeyType = 0x100 //nolint:unused
-	ckaLabel   = 0x03  //nolint:unused
-	ckaID      = 0x102 //nolint:unused
-	ckaECPoint = 0x181 //nolint:unused
+	ckaClass   = 0x00  //nolint:unused // PKCS#11 constant reserved for future implementation
+	ckaKeyType = 0x100 //nolint:unused // PKCS#11 constant reserved for future implementation
+	ckaLabel   = 0x03  //nolint:unused // PKCS#11 constant reserved for future implementation
+	ckaID      = 0x102 //nolint:unused // PKCS#11 constant reserved for future implementation
+	ckaECPoint = 0x181 //nolint:unused // PKCS#11 constant reserved for future implementation
 
 	ckmEDDSA = 0x1050
-	ckkEDDSA = 0x42 //nolint:unused
+	ckkEDDSA = 0x42 //nolint:unused // PKCS#11 constant reserved for future implementation
 
 	ckrOK = 0x00
 )
@@ -77,7 +77,7 @@ func Pkcs11ConfigFromEnv() (*Pkcs11Config, error) {
 }
 
 // pkcs11Attribute mirrors CK_ATTRIBUTE.
-type pkcs11Attribute struct { //nolint:unused
+type pkcs11Attribute struct { //nolint:unused // Reserved for future PKCS#11 implementation
 	typ    uint64
 	pValue unsafe.Pointer
 	ulLen  uint64
@@ -102,18 +102,18 @@ type Pkcs11Signer struct {
 	pubKey    []byte
 
 	// C_* function pointers resolved from the loaded library.
-	fnInitialize      func(unsafe.Pointer) uint64                                          //nolint:unused
-	fnGetSlotList     func(bool, unsafe.Pointer, *uint64) uint64                           //nolint:unused
-	fnGetTokenInfo    func(uint64, unsafe.Pointer) uint64                                  //nolint:unused
-	fnOpenSession     func(uint64, uint64, unsafe.Pointer, unsafe.Pointer, *uint64) uint64 //nolint:unused
+	fnInitialize      func(unsafe.Pointer) uint64                                          //nolint:unused // PKCS#11 function pointer reserved for future implementation
+	fnGetSlotList     func(bool, unsafe.Pointer, *uint64) uint64                           //nolint:unused // PKCS#11 function pointer reserved for future implementation
+	fnGetTokenInfo    func(uint64, unsafe.Pointer) uint64                                  //nolint:unused // PKCS#11 function pointer reserved for future implementation
+	fnOpenSession     func(uint64, uint64, unsafe.Pointer, unsafe.Pointer, *uint64) uint64 //nolint:unused // PKCS#11 function pointer reserved for future implementation
 	fnCloseSession    func(uint64) uint64
-	fnLogin           func(uint64, uint64, unsafe.Pointer, uint64) uint64 //nolint:unused
-	fnFindObjectsInit func(uint64, unsafe.Pointer, uint64) uint64         //nolint:unused
-	fnFindObjects     func(uint64, *uint64, uint64, *uint64) uint64       //nolint:unused
-	fnFindObjectsFin  func(uint64) uint64                                 //nolint:unused
+	fnLogin           func(uint64, uint64, unsafe.Pointer, uint64) uint64 //nolint:unused // PKCS#11 function pointer reserved for future implementation
+	fnFindObjectsInit func(uint64, unsafe.Pointer, uint64) uint64         //nolint:unused // PKCS#11 function pointer reserved for future implementation
+	fnFindObjects     func(uint64, *uint64, uint64, *uint64) uint64       //nolint:unused // PKCS#11 function pointer reserved for future implementation
+	fnFindObjectsFin  func(uint64) uint64                                 //nolint:unused // PKCS#11 function pointer reserved for future implementation
 	fnSignInit        func(uint64, unsafe.Pointer, uint64) uint64
 	fnSign            func(uint64, unsafe.Pointer, uint64, unsafe.Pointer, *uint64) uint64
-	fnGetAttrValue    func(uint64, uint64, unsafe.Pointer, uint64) uint64 //nolint:unused
+	fnGetAttrValue    func(uint64, uint64, unsafe.Pointer, uint64) uint64 //nolint:unused // PKCS#11 function pointer reserved for future implementation
 	fnFinalize        func(unsafe.Pointer) uint64
 }
 
@@ -253,7 +253,7 @@ func (s *Pkcs11Signer) Close() error {
 }
 
 // buildKeyTemplate constructs PKCS#11 search attributes from the config.
-func (s *Pkcs11Signer) buildKeyTemplate() ([]pkcs11Attribute, error) { //nolint:unused
+func (s *Pkcs11Signer) buildKeyTemplate() ([]pkcs11Attribute, error) { //nolint:unused // Reserved for future PKCS#11 implementation
 	classVal := uint64(ckoPrivateKey)
 	keyTypeVal := uint64(ckkEDDSA)
 

--- a/internal/simulator/helpers_test.go
+++ b/internal/simulator/helpers_test.go
@@ -4,4 +4,4 @@
 package simulator
 
 func uint32Ptr(v uint32) *uint32 { return &v }
-func stringPtr(s string) *string { return &s } //nolint:unused
+func stringPtr(s string) *string { return &s } //nolint:unused // Reserved for future test use

--- a/internal/terminal/ansi.go
+++ b/internal/terminal/ansi.go
@@ -118,7 +118,7 @@ func (r *ANSIRenderer) Error() string {
 	return "[X]"
 }
 
-func (r *ANSIRenderer) Symbol(name string) string { //nolint:gocyclo
+func (r *ANSIRenderer) Symbol(name string) string { //nolint:gocyclo // Large switch statement mapping symbol names to ASCII representations
 	if r.IsTTY() {
 		switch name {
 		case "check":

--- a/internal/trace/splitpane.go
+++ b/internal/trace/splitpane.go
@@ -104,7 +104,7 @@ func DefaultSplitPane() *SplitPane {
 func (p *SplitPane) Render(w io.Writer, node *TraceNode, src *SourceContext) {
 	width := p.resolveWidth()
 	bw := bufio.NewWriter(w)
-	defer func() { _ = bw.Flush() }() //nolint:errcheck
+	defer func() { _ = bw.Flush() }() //nolint:errcheck // Best-effort buffer flush on exit
 
 	p.renderTracePane(bw, node, width)
 	p.renderDivider(bw, width, src)

--- a/internal/trace/treeviewer_mouse.go
+++ b/internal/trace/treeviewer_mouse.go
@@ -46,13 +46,13 @@ func (tv *TreeViewerWithMouse) StartWithMouse() error {
 	if err := tv.enableRawMode(); err != nil {
 		return fmt.Errorf("failed to enable raw mode: %w", err)
 	}
-	defer func() { _ = tv.restoreTerminalState(initialTermState) }() //nolint:errcheck
+	defer func() { _ = tv.restoreTerminalState(initialTermState) }() //nolint:errcheck // Best-effort terminal restore on exit
 
 	// Enable mouse tracking
 	if err := tv.mouseTracker.Enable(); err != nil {
 		return fmt.Errorf("failed to enable mouse tracking: %w", err)
 	}
-	defer func() { _ = tv.mouseTracker.Disable() }() //nolint:errcheck
+	defer func() { _ = tv.mouseTracker.Disable() }() //nolint:errcheck // Best-effort mouse tracking disable on exit
 
 	// Build initial tree
 	nodes := make([]*TraceNode, 0)
@@ -218,20 +218,20 @@ func (tv *TreeViewerWithMouse) getTraceRoot() *TraceNode {
 // renderView clears and renders the current view
 func (tv *TreeViewerWithMouse) renderView() {
 	// Clear screen
-	_, _ = fmt.Print("\x1b[2J\x1b[H") //nolint:errcheck
+	_, _ = fmt.Print("\x1b[2J\x1b[H") //nolint:errcheck // Terminal output, write failure is non-critical
 
 	// Render header
-	_, _ = fmt.Printf("ERST Interactive Trace Tree Viewer (Mouse Support Enabled)\n")                  //nolint:errcheck
-	_, _ = fmt.Printf("Transaction: %s | Steps: %d\n", tv.trace.TransactionHash, len(tv.trace.States)) //nolint:errcheck
-	_, _ = fmt.Print("─────────────────────────────────────────────────────────\n")                    //nolint:errcheck
+	_, _ = fmt.Printf("ERST Interactive Trace Tree Viewer (Mouse Support Enabled)\n")                  //nolint:errcheck // Terminal output, write failure is non-critical
+	_, _ = fmt.Printf("Transaction: %s | Steps: %d\n", tv.trace.TransactionHash, len(tv.trace.States)) //nolint:errcheck // Terminal output, write failure is non-critical
+	_, _ = fmt.Print("─────────────────────────────────────────────────────────\n")                    //nolint:errcheck // Terminal output, write failure is non-critical
 
 	// Render tree
-	_, _ = fmt.Print(tv.renderer.Render()) //nolint:errcheck
+	_, _ = fmt.Print(tv.renderer.Render()) //nolint:errcheck // Terminal output, write failure is non-critical
 
 	// Render footer
-	_, _ = fmt.Print("\n─────────────────────────────────────────────────────────\n")                                                   //nolint:errcheck
-	_, _ = fmt.Print("Controls: n=next-step | ↑↓/kj=navigate | Space/Enter=expand | e=expand-all | c=collapse-all | h=help | q=quit\n") //nolint:errcheck
-	_, _ = fmt.Print(tv.renderCurrentStateView())                                                                                       //nolint:errcheck
+	_, _ = fmt.Print("\n─────────────────────────────────────────────────────────\n")                                                   //nolint:errcheck // Terminal output, write failure is non-critical
+	_, _ = fmt.Print("Controls: n=next-step | ↑↓/kj=navigate | Space/Enter=expand | e=expand-all | c=collapse-all | h=help | q=quit\n") //nolint:errcheck // Terminal output, write failure is non-critical
+	_, _ = fmt.Print(tv.renderCurrentStateView())                                                                                       //nolint:errcheck // Terminal output, write failure is non-critical
 }
 
 // showHelp displays help information
@@ -263,11 +263,11 @@ symbols with your mouse, or use keyboard shortcuts to navigate.
 
 Press any key to continue...
 `
-	_, _ = fmt.Print(helpText) //nolint:errcheck
+	_, _ = fmt.Print(helpText) //nolint:errcheck // Terminal output, write failure is non-critical
 
 	// Wait for input
 	buf := make([]byte, 1)
-	_, _ = syscall.Read(0, buf) //nolint:errcheck
+	_, _ = syscall.Read(0, buf) //nolint:errcheck // Best-effort input wait in help view
 
 	tv.renderView()
 }
@@ -339,6 +339,6 @@ func (tv *TreeViewerWithMouse) restoreTerminalState(state string) error {
 func (tv *TreeViewerWithMouse) enableRawMode() error {
 	// Enable raw mode using stty-like behavior
 	// Hide cursor
-	_, _ = fmt.Print("\x1b[?25l") //nolint:errcheck
+	_, _ = fmt.Print("\x1b[?25l") //nolint:errcheck // Terminal output, write failure is non-critical
 	return nil
 }

--- a/internal/updater/checker_test.go
+++ b/internal/updater/checker_test.go
@@ -283,7 +283,7 @@ func TestAPIIntegration(t *testing.T) {
 				TagName: "v1.2.3",
 			}
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(response) //nolint:errcheck
+			_ = json.NewEncoder(w).Encode(response) //nolint:errcheck // Test code, HTTP response writer failure is not critical
 		}))
 		defer server.Close()
 

--- a/internal/visualizer/color.go
+++ b/internal/visualizer/color.go
@@ -33,7 +33,7 @@ func ColorEnabled() bool {
 }
 
 // colorMap maps color names to ANSI SGR codes.
-var colorMap = map[string]string{ //nolint:unused
+var colorMap = map[string]string{ //nolint:unused // Reserved for future use in dynamic color mapping
 	"red":     sgrRed,
 	"green":   sgrGreen,
 	"yellow":  sgrYellow,
@@ -107,7 +107,7 @@ func Info() string {
 
 // Symbol returns a symbol name rendered as ASCII markers.
 //
-//nolint:gocyclo
+//nolint:gocyclo // Large switch statement mapping symbol names to ASCII representations
 func Symbol(name string) string {
 	if ColorEnabled() {
 		switch name {

--- a/internal/wat/disassembler.go
+++ b/internal/wat/disassembler.go
@@ -819,7 +819,7 @@ func WriteWATToFile(path string, wasmBytes []byte) error {
 
 // decodeOpcode returns the WAT mnemonic, operand string, and number of
 // additional bytes consumed for operands.
-func decodeOpcode(opcode byte, rest []byte) (string, string, int) { //nolint:gocyclo
+func decodeOpcode(opcode byte, rest []byte) (string, string, int) { //nolint:gocyclo // Large switch statement mapping WASM opcodes to WAT mnemonics is naturally complex
 	switch opcode {
 	// Control flow
 	case 0x00:


### PR DESCRIPTION
This commit adds explanatory rationale comments to every //nolint directive
in the codebase, explaining why each linter warning is being bypassed.
closes #1193 
