### PR TITLE
fix: improve crash reporter resilience

### DIFF
--- a/internal/crashreport/reporter.go
+++ b/internal/crashreport/reporter.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"runtime"
@@ -94,6 +95,7 @@ type Reporter struct {
 	cfg          Config
 	client       *http.Client
 	sentryActive bool
+	stderr       io.Writer
 }
 
 // New creates a Reporter from cfg, initialising Sentry if a DSN is available.
@@ -123,6 +125,7 @@ func New(cfg Config) *Reporter {
 		client: &http.Client{
 			Timeout: defaultTimeout,
 		},
+		stderr: os.Stderr,
 	}
 
 	if cfg.SentryDSN != "" {
@@ -178,6 +181,7 @@ func (r *Reporter) Send(ctx context.Context, err error, stack []byte, command st
 	}
 
 	if len(errs) > 0 {
+		fmt.Fprintf(r.stderr, "warning: failed to submit crash report\n")
 		return fmt.Errorf("crashreport: %v", errs)
 	}
 	return nil

--- a/internal/crashreport/reporter_test.go
+++ b/internal/crashreport/reporter_test.go
@@ -4,6 +4,7 @@
 package crashreport
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -14,6 +15,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -351,4 +353,78 @@ func TestIsEnabled_EnvVarNo(t *testing.T) {
 	setEnv(t, envOptIn, "no")
 	r := New(Config{Enabled: true})
 	assert.False(t, r.IsEnabled())
+}
+
+// ---- Resilience: timeout and network failure ---------------------------------
+
+func TestSend_TimeoutDoesNotHangCLI(t *testing.T) {
+	setEnv(t, envOptIn, "true")
+
+	// Server that stalls just long enough to trigger the client timeout, then exits.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-time.After(500 * time.Millisecond):
+		}
+	}))
+	defer srv.Close()
+
+	reporter := New(Config{Enabled: true, Endpoint: srv.URL})
+	// Use a very short client timeout so the test completes quickly.
+	reporter.client.Timeout = 50 * time.Millisecond
+
+	var buf bytes.Buffer
+	reporter.stderr = &buf
+
+	start := time.Now()
+	err := reporter.Send(context.Background(), errors.New("crash"), nil, "")
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "should return an error on timeout")
+	assert.Less(t, elapsed, 5*time.Second, "Send should not block longer than the timeout")
+	assert.Contains(t, buf.String(), "warning: failed to submit crash report")
+}
+
+func TestSend_NetworkFailureDoesNotPanic(t *testing.T) {
+	setEnv(t, envOptIn, "true")
+
+	reporter := New(Config{Enabled: true, Endpoint: "http://localhost:0/unreachable"})
+
+	var buf bytes.Buffer
+	reporter.stderr = &buf
+
+	// Must not panic.
+	require.NotPanics(t, func() {
+		_ = reporter.Send(context.Background(), errors.New("crash"), nil, "")
+	})
+}
+
+func TestSend_WarningEmittedOnFailure(t *testing.T) {
+	setEnv(t, envOptIn, "true")
+
+	srv := newTestServer(t, http.StatusInternalServerError, nil)
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	reporter := New(Config{Enabled: true, Endpoint: srv.URL})
+	reporter.stderr = &buf
+
+	err := reporter.Send(context.Background(), errors.New("crash"), nil, "")
+	require.Error(t, err)
+	assert.Contains(t, buf.String(), "warning: failed to submit crash report")
+}
+
+func TestSend_NoWarningOnSuccess(t *testing.T) {
+	setEnv(t, envOptIn, "true")
+
+	srv := newTestServer(t, http.StatusOK, nil)
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	reporter := New(Config{Enabled: true, Endpoint: srv.URL})
+	reporter.stderr = &buf
+
+	err := reporter.Send(context.Background(), errors.New("crash"), nil, "")
+	require.NoError(t, err)
+	assert.Empty(t, buf.String(), "no warning should be emitted on success")
 }


### PR DESCRIPTION
Closes #1355

## Summary
- Added `stderr io.Writer` field to `Reporter` (defaults to `os.Stderr`) for testable warning output
- `Send()` now writes `warning: failed to submit crash report` to stderr when any sink fails
- HTTP client timeout (5s) and per-request context timeout are already enforced; added explicit test coverage
- Failures in crash reporting are contained: no panic, no CLI crash

## New Tests
- `TestSend_TimeoutDoesNotHangCLI`: verifies Send returns quickly when server is unresponsive (50ms timeout)
- `TestSend_NetworkFailureDoesNotPanic`: verifies no panic on connection-refused errors
- `TestSend_WarningEmittedOnFailure`: verifies warning is written to stderr on HTTP 5xx
- `TestSend_NoWarningOnSuccess`: verifies no warning on successful submission

## Testing
- go test ./internal/crashreport/... (all 28 tests pass)