### PR TITLE
fix(fuzz): deep copy corpus entries to prevent concurrent mutation

### DIFF
--- a/internal/fuzz/fuzzer.go
+++ b/internal/fuzz/fuzzer.go
@@ -35,6 +35,37 @@ type CorpusEntry struct {
 	Timestamp   time.Time
 }
 
+// DeepCopy returns a fully independent copy of the CorpusEntry.
+// Both the entry metadata and the underlying FuzzerInput are copied so that
+// callers cannot mutate internal fuzzer state through the returned value.
+func (ce *CorpusEntry) DeepCopy() *CorpusEntry {
+	cp := &CorpusEntry{
+		ResultIdx:   ce.ResultIdx,
+		NewCoverage: ce.NewCoverage,
+		Timestamp:   ce.Timestamp,
+	}
+
+	if ce.Input != nil {
+		cp.Input = ce.Input.DeepCopy()
+	}
+
+	if ce.Coverage != nil {
+		covCopy := &CoverageMap{
+			totalCoverage: ce.Coverage.totalCoverage,
+			timestamp:     ce.Coverage.timestamp,
+		}
+		if ce.Coverage.coveredLines != nil {
+			covCopy.coveredLines = make(map[string]bool, len(ce.Coverage.coveredLines))
+			for k, v := range ce.Coverage.coveredLines {
+				covCopy.coveredLines[k] = v
+			}
+		}
+		cp.Coverage = covCopy
+	}
+
+	return cp
+}
+
 // CoverageGuidedFuzzer implements a coverage-guided fuzzer for Stellar contracts
 type CoverageGuidedFuzzer struct {
 	runner           simulator.RunnerInterface
@@ -564,23 +595,29 @@ func (f *CoverageGuidedFuzzer) logProgress(iteration uint64) {
 	)
 }
 
-// GetCrashingInputs returns all inputs that caused crashes
+// GetCrashingInputs returns deep copies of all inputs that caused crashes.
+// Callers may freely mutate the returned values without affecting internal state.
 func (f *CoverageGuidedFuzzer) GetCrashingInputs() []*simulator.FuzzerInput {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
 	result := make([]*simulator.FuzzerInput, len(f.crashingInputs))
-	copy(result, f.crashingInputs)
+	for i, input := range f.crashingInputs {
+		result[i] = input.DeepCopy()
+	}
 	return result
 }
 
-// GetCorpus returns a copy of the current corpus
+// GetCorpus returns deep copies of the current corpus entries.
+// Callers may freely mutate the returned values without affecting internal state.
 func (f *CoverageGuidedFuzzer) GetCorpus() []*CorpusEntry {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
 	result := make([]*CorpusEntry, len(f.corpus))
-	copy(result, f.corpus)
+	for i, entry := range f.corpus {
+		result[i] = entry.DeepCopy()
+	}
 	return result
 }
 

--- a/internal/fuzz/fuzzer_test.go
+++ b/internal/fuzz/fuzzer_test.go
@@ -295,6 +295,135 @@ func TestCoverageStatisticsString(t *testing.T) {
 	assert.Contains(t, str, "3")  // crashes
 }
 
+// TestGetCrashingInputsDeepCopy verifies that mutating a returned crashing input
+// does not affect the fuzzer's internal state (isolation guarantee).
+func TestGetCrashingInputsDeepCopy(t *testing.T) {
+	runner := simulator.NewDefaultMockRunner()
+	fuzzer := NewCoverageGuidedFuzzer(runner, FuzzerConfig{})
+
+	// Inject a crashing input directly so we have a known, stable value.
+	original := &simulator.FuzzerInput{
+		EnvelopeXdr: "deadbeef",
+		LedgerEntries: map[string]string{
+			"key1": "value1",
+		},
+		Args:      []string{"arg1", "arg2"},
+		Timestamp: 1000,
+		Seed:      42,
+	}
+	fuzzer.mu.Lock()
+	fuzzer.crashingInputs = append(fuzzer.crashingInputs, original)
+	fuzzer.mu.Unlock()
+
+	// Retrieve a copy and mutate it.
+	crashes := fuzzer.GetCrashingInputs()
+	require.Len(t, crashes, 1)
+
+	returned := crashes[0]
+	returned.EnvelopeXdr = "mutated"
+	returned.LedgerEntries["key1"] = "mutated_value"
+	returned.LedgerEntries["new_key"] = "new_value"
+	returned.Args[0] = "mutated_arg"
+
+	// Internal state must be unchanged.
+	fuzzer.mu.RLock()
+	internal := fuzzer.crashingInputs[0]
+	fuzzer.mu.RUnlock()
+
+	assert.Equal(t, "deadbeef", internal.EnvelopeXdr, "EnvelopeXdr should not be mutated")
+	assert.Equal(t, "value1", internal.LedgerEntries["key1"], "LedgerEntries value should not be mutated")
+	assert.NotContains(t, internal.LedgerEntries, "new_key", "new key should not appear in internal map")
+	assert.Equal(t, "arg1", internal.Args[0], "Args should not be mutated")
+}
+
+// TestGetCorpusDeepCopy verifies that mutating a returned corpus entry does not
+// affect the fuzzer's internal corpus state (isolation guarantee).
+func TestGetCorpusDeepCopy(t *testing.T) {
+	runner := simulator.NewDefaultMockRunner()
+	fuzzer := NewCoverageGuidedFuzzer(runner, FuzzerConfig{
+		MaxCorpusSize:  10,
+		EnableCoverage: false,
+	})
+
+	// Seed the corpus with a known input.
+	input := &simulator.FuzzerInput{
+		EnvelopeXdr: "cafebabe",
+		LedgerEntries: map[string]string{
+			"entry1": "original",
+		},
+		Args:      []string{"a", "b"},
+		Timestamp: 2000,
+	}
+	fuzzer.addToCorpus(context.Background(), input, nil)
+
+	corpus := fuzzer.GetCorpus()
+	require.Len(t, corpus, 1)
+
+	returned := corpus[0]
+	require.NotNil(t, returned.Input)
+
+	// Mutate the returned copy.
+	returned.Input.EnvelopeXdr = "mutated_xdr"
+	returned.Input.LedgerEntries["entry1"] = "mutated"
+	returned.Input.LedgerEntries["extra"] = "extra_value"
+	returned.Input.Args = append(returned.Input.Args, "c")
+
+	// Internal corpus entry must be unchanged.
+	fuzzer.mu.RLock()
+	internalEntry := fuzzer.corpus[0]
+	fuzzer.mu.RUnlock()
+
+	assert.Equal(t, "cafebabe", internalEntry.Input.EnvelopeXdr, "EnvelopeXdr should not be mutated")
+	assert.Equal(t, "original", internalEntry.Input.LedgerEntries["entry1"], "LedgerEntries should not be mutated")
+	assert.NotContains(t, internalEntry.Input.LedgerEntries, "extra", "extra key should not appear in internal map")
+	assert.Len(t, internalEntry.Input.Args, 2, "Args slice length should not change")
+}
+
+// TestFuzzerInputDeepCopy verifies that FuzzerInput.DeepCopy produces a fully
+// independent copy with no shared underlying maps or slices.
+func TestFuzzerInputDeepCopy(t *testing.T) {
+	original := &simulator.FuzzerInput{
+		EnvelopeXdr: "aabbcc",
+		LedgerEntries: map[string]string{
+			"k": "v",
+		},
+		Args:      []string{"x"},
+		Timestamp: 999,
+		Seed:      7,
+	}
+
+	cp := original.DeepCopy()
+
+	// Values equal on creation.
+	assert.Equal(t, original.EnvelopeXdr, cp.EnvelopeXdr)
+	assert.Equal(t, original.LedgerEntries, cp.LedgerEntries)
+	assert.Equal(t, original.Args, cp.Args)
+	assert.Equal(t, original.Timestamp, cp.Timestamp)
+	assert.Equal(t, original.Seed, cp.Seed)
+
+	// Mutating the copy does not affect the original.
+	cp.EnvelopeXdr = "changed"
+	cp.LedgerEntries["k"] = "changed"
+	cp.Args[0] = "changed"
+
+	assert.Equal(t, "aabbcc", original.EnvelopeXdr)
+	assert.Equal(t, "v", original.LedgerEntries["k"])
+	assert.Equal(t, "x", original.Args[0])
+}
+
+// TestFuzzerInputDeepCopyNilFields verifies DeepCopy handles nil maps and slices safely.
+func TestFuzzerInputDeepCopyNilFields(t *testing.T) {
+	original := &simulator.FuzzerInput{
+		EnvelopeXdr:   "test",
+		LedgerEntries: nil,
+		Args:          nil,
+	}
+
+	cp := original.DeepCopy()
+	assert.Nil(t, cp.LedgerEntries)
+	assert.Nil(t, cp.Args)
+}
+
 // BenchmarkMutation benchmarks the mutation performance
 func BenchmarkMutation(b *testing.B) {
 	runner := simulator.NewDefaultMockRunner()

--- a/internal/simulator/fuzzing_harness.go
+++ b/internal/simulator/fuzzing_harness.go
@@ -19,6 +19,31 @@ type FuzzerInput struct {
 	Seed          uint64
 }
 
+// DeepCopy returns a fully independent copy of the FuzzerInput.
+// The returned value shares no underlying memory with the original, so
+// mutations to LedgerEntries or Args on either side are isolated.
+func (fi *FuzzerInput) DeepCopy() *FuzzerInput {
+	cp := &FuzzerInput{
+		EnvelopeXdr: fi.EnvelopeXdr,
+		Timestamp:   fi.Timestamp,
+		Seed:        fi.Seed,
+	}
+
+	if fi.LedgerEntries != nil {
+		cp.LedgerEntries = make(map[string]string, len(fi.LedgerEntries))
+		for k, v := range fi.LedgerEntries {
+			cp.LedgerEntries[k] = v
+		}
+	}
+
+	if fi.Args != nil {
+		cp.Args = make([]string, len(fi.Args))
+		copy(cp.Args, fi.Args)
+	}
+
+	return cp
+}
+
 // FuzzingConfig contains configuration for fuzzing operations
 type FuzzingConfig struct {
 	MaxInputSize     int


### PR DESCRIPTION
## Description

`GetCrashingInputs` and `GetCorpus` returned slices of pointers that shared the same underlying `FuzzerInput` values as the fuzzer's internal state. A caller mutating the returned `LedgerEntries` map or `Args` slice would silently corrupt the corpus and cause data races under `-race`.

## Changes

- **`internal/simulator/fuzzing_harness.go`** — Add `FuzzerInput.DeepCopy()` that clones `LedgerEntries` and `Args` into fresh allocations.
- **`internal/fuzz/fuzzer.go`** — Add `CorpusEntry.DeepCopy()` (including deep-copying `CoverageMap`). Rewrite `GetCrashingInputs` and `GetCorpus` to iterate and deep-copy each element instead of shallow-copying the pointer slice.
- **`internal/fuzz/fuzzer_test.go`** — Add four isolation tests: `TestGetCrashingInputsDeepCopy`, `TestGetCorpusDeepCopy`, `TestFuzzerInputDeepCopy`, `TestFuzzerInputDeepCopyNilFields`.

## Related Issues

Closes #1554

## Testing

```
go test -v -race ./internal/fuzz/...   # 19/19 PASS
go test -v -race ./internal/simulator/ # all PASS
```

## Checklist

- [x] Code follows style guidelines
- [x] Tests added/updated
- [x] No new warnings or errors
- [x] Race detector clean