### PR TITLE
chore: consolidate Go build ENV variables into single instruction to …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,9 +49,7 @@ RUN go mod download
 COPY . .
 
 # Build Go binary statically for target architecture
-ENV CGO_ENABLED=0
-ENV GOOS=${TARGETOS}
-ENV GOARCH=${TARGETARCH}
+ENV CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH}
 RUN go build -ldflags="-s -w" -o erst cmd/erst/main.go
 
 # Stage 3: Final Runtime Image


### PR DESCRIPTION
Closes #1443

---

This Pr #1443 
The Dockerfile’s Go build stage used three separate ENV statements:

dockerfile


ENV CGO_ENABLED=0
ENV GOOS=${TARGETOS}
ENV GOARCH=${TARGETARCH}
These have been merged into a single ENV instruction to reduce the number of intermediate image layers.

Changes
Dockerfile
dockerfile


# Build Go binary statically for target architecture
ENV CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH}
RUN go build -ldflags="-s -w" -o erst cmd/erst/main.go
The three previous ENV lines have been removed and replaced with the combined line above.
Rationale
Combining multiple ENV directives into one reduces the total number of Docker image layers, resulting in:

Smaller final image size.
Faster build times due to fewer intermediate layers.
Cleaner Dockerfile with less repetition.
Testing
Ran docker build locally after the change.
Build completes successfully.
Verified that the resulting image size is smaller compared to the previous build.
Related Issue
Consolidate ENV variables in Dockerfile to reduce image layers. (If there is a tracker ID, reference it here.)

