### PR TITLE
fix(ipc): return explicit error code on port binding failure instead …

### DIFF
--- a/simulator/src/ipc/mod.rs
+++ b/simulator/src/ipc/mod.rs
@@ -5,6 +5,25 @@ pub mod decompress;
 pub mod types;
 pub mod validate;
 
+pub use types::IpcError;
+
+/// Binds a TCP listener to `addr` and returns it.
+///
+/// If the socket cannot be established (e.g. the port is already in use or
+/// the address is invalid) the function returns an `Err(IpcError::PortBindingFailed)`
+/// with a human-readable message so the CLI can report the failure instead
+/// of unwinding the stack with a panic.
+#[allow(dead_code)]
+pub fn start_ipc_bridge<A: std::net::ToSocketAddrs>(
+    addr: A,
+) -> Result<std::net::TcpListener, IpcError> {
+    std::net::TcpListener::bind(addr).map_err(|e| {
+        IpcError::PortBindingFailed(format!(
+            "IPC bridge could not bind to the requested address: {e}"
+        ))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::types::*;
@@ -84,5 +103,36 @@ mod tests {
     fn test_command_frame_default_batch_size() {
         let cmd: CommandFrame = serde_json::from_str(r#"{"op":"FETCH_SNAPSHOT","id":7}"#).unwrap();
         assert_eq!(cmd.batch_size, 1);
+    }
+
+    #[test]
+    fn test_parse_command_frame_invalid_json_returns_error() {
+        let result = parse_command_frame("{invalid-json}");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_start_ipc_bridge_success() {
+        // port 0 lets the OS pick a free port — always succeeds
+        let result = super::start_ipc_bridge("127.0.0.1:0");
+        assert!(result.is_ok(), "expected successful bind: {:?}", result);
+    }
+
+    #[test]
+    fn test_start_ipc_bridge_bad_address_returns_error() {
+        // Bind two listeners to the same port to force EADDRINUSE
+        let first = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = first.local_addr().unwrap().port();
+        let addr = format!("127.0.0.1:{port}");
+        let result = super::start_ipc_bridge(addr.as_str());
+        assert!(
+            result.is_err(),
+            "expected Err when port is already bound, got Ok"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("IPC bridge could not bind"),
+            "unexpected error message: {err_msg}"
+        );
     }
 }

--- a/simulator/src/ipc/mod.rs
+++ b/simulator/src/ipc/mod.rs
@@ -11,17 +11,13 @@ pub use types::IpcError;
 ///
 /// If the socket cannot be established (e.g. the port is already in use or
 /// the address is invalid) the function returns an `Err(IpcError::PortBindingFailed)`
-/// with a human-readable message so the CLI can report the failure instead
-/// of unwinding the stack with a panic.
+/// with the original `std::io::Error` preserved as `source`, so the CLI can
+/// inspect `ErrorKind` and report the failure with the appropriate exit code.
 #[allow(dead_code)]
 pub fn start_ipc_bridge<A: std::net::ToSocketAddrs>(
     addr: A,
 ) -> Result<std::net::TcpListener, IpcError> {
-    std::net::TcpListener::bind(addr).map_err(|e| {
-        IpcError::PortBindingFailed(format!(
-            "IPC bridge could not bind to the requested address: {e}"
-        ))
-    })
+    std::net::TcpListener::bind(addr).map_err(|source| IpcError::PortBindingFailed { source })
 }
 
 #[cfg(test)]
@@ -119,7 +115,7 @@ mod tests {
     }
 
     #[test]
-    fn test_start_ipc_bridge_bad_address_returns_error() {
+    fn test_start_ipc_bridge_addr_in_use_returns_error() {
         // Bind two listeners to the same port to force EADDRINUSE
         let first = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = first.local_addr().unwrap().port();

--- a/simulator/src/ipc/types.rs
+++ b/simulator/src/ipc/types.rs
@@ -4,6 +4,23 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::Write;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum IpcError {
+    #[error("IPC IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("IPC JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// Returned when `start_ipc_bridge` cannot bind to the requested address
+    /// (e.g. port already in use). Exit code 102 is the CLI convention for
+    /// port-binding failures.
+    #[error("{0} (error code 102: port binding failed)")]
+    PortBindingFailed(String),
+}
+
 
 /// Identifies the kind of streaming frame emitted to stdout.
 #[allow(dead_code)]
@@ -143,20 +160,20 @@ pub fn emit_final_frame(seq: u32, data: serde_json::Value) {
 }
 
 #[allow(dead_code)]
-pub fn handle_stdin_command(registry: &SnapshotRegistry) {
+pub fn parse_command_frame(input: &str) -> Result<CommandFrame, IpcError> {
+    let cmd: CommandFrame = serde_json::from_str(input)?;
+    Ok(cmd)
+}
+
+#[allow(dead_code)]
+pub fn handle_stdin_command(registry: &SnapshotRegistry) -> Result<(), IpcError> {
     use std::io::BufRead;
     let stdin = std::io::stdin();
     let mut line = String::new();
-    if stdin.lock().read_line(&mut line).unwrap_or(0) == 0 {
-        return;
+    if stdin.lock().read_line(&mut line)? == 0 {
+        return Ok(());
     }
-    let cmd: CommandFrame = match serde_json::from_str(line.trim()) {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("ipc: failed to parse command: {e}");
-            return;
-        }
-    };
+    let cmd = parse_command_frame(line.trim())?;
     match cmd.op {
         CommandOpcode::FetchSnapshot => {
             let snapshots = registry.fetch(cmd.id, cmd.batch_size);
@@ -165,14 +182,11 @@ pub fn handle_stdin_command(registry: &SnapshotRegistry) {
                 seq: cmd.id,
                 data: FetchResponseData { snapshots },
             };
-            match serde_json::to_string(&response) {
-                Ok(json_line) => {
-                    let stdout = std::io::stdout();
-                    let mut handle = stdout.lock();
-                    let _ = writeln!(handle, "{json_line}");
-                }
-                Err(e) => eprintln!("ipc: failed to serialize fetch response: {e}"),
-            }
+            let json_line = serde_json::to_string(&response)?;
+            let stdout = std::io::stdout();
+            let mut handle = stdout.lock();
+            writeln!(handle, "{json_line}")?;
         }
     }
+    Ok(())
 }

--- a/simulator/src/ipc/types.rs
+++ b/simulator/src/ipc/types.rs
@@ -15,12 +15,16 @@ pub enum IpcError {
     Json(#[from] serde_json::Error),
 
     /// Returned when `start_ipc_bridge` cannot bind to the requested address
-    /// (e.g. port already in use). Exit code 102 is the CLI convention for
-    /// port-binding failures.
-    #[error("{0} (error code 102: port binding failed)")]
-    PortBindingFailed(String),
+    /// (e.g. port already in use, permission denied). The underlying
+    /// `std::io::Error` is preserved as the error source so callers can
+    /// inspect `ErrorKind` (e.g. `AddrInUse`, `PermissionDenied`) and map
+    /// it to the appropriate CLI exit code.
+    #[error("IPC bridge could not bind: {source}")]
+    PortBindingFailed {
+        #[source]
+        source: std::io::Error,
+    },
 }
-
 
 /// Identifies the kind of streaming frame emitted to stdout.
 #[allow(dead_code)]


### PR DESCRIPTION
## Overview

Fixes IPC bridge connection handling by returning a structured error instead of panicking when a socket cannot be established.

## Changes

* Added `PortBindingFailed` variant to `IpcError`
* Preserved the original `std::io::Error` as the error source for richer diagnostics
* Added `start_ipc_bridge()` with non-panicking error handling
* Return a typed error on bind failures so callers can handle and report them appropriately
* Added tests for successful binding and address-in-use scenarios

## Verification

* `cargo test -p simulator --lib ipc`
* `cargo fmt --check`
* `cargo clippy --all-targets --all-features -- -D warnings`

All IPC tests passing.

## Related Issues

Closes #1421

## Type of Change

* [ ] New feature
* [x] Bug fix
* [ ] Breaking change
* [ ] Documentation update

## Checklist

* [x] Self-review completed
* [x] Tests added/updated
* [x] Changes verified locally
