### PR TITLE
test: contain memory_limit_test panics with catch_unwind

### DIFF
--- a/simulator/src/memory_limit_test.rs
+++ b/simulator/src/memory_limit_test.rs
@@ -7,6 +7,7 @@
 mod tests {
     use crate::runner::SimHost;
     use crate::types::ResourceCalibration;
+    use std::panic;
 
     #[test]
     fn test_memory_limit_field() {
@@ -26,8 +27,8 @@ mod tests {
     }
 
     #[test]
-    fn test_memory_limit_check() {
-        // Test memory limit checking functionality
+    fn test_memory_limit_check_no_panic() {
+        // Test memory limit checking functionality when within limits
         let memory_limit = Some(1000); // Very small limit
         let host = SimHost::new(None, None, memory_limit);
 
@@ -36,15 +37,18 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Memory limit exceeded")]
-    fn test_memory_limit_exceeded() {
-        // This test would require mocking the host to return high memory usage
-        // For now, we just verify the panic message format
+    fn test_memory_limit_exceeded_does_not_propagate_panic() {
+        // Use catch_unwind to ensure panics from check_memory_limit do not
+        // abort the entire test process.
         let memory_limit = Some(100);
         let host = SimHost::new(None, None, memory_limit);
 
-        // This will panic if memory usage exceeds limit
-        // Note: In a real test, we'd need to mock the budget to return high usage
-        host.check_memory_limit();
+        let result = panic::catch_unwind(|| {
+            host.check_memory_limit();
+        });
+
+        // We only assert that a panic is observed here, without relying on
+        // the exact panic message format.
+        assert!(result.is_err());
     }
 }

--- a/simulator/src/repl.rs
+++ b/simulator/src/repl.rs
@@ -6,6 +6,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use tracing::{error, info};
 use wasmparser::{ExternalKind, Operator, Parser, Payload, TypeRef, ValType};
 
 #[derive(Debug, thiserror::Error)]
@@ -36,6 +37,11 @@ pub fn run_repl(wasm_path: &Path, initial_function: Option<&str>) -> Result<(), 
         session.select_function(selection)?;
     }
 
+    // Informational messages go through the configured logger
+    info!("loaded_wasm = {}", wasm_path.display());
+    info!("selected_function = {}", session.current_function_label());
+
+    // User-facing banner stays on stdout
     println!("Loaded {}", wasm_path.display());
     println!("Selected {}", session.current_function_label());
     println!("Type 'help' for commands.");
@@ -56,17 +62,23 @@ pub fn run_repl(wasm_path: &Path, initial_function: Option<&str>) -> Result<(), 
             break;
         }
 
-        match session.handle_command(line.trim())? {
-            CommandOutcome::Continue(message) => {
+        match session.handle_command(line.trim()) {
+            Ok(CommandOutcome::Continue(message)) => {
                 if !message.is_empty() {
                     println!("{message}");
                 }
             }
-            CommandOutcome::Exit(message) => {
+            Ok(CommandOutcome::Exit(message)) => {
                 if !message.is_empty() {
                     println!("{message}");
                 }
                 break;
+            }
+            Err(err) => {
+                // Send structured error to stderr via the logger and a simple
+                // human-readable message to the terminal user.
+                error!("repl_error = {:?}", err);
+                eprintln!("error: {err}");
             }
         }
     }


### PR DESCRIPTION
Handle panics in the memory limit test without relying on #[should_panic].

Replace #[should_panic]-based test_memory_limit_exceeded with a catch_unwind wrapper so that panics from check_memory_limit are contained within the test and do not risk aborting the entire test run.
Keep existing field and no-limit tests intact.
This change addresses issue https://github.com/dotandev/hintents/issues/1428 by making the memory limit tests more robust to panic behaviour without depending on global panic propagation.

Closes https://github.com/dotandev/hintents/issues/1428.


Route REPL diagnostics through the existing tracing logger and stderr instead of hard-coded println!.

Keep user-facing prompts and help text on stdout to preserve the interactive REPL UX.
Send structured informational messages (loaded module, selected function) through tracing::info! so they can be filtered, redirected, or disabled via the configured subscriber.
On command handling errors, log the structured error via tracing::error! and print a concise error: … line to stderr with eprintln!, enabling proper stderr redirection in terminal environments.
This change addresses issue https://github.com/dotandev/hintents/issues/1427 by separating user IO from diagnostics and plugging the REPL into the simulator's logging pipeline.

Closes https://github.com/dotandev/hintents/issues/1427.