### PR TITLE
fix(context): bubble up Result from apply_control_command instead of …

### DIFF
--- a/simulator/src/context.rs
+++ b/simulator/src/context.rs
@@ -25,7 +25,10 @@ pub struct HarnessContext {
 
 impl HarnessContext {
     /// Applies control-command side effects and returns human-readable log lines.
-    pub fn apply_control_command(&mut self, request: &SimulationRequest) -> Result<Vec<String>, SimulationContextError> {
+    pub fn apply_control_command(
+        &mut self,
+        request: &SimulationRequest,
+    ) -> Result<Vec<String>, SimulationContextError> {
         let mut logs = Vec::new();
 
         let Some(command) = request.control_command.as_deref() else {

--- a/simulator/src/context.rs
+++ b/simulator/src/context.rs
@@ -25,11 +25,11 @@ pub struct HarnessContext {
 
 impl HarnessContext {
     /// Applies control-command side effects and returns human-readable log lines.
-    pub fn apply_control_command(&mut self, request: &SimulationRequest) -> Vec<String> {
+    pub fn apply_control_command(&mut self, request: &SimulationRequest) -> Result<Vec<String>, SimulationContextError> {
         let mut logs = Vec::new();
 
         let Some(command) = request.control_command.as_deref() else {
-            return logs;
+            return Ok(logs);
         };
 
         if command.eq_ignore_ascii_case(ROLLBACK_AND_RESUME) {
@@ -54,11 +54,11 @@ impl HarnessContext {
                 ));
             }
             logs.push(replay_log);
-            return logs;
+            return Ok(logs);
         }
 
         logs.push(format!("Bridge command ignored: {}", command));
-        logs
+        Ok(logs)
     }
 
     /// Resets temporary harness counters that should not leak across forks.

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -421,7 +421,13 @@ fn main() {
     };
 
     let mut harness_ctx = context::HarnessContext::default();
-    let harness_logs = harness_ctx.apply_control_command(&request);
+    let harness_logs = match harness_ctx.apply_control_command(&request) {
+        Ok(logs) => logs,
+        Err(e) => {
+            send_error(format!("Harness context error: {}", e));
+            return;
+        }
+    };
 
     let envelope = match base64::engine::general_purpose::STANDARD.decode(&request.envelope_xdr) {
         Ok(bytes) => match soroban_env_host::xdr::TransactionEnvelope::from_xdr(


### PR DESCRIPTION
Closes #1372 

## fix(context): bubble up Result from apply_control_command (#1372)

### Summary

`apply_control_command` in `simulator/src/context.rs` previously returned
a plain `Vec<String>`, giving it no way to signal failures — any error
would have had to panic and halt the VM abruptly. This PR changes the
return type to `Result<Vec<String>, SimulationContextError>` so errors
propagate cleanly to the host.

### Changes

**`simulator/src/context.rs`**
- Changed `apply_control_command` return type from `Vec<String>` to
  `Result<Vec<String>, SimulationContextError>`
- Wrapped all three return sites in `Ok(...)`

**`simulator/src/main.rs`**
- Updated the single call site to `match` on the `Result`, extracting
  `Vec<String>` on success and sending a clean error response on failure
  (no panic / VM halt)

### Testing

- `cargo check` passes with zero errors or warnings
- Existing test in `context.rs` (`rollback_to_restores_exact_snapshot_and_truncates_future_events`)
  continues to pass unchanged
