### PR TITLE
fix: remove unwrap in source mapper cache directory derivation

### DIFF
--- a/simulator/src/source_map_cache.rs
+++ b/simulator/src/source_map_cache.rs
@@ -139,11 +139,24 @@ impl SourceMapCache {
         self
     }
 
-    /// Gets the default cache directory (~/.erst/cache/sourcemaps)
+    /// Gets the default cache directory (~/.erst/cache/sourcemaps).
+    /// Falls back to the OS temp directory when the home directory is unavailable.
     fn get_default_cache_dir() -> Result<PathBuf, String> {
-        let home_dir =
-            dirs::home_dir().ok_or_else(|| "Failed to determine home directory".to_string())?;
-        Ok(home_dir.join(".erst").join("cache").join(CACHE_DIR_NAME))
+        if let Some(home_dir) = dirs::home_dir() {
+            return Ok(home_dir.join(".erst").join("cache").join(CACHE_DIR_NAME));
+        }
+        // Home directory unavailable; use the OS temp directory as a fallback.
+        let temp_cache = std::env::temp_dir()
+            .join("erst")
+            .join("cache")
+            .join(CACHE_DIR_NAME);
+        fs::create_dir_all(&temp_cache).map_err(|e| {
+            format!(
+                "Failed to create cache directory in temp dir {:?}: {e}",
+                temp_cache
+            )
+        })?;
+        Ok(temp_cache)
     }
 
     /// Computes SHA256 hash of WASM bytes
@@ -452,7 +465,16 @@ impl SourceMapCache {
 
 impl Default for SourceMapCache {
     fn default() -> Self {
-        Self::new().expect("Failed to create default source map cache")
+        Self::new().unwrap_or_else(|e| {
+            eprintln!("Warning: source map cache unavailable ({e}); falling back to temp directory");
+            Self {
+                cache_dir: std::env::temp_dir()
+                    .join("erst")
+                    .join("cache")
+                    .join(CACHE_DIR_NAME),
+                max_cache_size: None,
+            }
+        })
     }
 }
 

--- a/simulator/src/source_map_cache.rs
+++ b/simulator/src/source_map_cache.rs
@@ -466,7 +466,9 @@ impl SourceMapCache {
 impl Default for SourceMapCache {
     fn default() -> Self {
         Self::new().unwrap_or_else(|e| {
-            eprintln!("Warning: source map cache unavailable ({e}); falling back to temp directory");
+            eprintln!(
+                "Warning: source map cache unavailable ({e}); falling back to temp directory"
+            );
             Self {
                 cache_dir: std::env::temp_dir()
                     .join("erst")


### PR DESCRIPTION
## Summary
- `get_default_cache_dir()` now falls back to `std::env::temp_dir()` when `dirs::home_dir()` is unavailable, instead of returning an error immediately
- `Default::default()` replaces `.expect()` with `.unwrap_or_else()` — logs a warning and uses the temp directory path rather than panicking when cache initialization fails
- Both paths handle permission errors gracefully: `create_dir_all` failures are propagated as `Err(String)` rather than causing a panic

## Test plan
- [ ] `cargo check` passes (verified locally)
- [ ] Existing tests in `source_map_cache.rs` continue to pass
- [ ] Existing tests in `source_mapper.rs` continue to pass
- [ ] Manually verify behaviour when home directory is unavailable (simulated via env override)

Closes #1401
