### PR TITLE
made minor quality improvements to regression harness tests

### DIFF
--- a/internal/simulator/regression_harness_test.go
+++ b/internal/simulator/regression_harness_test.go
@@ -5,6 +5,8 @@ package simulator
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,7 +57,7 @@ func TestRegressionTestSuite(t *testing.T) {
 
 		for i := 0; i < 5; i++ {
 			result := RegressionTestResult{
-				TransactionHash: "tx-" + string(rune(i)),
+				TransactionHash: fmt.Sprintf("tx-%d", i),
 				Status:          "pass",
 			}
 			suite.addResult(result)
@@ -174,21 +176,28 @@ func TestRegressionTestSuite_ConcurrentAddition(t *testing.T) {
 	}
 
 	// Simulate concurrent additions
-	done := make(chan bool, 100)
+	var wg sync.WaitGroup
 	for i := 0; i < 100; i++ {
+		wg.Add(1)
 		go func(idx int) {
+			defer wg.Done()
+
 			result := RegressionTestResult{
-				TransactionHash: "tx-" + string(rune(idx)),
+				TransactionHash: fmt.Sprintf("tx-%d", idx),
 				Status:          "pass",
 			}
 			suite.addResult(result)
-			done <- true
 		}(i)
 	}
 
-	for i := 0; i < 100; i++ {
-		<-done
-	}
+	wg.Wait()
 
 	assert.Equal(t, 100, len(suite.Results))
+
+	seen := make(map[string]struct{}, len(suite.Results))
+	for _, result := range suite.Results {
+		seen[result.TransactionHash] = struct{}{}
+	}
+
+	assert.Equal(t, 100, len(seen))
 }


### PR DESCRIPTION
Closes #1410 

Currently, there are no `defer os.RemoveAll` occurrences at all in the `internal/simulator/regression_harness_test.go` file so that doesn't require any changes. I instead made changes to the current test implementation. The changes replace invalid `string(rune(i))` transaction IDs with stable numeric IDs and simplifying the concurrent test synchronization with sync.WaitGroup. Also adds a uniqueness assertion so the concurrent result aggregation test verifies all expected entries were recorded.