### PR TITLE
test(simulator): assert_eq! on signature mock instead of unwrap

### DIFF
--- a/simulator/tests/signature_verification_mock_test.rs
+++ b/simulator/tests/signature_verification_mock_test.rs
@@ -34,8 +34,7 @@ fn test_signature_verification_mock_true() {
         include_linear_memory: false,
     };
 
-    assert!(request.mock_signature_verification.is_some());
-    assert!(request.mock_signature_verification.unwrap());
+    assert_eq!(request.mock_signature_verification, Some(true));
 }
 
 #[test]
@@ -67,8 +66,7 @@ fn test_signature_verification_mock_false() {
         include_linear_memory: false,
     };
 
-    assert!(request.mock_signature_verification.is_some());
-    assert!(!request.mock_signature_verification.unwrap());
+    assert_eq!(request.mock_signature_verification, Some(false));
 }
 
 #[test]
@@ -100,5 +98,5 @@ fn test_signature_verification_mock_disabled() {
         include_linear_memory: false,
     };
 
-    assert!(request.mock_signature_verification.is_none());
+    assert_eq!(request.mock_signature_verification, None);
 }


### PR DESCRIPTION
Replaces the `assert!(is_some())` + `assert!(unwrap())` pairs in the signature verification mock tests with single `assert_eq!` calls on the `Option`. A mismatch now reports the actual value instead of panicking with no context.

**Verification:** `cargo test --test signature_verification_mock_test` → 3 passed.

Closes #1412