### PR TITLE
fixed the nil map panic in request builder

### DIFF
--- a/internal/simulator/builder.go
+++ b/internal/simulator/builder.go
@@ -155,10 +155,7 @@ func (b *SimulationRequestBuilder) Build() (req *SimulationRequest, err error) {
 		ResultMetaXdr: b.resultMetaXdr,
 	}
 
-	// Only set ledger entries if there are any
-	if len(b.ledgerEntries) > 0 {
-		req.LedgerEntries = b.ledgerEntries
-	}
+	req.LedgerEntries = b.ledgerEntries
 
 	// Only set restore preamble if present
 	if b.restorePreamble != nil {


### PR DESCRIPTION
closes #1349

Removed the `if len(b.ledgerEntries) > 0` guard in `builder.go:Build()`. `req.LedgerEntries` is now unconditionally assigned from `b.ledgerEntries`, which is always an initialized map; preventing nil panics when downstream code (Go or Rust bridge) iterates over it.