### PR TITLE
chore: remove redundant go mod download from deps target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,6 @@ clean:
 # Install dependencies
 deps:
 	go mod tidy
-	go mod download
 
 # Run benchmarks
 bench:


### PR DESCRIPTION
Closes #1439 