### PR TITLE
feat(audit): enforce canonical JSON marshaling for signed audit envelope

### DIFF
--- a/internal/cmd/audit_sign.go
+++ b/internal/cmd/audit_sign.go
@@ -105,16 +105,18 @@ func runAuditSign(cmd *cobra.Command, args []string) error {
 		return errors.WrapValidationError(fmt.Sprintf("failed to retrieve public key: %v", err))
 	}
 
-	auditLog := SignedAuditLog{
-		Version:   "1.0.0",
-		Timestamp: time.Now().UTC(),
-		TraceHash: hex.EncodeToString(hash[:]),
-		Signature: hex.EncodeToString(signature),
-		PublicKey: hex.EncodeToString(publicKey),
-		Payload:   json.RawMessage(payloadBytes),
+	// Build the envelope as a plain map so marshalCanonical can sort all keys,
+	// including nested ones, deterministically.
+	envelope := map[string]interface{}{
+		"version":    "1.0.0",
+		"timestamp":  time.Now().UTC().Format(time.RFC3339Nano),
+		"trace_hash": hex.EncodeToString(hash[:]),
+		"signature":  hex.EncodeToString(signature),
+		"public_key": hex.EncodeToString(publicKey),
+		"payload":    payload, // already decoded interface{}; canonical encoder will sort its keys
 	}
 
-	output, err := json.MarshalIndent(auditLog, "", "  ")
+	output, err := marshalCanonical(envelope)
 	if err != nil {
 		return errors.WrapMarshalFailed(err)
 	}


### PR DESCRIPTION
Description
  
  The audit signing pipeline hashed a canonical form of the payload but serialized the outer
  SignedAuditLog envelope using json.MarshalIndent, which emits keys in struct-field declaration
  order and stores the original (non-canonical) payload bytes. This created a mismatch: the
  payload field in the output diverged from what was actually hashed and signed, making
  independent verification against the output unreliable.
  
  This change replaces the struct-based envelope serialization with a map[string]interface{}
  passed through the existing marshalCanonical pipeline, ensuring:
  
  - All object keys in the output — including nested keys inside payload — are sorted
  alphabetically
  - The payload field in the output is byte-for-byte identical to what was hashed
  - The full envelope is compact, whitespace-free, and deterministic across platforms, matching
  the behavior of fast-json-stable-stringify on the Node.js side
  
  Related Issues
  
  Closes #— (canonical JSON parity between Go CLI and Node.js audit signer)
  
  Testing
  
  Existing tests (TestRunAuditSign_OutputsJSON, TestMarshalCanonical_*, TestCanonicalJSON_*) pass
  without modification. The output envelope is now verifiable by deserializing and
  re-canonicalizing independently.
  
  Checklist
  
  - [x] Code follows style guidelines
  - [x] Tests pass
  - [x] No new warnings or errors
  - [x] No new dependencies introduced

closes #1371 