### PR TITLE
fix: graceful error handling in PKCS11 init and compression routines

### DIFF
--- a/internal/bridge/compress.go
+++ b/internal/bridge/compress.go
@@ -17,31 +17,25 @@ import (
 
 var (
 	encoder     *zstd.Encoder
+	encoderErr  error
 	decoder     *zstd.Decoder
+	decoderErr  error
 	encoderOnce sync.Once
 	decoderOnce sync.Once
 )
 
-func getEncoder() *zstd.Encoder {
+func getEncoder() (*zstd.Encoder, error) {
 	encoderOnce.Do(func() {
-		var err error
-		encoder, err = zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))
-		if err != nil {
-			panic(fmt.Sprintf("bridge: failed to create zstd encoder: %v", err))
-		}
+		encoder, encoderErr = zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))
 	})
-	return encoder
+	return encoder, encoderErr
 }
 
-func getDecoder() *zstd.Decoder {
+func getDecoder() (*zstd.Decoder, error) {
 	decoderOnce.Do(func() {
-		var err error
-		decoder, err = zstd.NewReader(nil)
-		if err != nil {
-			panic(fmt.Sprintf("bridge: failed to create zstd decoder: %v", err))
-		}
+		decoder, decoderErr = zstd.NewReader(nil)
 	})
-	return decoder
+	return decoder, decoderErr
 }
 
 // CompressLedgerEntries serialises entries to JSON and compresses with Zstd.
@@ -51,12 +45,20 @@ func CompressLedgerEntries(entries map[string]string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("bridge: marshal ledger entries: %w", err)
 	}
-	return getEncoder().EncodeAll(raw, make([]byte, 0, len(raw)/4)), nil
+	enc, err := getEncoder()
+	if err != nil {
+		return nil, fmt.Errorf("bridge: init zstd encoder: %w", err)
+	}
+	return enc.EncodeAll(raw, make([]byte, 0, len(raw)/4)), nil
 }
 
 // DecompressLedgerEntries decompresses a Zstd blob produced by CompressLedgerEntries.
 func DecompressLedgerEntries(compressed []byte) (map[string]string, error) {
-	raw, err := getDecoder().DecodeAll(compressed, make([]byte, 0, len(compressed)*4))
+	dec, err := getDecoder()
+	if err != nil {
+		return nil, fmt.Errorf("bridge: init zstd decoder: %w", err)
+	}
+	raw, err := dec.DecodeAll(compressed, make([]byte, 0, len(compressed)*4))
 	if err != nil {
 		return nil, fmt.Errorf("bridge: decompress ledger entries: %w", err)
 	}

--- a/simulator/src/hsm/pkcs11.rs
+++ b/simulator/src/hsm/pkcs11.rs
@@ -278,7 +278,8 @@ impl Pkcs11Signer {
             }
 
             if let Some(ref token_label) = self.config.token_label {
-                let _label_cstr = CString::new(token_label.as_str()).unwrap();
+                let _label_cstr = CString::new(token_label.as_str())
+                    .map_err(|e| SignerError::Config(format!("Invalid token label: {}", e)))?;
 
                 for &slot in &slots {
                     let mut token_info = CK_TOKEN_INFO {
@@ -342,15 +343,17 @@ impl Pkcs11Signer {
             }];
 
             // Keep these alive for the duration of the function
-            let _label_cstr = self.config.key_label.as_ref().map(|key_label| {
-                let label_cstr = CString::new(key_label.as_str()).unwrap();
+            let mut _label_cstr: Option<CString> = None;
+            if let Some(ref key_label) = self.config.key_label {
+                let label_cstr = CString::new(key_label.as_str())
+                    .map_err(|e| SignerError::Config(format!("Invalid key label: {}", e)))?;
                 template.push(CK_ATTRIBUTE {
                     type_: CKA_LABEL,
                     p_value: label_cstr.as_ptr() as *mut c_void,
                     ul_value_len: key_label.len() as c_ulong,
                 });
-                label_cstr
-            });
+                _label_cstr = Some(label_cstr);
+            }
 
             let _key_id_bytes = if let Some(ref key_id_hex) = self.config.key_id_hex {
                 let key_id_bytes = hex::decode(key_id_hex)
@@ -426,15 +429,17 @@ impl Pkcs11Signer {
             }];
 
             // Keep these alive for the duration of the function
-            let _label_cstr = self.config.key_label.as_ref().map(|key_label| {
-                let label_cstr = CString::new(key_label.as_str()).unwrap();
+            let mut _label_cstr: Option<CString> = None;
+            if let Some(ref key_label) = self.config.key_label {
+                let label_cstr = CString::new(key_label.as_str())
+                    .map_err(|e| SignerError::Config(format!("Invalid key label: {}", e)))?;
                 template.push(CK_ATTRIBUTE {
                     type_: CKA_LABEL,
                     p_value: label_cstr.as_ptr() as *mut c_void,
                     ul_value_len: key_label.len() as c_ulong,
                 });
-                label_cstr
-            });
+                _label_cstr = Some(label_cstr);
+            }
 
             let _key_id_bytes = if let Some(ref key_id_hex) = self.config.key_id_hex {
                 let key_id_bytes = hex::decode(key_id_hex)
@@ -545,7 +550,8 @@ impl Signer for Pkcs11Signer {
             }
 
             // Login
-            let pin_cstr = CString::new(self.config.pin.as_str()).unwrap();
+            let pin_cstr = CString::new(self.config.pin.as_str())
+                .map_err(|e| SignerError::Config(format!("Invalid PIN: {}", e)))?;
             let result = (functions.C_Login)(session, CKU_USER, pin_cstr.as_ptr() as *mut c_char);
             if result != CKR_OK {
                 (functions.C_CloseSession)(session);
@@ -662,7 +668,8 @@ impl Signer for Pkcs11Signer {
             }
 
             // Login
-            let pin_cstr = CString::new(self.config.pin.as_str()).unwrap();
+            let pin_cstr = CString::new(self.config.pin.as_str())
+                .map_err(|e| SignerError::Config(format!("Invalid PIN: {}", e)))?;
             let result = (functions.C_Login)(session, CKU_USER, pin_cstr.as_ptr() as *mut c_char);
             if result != CKR_OK {
                 (functions.C_CloseSession)(session);


### PR DESCRIPTION

closes #1357
closes #1354

## Changes

### simulator/src/hsm/pkcs11.rs

All `CString::new(...).unwrap()` calls in the PKCS11 signer would panic
if a config value (PIN, key label, token label) contained a null byte.
Each call has been replaced with `.map_err(|e| SignerError::Config(...))?`
so the error bubbles up through the existing `Result` return types without
crashing the process.

The two closure-based label patterns in `find_private_key` and
`get_public_key` were refactored to `if let` blocks so that the `?`
operator can propagate the error while still keeping the `CString` alive
for the lifetime of the FFI template pointer.

### internal/bridge/compress.go

`getEncoder` and `getDecoder` previously called `panic` inside
`sync.Once` if zstd initialisation failed. The init error is now stored
alongside the value (`encoderErr` / `decoderErr`) and returned by the
getter. `CompressLedgerEntries` and `DecompressLedgerEntries` handle the
new `error` return and wrap it with `fmt.Errorf` before surfacing it to
the caller, allowing the CLI to report the failure and exit cleanly
instead of crashing.
