### PR TITLE
fix(shell): clamp ledger timestamp during time-travel debugging

### DIFF
--- a/internal/shell/session.go
+++ b/internal/shell/session.go
@@ -14,6 +14,10 @@ import (
 	"github.com/dotandev/hintents/internal/simulator"
 )
 
+// maxShellTimestamp is the latest allowed ledger timestamp (2100-01-01 UTC).
+// Prevents unbounded growth when the clock is behind during extended time-travel debugging.
+const maxShellTimestamp int64 = 4102444800
+
 // Session represents an interactive shell session with persistent ledger state
 type Session struct {
 	runner          simulator.RunnerInterface
@@ -129,6 +133,9 @@ func (s *Session) updateLedgerState(resp *simulator.SimulationResponse) {
 	now := time.Now().Unix()
 	if now <= s.timestamp {
 		now = s.timestamp + 1
+	}
+	if now > maxShellTimestamp {
+		now = maxShellTimestamp
 	}
 	s.timestamp = now
 


### PR DESCRIPTION
## Summary
- Add `maxShellTimestamp` constant (2100-01-01 UTC) to bound shell ledger timestamps
- Clamp computed timestamp in `updateLedgerState` when incrementing past a stale clock during extended time-travel debugging

closes #1370

## Test plan
- [x] `go test ./internal/shell/... -count=1`


Made with [Cursor](https://cursor.com)