### PR TITLE
feat(shell): extract ledger state from simulation response

### DIFF
--- a/internal/shell/session.go
+++ b/internal/shell/session.go
@@ -75,13 +75,15 @@ func (s *Session) Invoke(ctx context.Context, contractID, function string, args 
 		return nil, fmt.Errorf("failed to build envelope: %w", err)
 	}
 
-	// Create simulation request
+	// Create simulation request with snapshots enabled so updateLedgerState
+	// can read post-execution ledger entry diffs from the response.
 	req := &simulator.SimulationRequest{
-		EnvelopeXdr:    envelopeXDR,
-		ResultMetaXdr:  "",
-		LedgerEntries:  s.ledgerEntries,
-		Timestamp:      s.timestamp,
-		LedgerSequence: s.ledgerSequence,
+		EnvelopeXdr:     envelopeXDR,
+		ResultMetaXdr:   "",
+		LedgerEntries:   s.ledgerEntries,
+		Timestamp:       s.timestamp,
+		LedgerSequence:  s.ledgerSequence,
+		EnableSnapshots: true,
 	}
 
 	// Execute simulation
@@ -120,20 +122,31 @@ func (s *Session) buildInvocationEnvelope(contractID, function string, args []st
 	return "", fmt.Errorf("envelope building not yet implemented - requires stellar-sdk integration")
 }
 
-// updateLedgerState updates the session's ledger state based on simulation results
+// updateLedgerState updates the session's ledger state based on simulation results.
+// It parses ledger entry diffs from the simulator's inline snapshot payload and
+// merges them into s.ledgerEntries to maintain persistent shell session state.
 func (s *Session) updateLedgerState(resp *simulator.SimulationResponse) {
-	// Increment ledger sequence
 	s.ledgerSequence++
 
-	// Update timestamp
 	now := time.Now().Unix()
 	if now <= s.timestamp {
 		now = s.timestamp + 1
 	}
 	s.timestamp = now
 
-	// TODO: Extract and update ledger entries from simulation response
-	// This would involve parsing the ResultMetaXDR to get state changes
+	if resp.OptimizationReport == nil || resp.OptimizationReport.Snapshots == nil {
+		return
+	}
+
+	// Each inline snapshot contains ledger entry pairs: [keyXDR_b64, entryXDR_b64].
+	// Merge all snapshots so the session reflects the post-simulation state.
+	for _, snapshot := range resp.OptimizationReport.Snapshots.Inline {
+		for _, pair := range snapshot.LedgerEntries {
+			if len(pair) == 2 {
+				s.ledgerEntries[pair[0]] = pair[1]
+			}
+		}
+	}
 }
 
 // GetStateSummary returns a summary of the current ledger state


### PR DESCRIPTION
## Summary

- Removes the TODO from updateLedgerState in internal/shell/session.go
- Enables EnableSnapshots: true on every SimulationRequest from Invoke so the simulator returns post-execution ledger entry diffs
- Parses esp.OptimizationReport.Snapshots.Inline — each inline snapshot carries LedgerEntries [][]string as [keyXDR_b64, entryXDR_b64] pairs
- Merges all snapshot pairs into s.ledgerEntries so session state reflects real ledger changes after each invocation

## Test plan
- [ ] go build ./... passes
- [ ] go test ./internal/shell/... passes
- [ ] GetStateSummary().EntryCount grows after invocations that write ledger entries

Closes #1347