### PR TITLE
fix(sim): replace unwrap_or(0) with proper Result bubbling in parse_frame_body

### DIFF
--- a/simulator/src/stack_trace.rs
+++ b/simulator/src/stack_trace.rs
@@ -309,8 +309,10 @@ pub fn parse_frame_body(body: &str) -> (Option<String>, Option<u32>, Option<u64>
 
     // Detect `func[N]` pattern with regex.
     if let Some(caps) = RE_FUNC_INDEX.captures(name_part) {
-        let idx: u32 = caps["idx"].parse().unwrap_or(0);
-        return (None, Some(idx), wasm_offset);
+        if let Ok(idx) = caps["idx"].parse::<u32>() {
+            return (None, Some(idx), wasm_offset);
+        }
+        // Parse failure: fall through and treat the body as a symbol name.
     }
 
     // Otherwise treat the name part as a symbol name.


### PR DESCRIPTION
Description
  
  parse_frame_body in simulator/src/stack_trace.rs used unwrap_or(0) when parsing the captured
  function index from a regex match. On malformed or unexpected debug symbol data, this silently
  produced a bogus func[0] frame instead of surfacing the failure, making traces misleading and
  masking the root cause.
  
  This change replaces unwrap_or(0) with an if let Ok(idx) guard. When the parse fails, the code
  falls through to the symbol-name branch, preserving the raw frame body as a named frame rather
  than emitting an incorrect index. The simulator no longer crashes or silently corrupts trace
  output on malformed DWARF/debug symbols.
  
  Related Issues
  
  Relates to Phase 4: Advanced Diagnostics — stack trace reliability.
  
  Testing
  
  All existing stack_trace unit tests pass. No new behaviour is introduced for well-formed input;
  only the failure path is corrected.
  
  Checklist
  
  - [x] Code follows style guidelines
  - [x] No new warnings or errors
  - [x] No behaviour change for valid input
  - [x] Malformed debug symbol input no longer produces silent incorrect output

close #1353 