### PR TITLE
feat(visualizer): add ASCII event tree renderer with tests

### DIFF
--- a/internal/visualizer/events.go
+++ b/internal/visualizer/events.go
@@ -1,0 +1,64 @@
+package visualizer
+
+import (
+	"strings"
+)
+
+// Event represents an emitted contract event during a contract call.
+type Event struct {
+	Type     string
+	Metadata string
+	Children []Event
+}
+
+// RenderEventTree renders a list of events as a structured ASCII tree.
+func RenderEventTree(events []Event) string {
+	if len(events) == 0 {
+		return "No events recorded."
+	}
+
+	var sb strings.Builder
+	sb.WriteString("Events\n")
+
+	renderNodes(&sb, events, "")
+
+	return strings.TrimSuffix(sb.String(), "\n")
+}
+
+// renderNodes is a recursive helper that builds the ASCII tree structure.
+func renderNodes(sb *strings.Builder, events []Event, prefix string) {
+	for i, event := range events {
+		isLast := i == len(events)-1
+
+		// Write the current level's prefix and branch character
+		sb.WriteString(prefix)
+		if isLast {
+			sb.WriteString("└── ")
+		} else {
+			sb.WriteString("├── ")
+		}
+
+		// Write the event type
+		sb.WriteString(event.Type)
+
+		// Optionally write metadata if present
+		if event.Metadata != "" {
+			sb.WriteString(" (")
+			sb.WriteString(event.Metadata)
+			sb.WriteString(")")
+		}
+
+		sb.WriteByte('\n')
+
+		// Recursively render children with updated prefix
+		if len(event.Children) > 0 {
+			nextPrefix := prefix
+			if isLast {
+				nextPrefix += "    "
+			} else {
+				nextPrefix += "│   "
+			}
+			renderNodes(sb, event.Children, nextPrefix)
+		}
+	}
+}

--- a/internal/visualizer/events.go
+++ b/internal/visualizer/events.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
 package visualizer
 
 import (

--- a/internal/visualizer/events_test.go
+++ b/internal/visualizer/events_test.go
@@ -1,0 +1,36 @@
+package visualizer
+
+import "testing"
+
+func TestRenderEventTree_Basic(t *testing.T) {
+	events := []Event{
+		{Type: "INIT_TRANSFER"},
+		{
+			Type: "DEBIT_ACCOUNT",
+			Children: []Event{
+				{Type: "FEE_CALC"},
+			},
+		},
+		{Type: "COMPLETE"},
+	}
+
+	output := RenderEventTree(events)
+
+	expected := `Events
+├── INIT_TRANSFER
+├── DEBIT_ACCOUNT
+│   └── FEE_CALC
+└── COMPLETE`
+
+	if output != expected {
+		t.Fatalf("unexpected output:\n%s", output)
+	}
+}
+
+func TestRenderEventTree_Empty(t *testing.T) {
+	output := RenderEventTree(nil)
+
+	if output != "No events recorded." {
+		t.Fatalf("unexpected output: %s", output)
+	}
+}

--- a/internal/visualizer/events_test.go
+++ b/internal/visualizer/events_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
 package visualizer
 
 import "testing"


### PR DESCRIPTION
## Feature: Structured ASCII Event Tree View

### Summary
Introduces a structured ASCII tree view for events emitted during contract execution, separate from the call graph.

### Changes
- Added `internal/visualizer/events.go`
- Implemented `RenderEventTree(events []Event) string`
- Supports nested event structures using ASCII tree formatting
- Gracefully handles empty inputs

Closes #1200 