### PR TITLE
migrate println! to tracing in CLI trace viewer

### DIFF
--- a/simulator/src/cli/trace_viewer.rs
+++ b/simulator/src/cli/trace_viewer.rs
@@ -1,20 +1,6 @@
 // Copyright 2026 Erst Users
 // SPDX-License-Identifier: Apache-2.0
 
-//
-// You may obtain a copy of the License at
-//
-//
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-
-//
-// You may obtain a copy of the License at
-//
-//
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-
-use crate::theme::ansi::apply;
-use crate::theme::load_theme;
 use std::path::PathBuf;
 
 #[allow(dead_code)]
@@ -29,17 +15,6 @@ pub fn trace_viewer_temp_path(file_name: &str) -> PathBuf {
 
 #[allow(dead_code)]
 pub fn render_trace() {
-    let theme = load_theme();
-
-    println!(
-        "{} {}",
-        apply(&theme.span, "SPAN"),
-        apply(&theme.event, "User logged in")
-    );
-
-    println!(
-        "{} {}",
-        apply(&theme.error, "ERROR"),
-        apply(&theme.error, "Connection failed")
-    );
+    tracing::info!(kind = "span", "User logged in");
+    tracing::error!(kind = "error", "Connection failed");
 }


### PR DESCRIPTION
## What

Replace the two `println!` calls in `render_trace()` with `tracing::info!` and `tracing::error!`, using a structured `kind` field to capture the event type. Remove the now-unused theme imports.

## Why

`println!` bypasses the logging infrastructure: output cannot be filtered by verbosity level and does not flow through the configured tracing subscriber. Using `tracing::info!` / `tracing::error!` makes the calls level-aware and compatible with structured (JSON) log sinks.

The ANSI theme formatting is dropped at the call site — presentation is the subscriber's responsibility, not the logging call site's.

Closes #1400