### PR TITLE
Test hardening + cross-platform git link paths

### DIFF
--- a/internal/tokenflow/tokenflow_test.go
+++ b/internal/tokenflow/tokenflow_test.go
@@ -19,8 +19,8 @@ func TestBuildReport_SACTransferAndMint_FromResultMeta(t *testing.T) {
 	contractStr, err := strkey.Encode(strkey.VersionByteContract, cid[:])
 	require.NoError(t, err)
 
-	fromAddr := scAddressAccount(bytes32(0x01))
-	toAddr := scAddressAccount(bytes32(0x02))
+	fromAddr := scAddressAccount(t, bytes32(0x01))
+	toAddr := scAddressAccount(t, bytes32(0x02))
 
 	transferEvent := diagnosticEvent(
 		cid,
@@ -33,7 +33,7 @@ func TestBuildReport_SACTransferAndMint_FromResultMeta(t *testing.T) {
 		true,
 	)
 
-	mintTo := scAddressAccount(bytes32(0x03))
+	mintTo := scAddressAccount(t, bytes32(0x03))
 	mintEvent := diagnosticEvent(
 		cid,
 		[]xdr.ScVal{
@@ -53,14 +53,14 @@ func TestBuildReport_SACTransferAndMint_FromResultMeta(t *testing.T) {
 	require.Equal(t, KindTransfer, r.Agg[0].Kind)
 	require.Equal(t, contractStr, r.Agg[0].Token.ID)
 	require.Equal(t, "SAC", r.Agg[0].Token.Symbol)
-	require.Equal(t, addrString(fromAddr), r.Agg[0].From)
-	require.Equal(t, addrString(toAddr), r.Agg[0].To)
+	require.Equal(t, addrString(t, fromAddr), r.Agg[0].From)
+	require.Equal(t, addrString(t, toAddr), r.Agg[0].To)
 	require.Equal(t, big.NewInt(50), r.Agg[0].Amount)
 
 	require.Equal(t, KindMint, r.Agg[1].Kind)
 	require.Equal(t, contractStr, r.Agg[1].Token.ID)
 	require.Equal(t, "MINT", r.Agg[1].From)
-	require.Equal(t, addrString(mintTo), r.Agg[1].To)
+	require.Equal(t, addrString(t, mintTo), r.Agg[1].To)
 	require.Equal(t, big.NewInt(7), r.Agg[1].Amount)
 }
 
@@ -68,7 +68,7 @@ func TestBuildReport_NativeXLMPayment_FromEnvelope(t *testing.T) {
 	src := bytes32(0x10)
 	dst := bytes32(0x20)
 
-	envB64 := encodeEnvelopeWithNativePayment(src, dst, 12_345_678) // 1.2345678 XLM
+	envB64 := encodeEnvelopeWithNativePayment(t, src, dst, 12_345_678) // 1.2345678 XLM
 	r, err := BuildReport(envB64, "")
 	require.NoError(t, err)
 	require.Len(t, r.Agg, 1)
@@ -77,8 +77,8 @@ func TestBuildReport_NativeXLMPayment_FromEnvelope(t *testing.T) {
 	require.Equal(t, KindTransfer, tr.Kind)
 	require.Equal(t, "XLM", tr.Token.Symbol)
 	require.Equal(t, "", tr.Token.ID)
-	require.Equal(t, addrMuxed(src), tr.From)
-	require.Equal(t, addrMuxed(dst), tr.To)
+	require.Equal(t, addrMuxed(t, src), tr.From)
+	require.Equal(t, addrMuxed(t, dst), tr.To)
 	require.Equal(t, big.NewInt(12_345_678), tr.Amount)
 }
 
@@ -124,14 +124,16 @@ func encodeResultMetaWithDiagnosticEvents(t *testing.T, events []xdr.DiagnosticE
 	return base64.StdEncoding.EncodeToString(b)
 }
 
-func encodeEnvelopeWithNativePayment(src [32]byte, dst [32]byte, stroops int64) string {
+func encodeEnvelopeWithNativePayment(t *testing.T, src [32]byte, dst [32]byte, stroops int64) string {
+	t.Helper()
+
 	srcMux, err := xdr.NewMuxedAccount(xdr.CryptoKeyTypeKeyTypeEd25519, xdr.Uint256(src))
 	if err != nil {
-		panic(err)
+		t.Fatalf("new muxed source account: %v", err)
 	}
 	dstMux, err := xdr.NewMuxedAccount(xdr.CryptoKeyTypeKeyTypeEd25519, xdr.Uint256(dst))
 	if err != nil {
-		panic(err)
+		t.Fatalf("new muxed destination account: %v", err)
 	}
 
 	payment := xdr.PaymentOp{
@@ -165,7 +167,7 @@ func encodeEnvelopeWithNativePayment(src [32]byte, dst [32]byte, stroops int64) 
 
 	b, err := env.MarshalBinary()
 	if err != nil {
-		panic(err)
+		t.Fatalf("marshal envelope: %v", err)
 	}
 	return base64.StdEncoding.EncodeToString(b)
 }
@@ -206,10 +208,12 @@ func scU128(v uint64) xdr.ScVal {
 	return xdr.ScVal{Type: xdr.ScValTypeScvU128, U128: &parts}
 }
 
-func scAddressAccount(pk [32]byte) xdr.ScAddress {
+func scAddressAccount(t *testing.T, pk [32]byte) xdr.ScAddress {
+	t.Helper()
+
 	acc, err := xdr.NewAccountId(xdr.PublicKeyTypePublicKeyTypeEd25519, xdr.Uint256(pk))
 	if err != nil {
-		panic(err)
+		t.Fatalf("new account id: %v", err)
 	}
 	a := xdr.AccountId(acc)
 	return xdr.ScAddress{
@@ -226,23 +230,27 @@ func bytes32(fill byte) [32]byte {
 	return b
 }
 
-func addrString(a xdr.ScAddress) string {
+func addrString(t *testing.T, a xdr.ScAddress) string {
+	t.Helper()
+
 	s, err := a.String()
 	if err != nil {
-		panic(err)
+		t.Fatalf("address string: %v", err)
 	}
 	return s
 }
 
-func addrMuxed(pk [32]byte) string {
+func addrMuxed(t *testing.T, pk [32]byte) string {
+	t.Helper()
+
 	m, err := xdr.NewMuxedAccount(xdr.CryptoKeyTypeKeyTypeEd25519, xdr.Uint256(pk))
 	if err != nil {
-		panic(err)
+		t.Fatalf("new muxed account: %v", err)
 	}
 	ma := xdr.MuxedAccount(m)
 	s, err := (&ma).GetAddress()
 	if err != nil {
-		panic(err)
+		t.Fatalf("muxed account address: %v", err)
 	}
 	return s
 }

--- a/simulator/src/git_detector.rs
+++ b/simulator/src/git_detector.rs
@@ -1,7 +1,7 @@
 // Copyright 2026 Erst Users
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, Instant};
 
@@ -177,14 +177,28 @@ impl GitRepository {
     fn make_relative_path(&self, file_path: &str) -> Option<String> {
         let path = Path::new(file_path);
 
-        if path.is_absolute() {
-            path.strip_prefix(&self.root_path)
-                .ok()
-                .and_then(|p| p.to_str())
-                .map(|s| s.to_string())
+        let relative = if path.is_absolute() {
+            path.strip_prefix(&self.root_path).ok()?
         } else {
-            Some(file_path.to_string())
-        }
+            path
+        };
+
+        Some(Self::to_url_path(relative))
+    }
+
+    /// Render a relative path as a URL fragment using `/` separators.
+    ///
+    /// Iterating over [`Path::components`] keeps this correct on Windows,
+    /// where the native separator is `\`; only the normal path segments are
+    /// retained, so prefixes, root, and `.`/`..` components are dropped.
+    fn to_url_path(path: &Path) -> String {
+        path.components()
+            .filter_map(|component| match component {
+                Component::Normal(segment) => segment.to_str(),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("/")
     }
 }
 

--- a/simulator/src/main_test.rs
+++ b/simulator/src/main_test.rs
@@ -12,13 +12,13 @@ mod restore_preamble_tests {
         LedgerEntryExt, LedgerKey, LedgerKeyContractData, ScAddress, ScVal, WriteXdr,
     };
 
-    fn encode_xdr<T: WriteXdr>(value: &T) -> String {
-        let bytes = value.to_xdr(soroban_env_host::xdr::Limits::none()).unwrap();
-        base64::engine::general_purpose::STANDARD.encode(&bytes)
+    fn encode_xdr<T: WriteXdr>(value: &T) -> Result<String, Box<dyn std::error::Error>> {
+        let bytes = value.to_xdr(soroban_env_host::xdr::Limits::none())?;
+        Ok(base64::engine::general_purpose::STANDARD.encode(&bytes))
     }
 
     #[test]
-    fn test_restore_preamble_injection() {
+    fn test_restore_preamble_injection() -> Result<(), Box<dyn std::error::Error>> {
         // Create a ContractData key and entry
         let contract_id = Hash([9u8; 32]);
         let key_val = ScVal::U32(123);
@@ -39,8 +39,8 @@ mod restore_preamble_tests {
             }),
             ext: LedgerEntryExt::V0,
         };
-        let key_b64 = encode_xdr(&key);
-        let entry_b64 = encode_xdr(&entry);
+        let key_b64 = encode_xdr(&key)?;
+        let entry_b64 = encode_xdr(&entry)?;
         let restore_preamble = json!({
             "ledger_entries": {
                 key_b64.clone(): entry_b64.clone()
@@ -76,9 +76,8 @@ mod restore_preamble_tests {
                     if let Some(map) = entries.as_object() {
                         for (key_xdr, entry_xdr_val) in map {
                             if let Some(entry_xdr) = entry_xdr_val.as_str() {
-                                let key = crate::snapshot::decode_ledger_key(key_xdr).unwrap();
-                                let entry =
-                                    crate::snapshot::decode_ledger_entry(entry_xdr).unwrap();
+                                let key = crate::snapshot::decode_ledger_key(key_xdr)?;
+                                let entry = crate::snapshot::decode_ledger_entry(entry_xdr)?;
                                 let result = host.put_ledger_entry(key.clone(), entry.clone());
                                 assert!(result.is_ok(), "Injection should succeed");
                             }
@@ -87,5 +86,7 @@ mod restore_preamble_tests {
                 }
             }
         }
+
+        Ok(())
     }
 }

--- a/simulator/tests/signature_verification_mock_test.rs
+++ b/simulator/tests/signature_verification_mock_test.rs
@@ -34,8 +34,7 @@ fn test_signature_verification_mock_true() {
         include_linear_memory: false,
     };
 
-    assert!(request.mock_signature_verification.is_some());
-    assert!(request.mock_signature_verification.unwrap());
+    assert_eq!(request.mock_signature_verification, Some(true));
 }
 
 #[test]
@@ -67,8 +66,7 @@ fn test_signature_verification_mock_false() {
         include_linear_memory: false,
     };
 
-    assert!(request.mock_signature_verification.is_some());
-    assert!(!request.mock_signature_verification.unwrap());
+    assert_eq!(request.mock_signature_verification, Some(false));
 }
 
 #[test]
@@ -100,5 +98,5 @@ fn test_signature_verification_mock_disabled() {
         include_linear_memory: false,
     };
 
-    assert!(request.mock_signature_verification.is_none());
+    assert_eq!(request.mock_signature_verification, None);
 }


### PR DESCRIPTION
Bundles four small, independent fixes around test robustness and path handling.

## Changes

- **`simulator/tests/signature_verification_mock_test.rs`** — replace `assert!(is_some())` + `assert!(unwrap())` pairs with `assert_eq!` on the `Option` so a mismatch reports the actual value instead of an opaque panic.
- **`simulator/src/main_test.rs`** — `test_restore_preamble_injection` now returns `Result<(), Box<dyn std::error::Error>>` and propagates decode/encode errors with `?` rather than `unwrap`.
- **`simulator/src/git_detector.rs`** — rebuild relative file paths from `Path::components()`, joining with `/`, so generated GitHub links stay correct on Windows instead of leaking backslashes.
- **`internal/tokenflow/tokenflow_test.go`** — thread `*testing.T` into the setup helpers, add `t.Helper()`, and swap `panic(err)` for descriptive `t.Fatalf` so failures are recorded by the test runner.

## Verification

- `cargo test --test signature_verification_mock_test` → 3 passed
- `cargo test --bin simulator git_detector` → 9 passed
- `go vet ./internal/tokenflow/` clean; `go test ./internal/tokenflow/` → ok

> Note: `main_test.rs` is currently an orphan (not referenced by any `mod`), so it is not built in CI. The change is correct in isolation; wiring it into the build is out of scope here.

Closes #1412
Closes #1419
Closes #1423
Closes #1402