### PR TITLE
fix(lsp): ensure graceful shutdown of LSP server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stellar/go-stellar-sdk v0.5.0
 	github.com/stretchr/testify v1.11.1
+	go.lsp.dev/jsonrpc2 v0.10.0
 	go.lsp.dev/protocol v0.12.0
 	go.opentelemetry.io/otel v1.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.28.0
@@ -56,7 +57,6 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stellar/go-xdr v0.0.0-20260423131911-a87d4d0789c3 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	go.lsp.dev/jsonrpc2 v0.10.0 // indirect
 	go.lsp.dev/pkg v0.0.0-20210717090340-384b27a52fb2 // indirect
 	go.lsp.dev/uri v0.3.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -4,12 +4,17 @@
 package lsp
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"sync"
 
 	"github.com/dotandev/hintents/internal/visualizer"
+	"go.lsp.dev/jsonrpc2"
 	"go.lsp.dev/protocol"
 )
 
@@ -17,6 +22,9 @@ import (
 type Server struct {
 	mu        sync.RWMutex
 	documents map[protocol.DocumentURI]string
+
+	connMu sync.Mutex
+	conn   jsonrpc2.Conn
 }
 
 // NewServer creates a new LSP backend server.
@@ -24,6 +32,138 @@ func NewServer() *Server {
 	return &Server{
 		documents: make(map[protocol.DocumentURI]string),
 	}
+}
+
+// Run serves LSP requests over the provided JSON-RPC stream until the context
+// is cancelled or the client disconnects. The main event loop listens for
+// context cancellation so JSON-RPC connections and internal channels close
+// cleanly instead of leaving orphan processes behind.
+func (s *Server) Run(ctx context.Context, r io.Reader, w io.Writer) error {
+	stream := jsonrpc2.NewStream(&readWriteCloser{Reader: r, Writer: w})
+	conn := jsonrpc2.NewConn(stream)
+
+	s.connMu.Lock()
+	s.conn = conn
+	s.connMu.Unlock()
+
+	conn.Go(ctx, s.handler())
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.closeConnection()
+			<-conn.Done()
+			if err := conn.Err(); err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, io.EOF) {
+				return err
+			}
+			return ctx.Err()
+		case <-conn.Done():
+			if err := conn.Err(); err != nil && !errors.Is(err, io.EOF) {
+				return err
+			}
+			return nil
+		}
+	}
+}
+
+func (s *Server) handler() jsonrpc2.Handler {
+	return func(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		if ctx.Err() != nil {
+			return reply(ctx, nil, protocol.ErrRequestCancelled)
+		}
+
+		dec := json.NewDecoder(bytes.NewReader(req.Params()))
+
+		switch req.Method() {
+		case protocol.MethodInitialize:
+			var params protocol.InitializeParams
+			if err := dec.Decode(&params); err != nil {
+				return reply(ctx, nil, fmt.Errorf("%w: %v", jsonrpc2.ErrParse, err))
+			}
+			resp, err := s.Initialize(ctx, &params)
+			return reply(ctx, resp, err)
+
+		case protocol.MethodInitialized:
+			var params protocol.InitializedParams
+			if err := dec.Decode(&params); err != nil {
+				return reply(ctx, nil, fmt.Errorf("%w: %v", jsonrpc2.ErrParse, err))
+			}
+			return reply(ctx, nil, s.Initialized(ctx, &params))
+
+		case protocol.MethodShutdown:
+			if len(req.Params()) > 0 {
+				return reply(ctx, nil, fmt.Errorf("expected no params: %w", jsonrpc2.ErrInvalidParams))
+			}
+			return reply(ctx, nil, s.Shutdown(ctx))
+
+		case protocol.MethodExit:
+			if len(req.Params()) > 0 {
+				return reply(ctx, nil, fmt.Errorf("expected no params: %w", jsonrpc2.ErrInvalidParams))
+			}
+			err := s.Exit(ctx)
+			_ = reply(ctx, nil, err)
+			return err
+
+		case protocol.MethodTextDocumentDidOpen:
+			var params protocol.DidOpenTextDocumentParams
+			if err := dec.Decode(&params); err != nil {
+				return reply(ctx, nil, fmt.Errorf("%w: %v", jsonrpc2.ErrParse, err))
+			}
+			return reply(ctx, nil, s.DidOpen(ctx, &params))
+
+		case protocol.MethodTextDocumentDidChange:
+			var params protocol.DidChangeTextDocumentParams
+			if err := dec.Decode(&params); err != nil {
+				return reply(ctx, nil, fmt.Errorf("%w: %v", jsonrpc2.ErrParse, err))
+			}
+			return reply(ctx, nil, s.DidChange(ctx, &params))
+
+		case protocol.MethodTextDocumentDidClose:
+			var params protocol.DidCloseTextDocumentParams
+			if err := dec.Decode(&params); err != nil {
+				return reply(ctx, nil, fmt.Errorf("%w: %v", jsonrpc2.ErrParse, err))
+			}
+			return reply(ctx, nil, s.DidClose(ctx, &params))
+
+		case protocol.MethodTextDocumentHover:
+			var params protocol.HoverParams
+			if err := dec.Decode(&params); err != nil {
+				return reply(ctx, nil, fmt.Errorf("%w: %v", jsonrpc2.ErrParse, err))
+			}
+			resp, err := s.Hover(ctx, &params)
+			return reply(ctx, resp, err)
+
+		default:
+			return reply(ctx, nil, jsonrpc2.ErrMethodNotFound)
+		}
+	}
+}
+
+func (s *Server) closeConnection() {
+	s.connMu.Lock()
+	defer s.connMu.Unlock()
+
+	if s.conn == nil {
+		return
+	}
+
+	_ = s.conn.Close()
+	s.conn = nil
+}
+
+func (s *Server) clearDocuments() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.documents = make(map[protocol.DocumentURI]string)
+}
+
+type readWriteCloser struct {
+	io.Reader
+	io.Writer
+}
+
+func (r *readWriteCloser) Close() error {
+	return nil
 }
 
 // Initialize validates the LSP initialization request and advertises capabilities.
@@ -46,11 +186,13 @@ func (s *Server) Initialized(ctx context.Context, params *protocol.InitializedPa
 
 // Shutdown ends the current LSP session.
 func (s *Server) Shutdown(ctx context.Context) error {
+	s.clearDocuments()
 	return nil
 }
 
 // Exit is called when the LSP client exits.
 func (s *Server) Exit(ctx context.Context) error {
+	s.closeConnection()
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Add a `Run()` event loop with a `context.Done()` listener in the LSP server
- Close JSON-RPC connections and clear internal document state on shutdown/exit
- Prevent orphan LSP processes when the server is cancelled or the client disconnects

closes #1369

## Test plan
- [x] `go test ./internal/lsp/...`
- [ ] Start the LSP server, send `shutdown` + `exit`, confirm the process exits cleanly
- [ ] Cancel the server context (SIGINT/SIGTERM) and confirm no orphan process remains

Made with [Cursor](https://cursor.com)