### PR TITLE
remove redundant gotidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,6 @@ clean:
 # Install dependencies
 deps:
 	go mod tidy
-	go mod download
 
 # Run benchmarks
 bench:


### PR DESCRIPTION
================================================================================
TITLE:
================================================================================

chore: Remove redundant go mod download from deps target

================================================================================
DESCRIPTION:
================================================================================

## Overview

Removes redundant `go mod download` command from the `deps` target in the Makefile, streamlining dependency management.

## Changes

### Makefile Optimization

- **deps target**: Removed redundant `go mod download` command
  - `go mod tidy` already downloads and verifies all modules
  - Eliminates unnecessary duplicate operation
  - Improves build efficiency

## Rationale

The `go mod tidy` command performs the following operations:
- Downloads all required modules
- Removes unused dependencies
- Updates go.mod and go.sum files
- Verifies module integrity

The subsequent `go mod download` call was redundant and added no additional value, only increasing build time.

## Testing

- Verified that `make deps` continues to work correctly
- Dependencies are properly resolved and cached
- No functional changes to build behavior

## Related Issues

None

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation update

## Checklist

- [x] Code follows project style guidelines
- [x] Changes verified locally
- [x] No functional impact to existing workflows

Closes #1439