### PR TITLE
perf(lsp): optimize lineAtPosition to avoid full string splits

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -298,17 +298,37 @@ func (s *Server) getDocument(uri protocol.DocumentURI) (string, bool) {
 	return text, ok
 }
 
+// lineAtPosition returns the text of the line at the given LSP position without
+// splitting the entire document. It scans forward using strings.IndexByte to
+// find newline boundaries, which avoids allocating a slice of all lines and
+// copying every sub-string — important for large documents where
+// strings.Split("\n") would produce O(n) heap allocations on every hover.
 func lineAtPosition(text string, position protocol.Position) string {
 	if text == "" {
 		return ""
 	}
 
-	lines := strings.Split(text, "\n")
 	lineIndex := int(position.Line)
-	if lineIndex < 0 || lineIndex >= len(lines) {
+	if lineIndex < 0 {
 		return ""
 	}
-	return lines[lineIndex]
+
+	start := 0
+	for i := 0; i < lineIndex; i++ {
+		idx := strings.IndexByte(text[start:], '\n')
+		if idx < 0 {
+			// Requested line is beyond the last line in the document.
+			return ""
+		}
+		start += idx + 1
+	}
+
+	// start now points at the beginning of the target line.
+	rest := text[start:]
+	if end := strings.IndexByte(rest, '\n'); end >= 0 {
+		return rest[:end]
+	}
+	return rest
 }
 
 func hostFunctionAtPosition(line string, position protocol.Position) (string, uint32, uint32) {


### PR DESCRIPTION
## Summary

Fixes #1566

`lineAtPosition` in `internal/lsp/server.go` was calling `strings.Split(text, "\n")` on every hover request. For large documents this allocates a `[]string` that copies every line in the file into the heap — work proportional to the entire document size regardless of which line is actually needed.

## What changed

Replaced `strings.Split` with byte-level scanning using `strings.IndexByte`. The new implementation walks forward through the raw string, counting newlines until it reaches the target line, then slices out just that line. This produces:

- **Zero extra allocations** beyond the returned sub-string slice (no intermediate `[]string`).
- **O(k) CPU** where `k` is the byte offset of the requested line, not O(n) over the full document.

```go
// Before — allocates all lines on every hover
lines := strings.Split(text, "\n")
return lines[lineIndex]

// After — scans only up to the target line
start := 0
for i := 0; i < lineIndex; i++ {
    idx := strings.IndexByte(text[start:], '\n')
    if idx < 0 { return "" }
    start += idx + 1
}
rest := text[start:]
if end := strings.IndexByte(rest, '\n'); end >= 0 {
    return rest[:end]
}
return rest
```

## Testing

All existing tests in `internal/lsp` pass with no changes required — the observable behaviour is identical, only the allocation profile improves.

```
ok  github.com/dotandev/hintents/internal/lsp  0.008s
```

## Closes

Closes #1566