### PR TITLE
Dp fixes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,6 +17,7 @@ jobs:
   integration:
     name: Integration / ${{ matrix.os }}
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false          # run all platforms even if one fails


### PR DESCRIPTION
closes #1441

I have added the timeout-minutes: 15 property to the integration job inside .github/workflows/integration.yml. This ensures that any hung tests across the Linux, macOS, or Windows matrices will be automatically terminated after 15 minutes, preventing excessive consumption of CI minutes.

Summary of Changes
.github/workflows/integration.yml: Added timeout-minutes: 15 to the integration job