### PR TITLE
Combine builder RUN commands in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,17 +7,16 @@ ARG TARGETARCH
 
 WORKDIR /app/simulator
 
-# Install build dependencies for cross-compilation
-# clang and lld are used as cross-linkers
-RUN apk add --no-cache musl-dev gcc clang lld llvm
-
 # Copy Rust project files
 COPY simulator/Cargo.toml simulator/Cargo.lock ./
 COPY simulator/src ./src
 
+# Install build dependencies for cross-compilation
+# clang and lld are used as cross-linkers
 # Build release binary (statically linked by default on Alpine)
 # We use cross-compilation if TARGETARCH is arm64 to keep build times fast
-RUN if [ "$TARGETARCH" = "arm64" ]; then \
+RUN apk add --no-cache musl-dev gcc clang lld llvm && \
+  if [ "$TARGETARCH" = "arm64" ]; then \
   rustup target add aarch64-unknown-linux-musl && \
   CC_aarch64_unknown_linux_musl=clang \
   AR_aarch64_unknown_linux_musl=llvm-ar \


### PR DESCRIPTION
## Summary
- combine the stage 1 Alpine dependency install and Rust build into a single RUN command
- keep the change scoped to Dockerfile only, as requested in #1446

## Validation
- reviewed Dockerfile diff for shell syntax and scope
- attempted targeted Docker build, but local Docker daemon was not running

Closes #1446