### PR TITLE
fix: improve network flag validation

### DIFF
--- a/internal/cmd/dry_run.go
+++ b/internal/cmd/dry_run.go
@@ -45,6 +45,8 @@ Example:
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// Validate network flag
 		switch rpc.Network(dryRunNetworkFlag) {
+		case rpc.Testnet, rpc.Mainnet, rpc.Futurenet:
+			return nil
 		default:
 			return errors.WrapInvalidNetwork(dryRunNetworkFlag)
 		}

--- a/internal/cmd/dry_run_test.go
+++ b/internal/cmd/dry_run_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDryRunCmd_NetworkValidation_ValidNetworks(t *testing.T) {
+	validNetworks := []string{"testnet", "mainnet", "futurenet"}
+	for _, network := range validNetworks {
+		t.Run(network, func(t *testing.T) {
+			prev := dryRunNetworkFlag
+			t.Cleanup(func() { dryRunNetworkFlag = prev })
+			dryRunNetworkFlag = network
+
+			err := dryRunCmd.PreRunE(dryRunCmd, []string{})
+			if err != nil {
+				t.Errorf("expected network %q to pass validation, got error: %v", network, err)
+			}
+		})
+	}
+}
+
+func TestDryRunCmd_NetworkValidation_InvalidNetwork(t *testing.T) {
+	prev := dryRunNetworkFlag
+	t.Cleanup(func() { dryRunNetworkFlag = prev })
+	dryRunNetworkFlag = "invalidnet"
+
+	err := dryRunCmd.PreRunE(dryRunCmd, []string{})
+	if err == nil {
+		t.Fatal("expected validation to fail for invalid network, got nil error")
+	}
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "invalidnet") {
+		t.Errorf("expected error to contain the invalid value %q, got: %s", "invalidnet", errMsg)
+	}
+	for _, valid := range []string{"testnet", "mainnet", "futurenet"} {
+		if !strings.Contains(errMsg, valid) {
+			t.Errorf("expected error to list supported value %q, got: %s", valid, errMsg)
+		}
+	}
+}
+
+func TestDryRunCmd_NetworkValidation_EmptyNetwork(t *testing.T) {
+	prev := dryRunNetworkFlag
+	t.Cleanup(func() { dryRunNetworkFlag = prev })
+	dryRunNetworkFlag = ""
+
+	err := dryRunCmd.PreRunE(dryRunCmd, []string{})
+	if err == nil {
+		t.Fatal("expected validation to fail for empty network, got nil error")
+	}
+}


### PR DESCRIPTION
Closes #1350

## Summary
- Added explicit `case rpc.Testnet, rpc.Mainnet, rpc.Futurenet` handling in `dryRunCmd.PreRunE` so valid networks pass validation without error
- The `default` case returns a descriptive `WrapInvalidNetwork` error that identifies the invalid value and lists all supported options (`testnet`, `mainnet`, `futurenet`)
- Added `internal/cmd/dry_run_test.go` with tests covering all valid networks, an invalid network value, and an empty network value

## Testing
- `go test ./...` — all packages pass
- Verified valid networks (`testnet`, `mainnet`, `futurenet`) accepted without error
- Verified descriptive error returned for unsupported values (e.g. `invalidnet`)
- Verified empty network value is rejected