### PR TITLE
Fix unwrap handling in mock HSM and safety test

### DIFF
--- a/simulator/src/hsm/mock.rs
+++ b/simulator/src/hsm/mock.rs
@@ -9,7 +9,7 @@
 use super::{MockHsmConfig, PublicKey, Signature, Signer, SignerError, SignerInfo};
 use async_trait::async_trait;
 use ed25519_dalek::{Signer as EdSigner, SigningKey, VerifyingKey};
-use rand::Rng;
+use rand::{Rng, RngCore};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
@@ -38,7 +38,11 @@ impl MockHsm {
             SigningKey::from_bytes(&seed)
         } else {
             let mut csprng = rand::rngs::OsRng;
-            SigningKey::generate(&mut csprng)
+            let mut seed = [0u8; 32];
+            csprng.try_fill_bytes(&mut seed).map_err(|e| {
+                SignerError::Hardware(format!("Failed to generate signing key: {}", e))
+            })?;
+            SigningKey::from_bytes(&seed)
         };
 
         Ok(Self {

--- a/simulator/src/simulator_safety_test.rs
+++ b/simulator/src/simulator_safety_test.rs
@@ -43,6 +43,38 @@ fn init_logger() {
     }
 }
 
+fn format_response_json(response: &SimulationResponse) -> String {
+    match serde_json::to_string(response) {
+        Ok(json) => json,
+        Err(err) => {
+            let fallback = serde_json::json!({
+                "status": "error",
+                "error": format!("Failed to serialize response: {}", err),
+            });
+            serde_json::to_string(&fallback).unwrap_or_else(|_| {
+                "{\"status\":\"error\",\"error\":\"Failed to serialize response\"}"
+                    .to_string()
+            })
+        }
+    }
+}
+
+fn format_structured_error_json(structured_error: &StructuredError) -> String {
+    match serde_json::to_string(structured_error) {
+        Ok(json) => json,
+        Err(err) => {
+            let fallback = serde_json::json!({
+                "error_type": "Serialization",
+                "message": format!("Failed to serialize structured error: {}", err),
+            });
+            serde_json::to_string(&fallback).unwrap_or_else(|_| {
+                "{\"error_type\":\"Serialization\",\"message\":\"Failed to serialize structured error\"}"
+                    .to_string()
+            })
+        }
+    }
+}
+
 fn send_error(msg: String) {
     let res = SimulationResponse {
         status: "error".to_string(),
@@ -56,7 +88,7 @@ fn send_error(msg: String) {
         budget_usage: None,
         source_location: None,
     };
-    println!("{}", serde_json::to_string(&res).unwrap());
+    println!("{}", format_response_json(&res));
     std::process::exit(1);
 }
 
@@ -157,7 +189,7 @@ fn main() {
             budget_usage: None,
             source_location: None,
         };
-        println!("{}", serde_json::to_string(&res).unwrap());
+        println!("{}", format_response_json(&res));
         warn!("Failed to read stdin: {}", e);
         return;
     }
@@ -178,7 +210,7 @@ fn main() {
                 budget_usage: None,
                 source_location: None,
             };
-            println!("{}", serde_json::to_string(&res).unwrap());
+            println!("{}", format_response_json(&res));
             return;
         }
     };
@@ -429,7 +461,7 @@ fn main() {
                 source_location: None,
             };
 
-            println!("{}", serde_json::to_string(&response).unwrap());
+            println!("{}", format_response_json(&response));
         }
         Ok(Err(host_error)) => {
             // Host error during execution (e.g., contract trap, validation failure)
@@ -444,7 +476,7 @@ fn main() {
 
             let response = SimulationResponse {
                 status: "error".to_string(),
-                error: Some(serde_json::to_string(&structured_error).unwrap()),
+                error: Some(format_structured_error_json(&structured_error)),
                 events: vec![],
                 diagnostic_events: vec![],
                 categorized_events: vec![],
@@ -454,7 +486,7 @@ fn main() {
                 budget_usage: None,
                 source_location: None,
             };
-            println!("{}", serde_json::to_string(&response).unwrap());
+            println!("{}", format_response_json(&response));
         }
         Err(panic_info) => {
             let panic_msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
@@ -477,7 +509,7 @@ fn main() {
                 budget_usage: None,
                 source_location: None,
             };
-            println!("{}", serde_json::to_string(&response).unwrap());
+            println!("{}", format_response_json(&response));
         }
     }
 }


### PR DESCRIPTION
## Summary
- handle mock HSM key generation failures without panicking
- avoid unwrap-based JSON serialization in simulator safety test output paths

## Testing
- not run

Fixes #1407
Fixes #1417