### PR TITLE
#1348 Validate Ledger Entry Keys in Builder FIXED

### DIFF
--- a/internal/simulator/builder.go
+++ b/internal/simulator/builder.go
@@ -17,7 +17,7 @@ import (
 //	req, err := NewSimulationRequestBuilder().
 //		WithEnvelopeXDR("AAAAAgAAAA...").
 //		WithResultMetaXDR("AAAAAQAAA...").
-//		WithLedgerEntry("key1", "value1").
+//		WithLedgerEntry("a2V5MQ==", "dmFsdWUx").
 //		Build()
 type SimulationRequestBuilder struct {
 	envelopeXdr               string
@@ -52,7 +52,8 @@ func (b *SimulationRequestBuilder) WithResultMetaXDR(xdr string) *SimulationRequ
 }
 
 // WithLedgerEntry adds a single ledger entry to the snapshot.
-// The key and value should both be XDR encoded.
+// The key and value should both be valid base64-encoded XDR strings.
+// Malformed base64 entries are caught at build time rather than during simulation.
 func (b *SimulationRequestBuilder) WithLedgerEntry(key, value string) *SimulationRequestBuilder {
 	if key == "" {
 		b.errors = append(b.errors, "ledger entry key cannot be empty")
@@ -62,12 +63,21 @@ func (b *SimulationRequestBuilder) WithLedgerEntry(key, value string) *Simulatio
 		b.errors = append(b.errors, fmt.Sprintf("ledger entry value for key '%s' cannot be empty", key))
 		return b
 	}
+	if !isValidBase64(key) {
+		b.errors = append(b.errors, fmt.Sprintf("ledger entry key '%s' is not valid base64", key))
+		return b
+	}
+	if !isValidBase64(value) {
+		b.errors = append(b.errors, fmt.Sprintf("ledger entry value for key '%s' is not valid base64", key))
+		return b
+	}
 	b.ledgerEntries[key] = value
 	return b
 }
 
 // WithLedgerEntries sets multiple ledger entries at once.
 // This replaces any previously set ledger entries.
+// Each key and value must be valid base64-encoded XDR.
 func (b *SimulationRequestBuilder) WithLedgerEntries(entries map[string]string) *SimulationRequestBuilder {
 	if entries == nil {
 		b.ledgerEntries = make(map[string]string)
@@ -82,6 +92,14 @@ func (b *SimulationRequestBuilder) WithLedgerEntries(entries map[string]string) 
 		}
 		if value == "" {
 			b.errors = append(b.errors, fmt.Sprintf("ledger entry value for key '%s' cannot be empty", key))
+			continue
+		}
+		if !isValidBase64(key) {
+			b.errors = append(b.errors, fmt.Sprintf("ledger entry key '%s' is not valid base64", key))
+			continue
+		}
+		if !isValidBase64(value) {
+			b.errors = append(b.errors, fmt.Sprintf("ledger entry value for key '%s' is not valid base64", key))
 			continue
 		}
 	}

--- a/internal/simulator/concurrency_test.go
+++ b/internal/simulator/concurrency_test.go
@@ -198,9 +198,9 @@ func TestConcurrentBuilderReadOnlyAccess(t *testing.T) {
 	req, err := NewSimulationRequestBuilder().
 		WithEnvelopeXDR("envelope_xdr_data").
 		WithResultMetaXDR("result_meta_xdr_data").
-		WithLedgerEntry("key1", "value1").
-		WithLedgerEntry("key2", "value2").
-		WithLedgerEntry("key3", "value3").
+		WithLedgerEntry("a2V5MQ==", "dmFsdWUx").
+		WithLedgerEntry("a2V5Mg==", "dmFsdWUy").
+		WithLedgerEntry("a2V5Mw==", "dmFsdWUz").
 		Build()
 	if err != nil {
 		t.Fatalf("builder error: %v", err)

--- a/internal/simulator/example_test.go
+++ b/internal/simulator/example_test.go
@@ -30,8 +30,8 @@ func ExampleSimulationRequestBuilder_withLedgerEntries() {
 	req, err := simulator.NewSimulationRequestBuilder().
 		WithEnvelopeXDR("AAAAAgAAAACE...").
 		WithResultMetaXDR("AAAAAQAAAAA...").
-		WithLedgerEntry("key1", "value1").
-		WithLedgerEntry("key2", "value2").
+		WithLedgerEntry("a2V5MQ==", "dmFsdWUx").
+		WithLedgerEntry("a2V5Mg==", "dmFsdWUy").
 		Build()
 
 	if err != nil {
@@ -46,9 +46,9 @@ func ExampleSimulationRequestBuilder_withLedgerEntries() {
 // ExampleSimulationRequestBuilder_bulkLedgerEntries demonstrates setting multiple entries at once.
 func ExampleSimulationRequestBuilder_bulkLedgerEntries() {
 	entries := map[string]string{
-		"contract_key_1": "contract_value_1",
-		"contract_key_2": "contract_value_2",
-		"contract_key_3": "contract_value_3",
+		"Y29udHJhY3Rfa2V5XzE=": "Y29udHJhY3RfdmFsdWVfMQ==",
+		"Y29udHJhY3Rfa2V5XzI=": "Y29udHJhY3RfdmFsdWVfMg==",
+		"Y29udHJhY3Rfa2V5XzM=": "Y29udHJhY3RfdmFsdWVfMw==",
 	}
 
 	req, err := simulator.NewSimulationRequestBuilder().


### PR DESCRIPTION
PULL REQUEST TEMPLATE
TITLE: Validate Ledger Entry Keys in Builder

fix(simulator): Add base64 validation to WithLedgerEntry and WithLedgerEntries builder methods


DESCRIPTION:
The SimulationRequestBuilder methods WithLedgerEntry and WithLedgerEntries in internal/simulator/builder.go were only validating for empty strings but never checking if the provided keys and values were valid base64-encoded XDR. Malformed entries like "key1", "!!!bad!!!", or "not@@base64" were silently accepted at build time and only failed later during simulation — making errors confusing and far from the root cause.

This PR adds base64 decoding checks to both methods so malformed entries are caught immediately during request construction, not deferred to simulation.


## Changes

Core Fix — internal/simulator/builder.go
WithLedgerEntry(key, value):

Added isValidBase64(key) check after the existing empty-string guard
Added isValidBase64(value) check after the key validation
On failure, appends a descriptive error (e.g. "ledger entry key 'xxx' is not valid base64") to b.errors and does not store the entry
Uses the existing isValidBase64() function from validator.go (same simulator package) — zero new imports required
WithLedgerEntries(entries):

Added the same isValidBase64(key) and isValidBase64(value) checks inside the existing validation loop
Uses continue to collect all errors across all entries (not just the first one)
Consistent with the existing error accumulation pattern in the builder
Doc comments:

Updated from "should both be XDR encoded" to "must be valid base64-encoded XDR strings"
Added explicit note: "Malformed base64 entries are caught at build time rather than during simulation"
Updated the package-level example to use valid base64 strings
Test Updates
internal/simulator/concurrency_test.go:

TestConcurrentBuilderReadOnlyAccess: Changed non-base64 strings ("key1"/"value1", etc.) to their valid base64 equivalents ("a2V5MQ=="/"dmFsdWUx", etc.)
internal/simulator/example_test.go:

ExampleSimulationRequestBuilder_withLedgerEntries: Updated to valid base64
ExampleSimulationRequestBuilder_bulkLedgerEntries: Updated map entries to valid base64


## Verification

All verification checks passed successfully, including go vet, simulator tests, and a full project build with no errors.

Behavior Before Fix

Invalid base64 ledger entries were accepted during request construction and only failed later during simulation, making debugging more difficult.

Behavior After Fix

Invalid base64 ledger entries are detected immediately during request building, producing clear validation errors before simulation begins.

Files Modified

builder.go received the validation logic and documentation updates, while test and example files were updated with valid base64 data.

Design Decisions

The implementation reuses existing validation utilities, rejects invalid data early, preserves the builder's error accumulation pattern, and remains fully backward compatible for valid inputs.

Related Issues

This PR resolves the issue where WithLedgerEntry failed to verify that provided keys and values were valid base64-encoded XDR data.

Closes #1348 

Type of Change

This is a bug fix that improves validation behavior without introducing breaking changes.

Checklist

The changes follow project standards, were self-reviewed, tested, lint-checked, verified locally, and maintain backward compatibility.