### PR TITLE
fix: map _val_to_u32 error to ScErrorType::Value for specific domain …

### DIFF
--- a/simulator/src/runner.rs
+++ b/simulator/src/runner.rs
@@ -167,7 +167,7 @@ impl SimHost {
     /// Convert a Val back to u32.
     pub fn _val_to_u32(&self, v: Val) -> Result<u32, HostError> {
         v.try_into_val(&self.inner).map_err(|_| {
-            EnvError::from_type_and_code(ScErrorType::Context, ScErrorCode::InvalidInput).into()
+            EnvError::from_type_and_code(ScErrorType::Value, ScErrorCode::InvalidInput).into()
         })
     }
 


### PR DESCRIPTION
Closes #1361 

## fix: Map `_val_to_u32` error to specific domain error (`ScErrorType::Value`)

### Problem

The `_val_to_u32` conversion function in `simulator/src/runner.rs` was mapping parse failures to the generic `ScErrorType::Context` domain:

```rust
EnvError::from_type_and_code(ScErrorType::Context, ScErrorCode::InvalidInput).into()
```

`ScErrorType::Context` is a catch-all for host execution context errors and does not accurately describe a value conversion failure, making trace decoding harder.

### Solution

Map the error to `ScErrorType::Value`, which is the correct Soroban XDR domain for value type mismatch and conversion failures:

```rust
EnvError::from_type_and_code(ScErrorType::Value, ScErrorCode::InvalidInput).into()
```

### Changes

- `simulator/src/runner.rs` — 1-line change in `_val_to_u32`

### Testing

- `cargo check` passes with zero errors and zero warnings.
- Existing tests in `test_simple_value_handling` continue to pass (valid `Val → u32` conversions are unaffected; only the error path domain label changes).
