### PR TITLE
perf(fuzz): reuse a single LCOV temp file across fuzzing iterations

### DIFF
--- a/internal/fuzz/fuzzer.go
+++ b/internal/fuzz/fuzzer.go
@@ -46,6 +46,11 @@ type CoverageGuidedFuzzer struct {
 	mu               sync.RWMutex
 	executionCount   uint64
 	lastCoverageGrow time.Time
+
+	// coverageTmpMu guards the lazily-created LCOV temp file that is shared
+	// across every fuzzing iteration of this instance.
+	coverageTmpMu   sync.Mutex
+	coverageTmpPath string // path of the reusable LCOV temp file ("" until created)
 }
 
 // FuzzerConfig contains configuration for the coverage-guided fuzzer
@@ -125,6 +130,10 @@ func (f *CoverageGuidedFuzzer) Run(ctx context.Context, seedInput *simulator.Fuz
 	if seedInput == nil {
 		return nil, fmt.Errorf("seed input required for fuzzing")
 	}
+
+	// The reusable LCOV temp file lives for the duration of the campaign and is
+	// removed once it ends, regardless of how the loop terminates.
+	defer f.cleanupCoverageTemp()
 
 	stats := &FuzzingStats{
 		StartTime: time.Now(),
@@ -421,17 +430,19 @@ func (f *CoverageGuidedFuzzer) executeInput(ctx context.Context, input *simulato
 	if f.config.EnableCoverage {
 		simReq.EnableCoverage = true
 		if simReq.CoverageLCOVPath == nil {
-			tmpFile, err := os.CreateTemp("", "erst-fuzz-*.lcov")
+			// Reuse a single temp file for the whole campaign instead of
+			// creating and deleting one on every iteration. The simulator
+			// overwrites the file each run, so a single per-instance file is
+			// sufficient and avoids per-iteration disk I/O. It is removed by
+			// cleanupCoverageTemp when the campaign ends.
+			coveragePath, err := f.coverageOutputPath()
 			if err != nil {
 				result.Status = "error"
 				result.ErrorMessage = fmt.Sprintf("failed to create coverage temp file: %v", err)
 				result.ExecutionTimeMs = 0
 				return result, nil
 			}
-			coveragePath := tmpFile.Name()
-			_ = tmpFile.Close()
 			simReq.CoverageLCOVPath = &coveragePath
-			defer os.Remove(coveragePath)
 		}
 	}
 
@@ -462,6 +473,45 @@ func (f *CoverageGuidedFuzzer) executeInput(ctx context.Context, input *simulato
 	}
 
 	return result, coverage
+}
+
+// coverageOutputPath returns the path of this fuzzer's reusable LCOV temp file,
+// creating it lazily on first use. The same file is handed to the simulator on
+// every iteration (the simulator overwrites it each run), which eliminates the
+// per-iteration os.CreateTemp/os.Remove churn that previously dominated disk I/O.
+func (f *CoverageGuidedFuzzer) coverageOutputPath() (string, error) {
+	f.coverageTmpMu.Lock()
+	defer f.coverageTmpMu.Unlock()
+
+	if f.coverageTmpPath != "" {
+		return f.coverageTmpPath, nil
+	}
+
+	tmpFile, err := os.CreateTemp("", "erst-fuzz-*.lcov")
+	if err != nil {
+		return "", err
+	}
+	path := tmpFile.Name()
+	if cerr := tmpFile.Close(); cerr != nil {
+		_ = os.Remove(path)
+		return "", cerr
+	}
+
+	f.coverageTmpPath = path
+	return path, nil
+}
+
+// cleanupCoverageTemp removes the reusable LCOV temp file, if one was created.
+// It is safe to call multiple times and resets the path so a subsequent Run
+// lazily recreates the file.
+func (f *CoverageGuidedFuzzer) cleanupCoverageTemp() {
+	f.coverageTmpMu.Lock()
+	defer f.coverageTmpMu.Unlock()
+
+	if f.coverageTmpPath != "" {
+		_ = os.Remove(f.coverageTmpPath)
+		f.coverageTmpPath = ""
+	}
 }
 
 // extractCoverage extracts coverage information from an input when explicit coverage is not available.

--- a/internal/fuzz/fuzzer_test.go
+++ b/internal/fuzz/fuzzer_test.go
@@ -6,6 +6,8 @@ package fuzz
 import (
 	"context"
 	"encoding/hex"
+	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -244,6 +246,7 @@ func TestExecuteInputWithCoverage(t *testing.T) {
 		}, nil
 	})
 	fuzzer := NewCoverageGuidedFuzzer(runner, FuzzerConfig{EnableCoverage: true})
+	defer fuzzer.cleanupCoverageTemp()
 
 	input := &simulator.FuzzerInput{EnvelopeXdr: "test_envelope"}
 	result, coverage := fuzzer.executeInput(context.Background(), input)
@@ -253,6 +256,61 @@ func TestExecuteInputWithCoverage(t *testing.T) {
 	assert.NotNil(t, coverage)
 	assert.Equal(t, uint32(2), coverage.totalCoverage)
 	assert.Len(t, coverage.coveredLines, 2)
+}
+
+// TestCoverageTempFileReuse verifies the fuzzer creates a single LCOV temp file
+// and reuses it across every iteration (instead of one per iteration), then
+// removes it when the campaign ends.
+func TestCoverageTempFileReuse(t *testing.T) {
+	var (
+		mu        sync.Mutex
+		seenPaths []string
+	)
+
+	runner := simulator.NewMockRunner(func(ctx context.Context, req *simulator.SimulationRequest) (*simulator.SimulationResponse, error) {
+		require.True(t, req.EnableCoverage)
+		require.NotNil(t, req.CoverageLCOVPath)
+
+		// The reused temp file must exist for the duration of the run.
+		_, statErr := os.Stat(*req.CoverageLCOVPath)
+		assert.NoError(t, statErr, "coverage temp file should exist during execution")
+
+		mu.Lock()
+		seenPaths = append(seenPaths, *req.CoverageLCOVPath)
+		mu.Unlock()
+
+		return &simulator.SimulationResponse{
+			Status:     "success",
+			LCOVReport: "TN:\nSF:/tmp/contract.wasm\nDA:10,1\nDA:20,1\nend_of_record\n",
+		}, nil
+	})
+
+	const iterations = 8
+	fuzzer := NewCoverageGuidedFuzzer(runner, FuzzerConfig{
+		MaxIterations:  iterations,
+		EnableCoverage: true,
+	})
+
+	seed := &simulator.FuzzerInput{
+		EnvelopeXdr:   hex.EncodeToString([]byte("seed input")),
+		LedgerEntries: map[string]string{},
+	}
+
+	_, err := fuzzer.Run(context.Background(), seed)
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.Greater(t, len(seenPaths), 1, "expected multiple simulator executions")
+	for _, p := range seenPaths {
+		assert.Equal(t, seenPaths[0], p, "every iteration must reuse the same temp file")
+	}
+
+	// After the campaign ends the reusable temp file must be cleaned up.
+	_, statErr := os.Stat(seenPaths[0])
+	assert.True(t, os.IsNotExist(statErr), "coverage temp file should be removed after Run")
+	assert.Empty(t, fuzzer.coverageTmpPath, "temp path should be reset after cleanup")
 }
 
 // TestContextCancellation tests behavior when context is cancelled


### PR DESCRIPTION
## Summary

Closes #1553.

`executeInput` in `internal/fuzz/fuzzer.go` created a fresh temp file with `os.CreateTemp` and deleted it (`defer os.Remove`) on **every** fuzzing iteration whenever coverage was enabled. Across a campaign this produces a create+unlink syscall pair per iteration, which dominates disk I/O.

This change creates the LCOV temp file **lazily, once per fuzzer instance** and reuses it for every iteration. The simulator overwrites the file on each run, so a single per-instance file is sufficient. The file is removed when the campaign ends.

## Changes

- Added `coverageTmpPath` (guarded by `coverageTmpMu`) to `CoverageGuidedFuzzer`.
- `coverageOutputPath()` lazily creates the reusable temp file on first use and returns the same path thereafter.
- `cleanupCoverageTemp()` removes the file and resets the path; called via `defer` in `Run()` so the file is cleaned up however the loop terminates (and a subsequent `Run` lazily recreates it).
- `executeInput` now requests the shared path instead of creating/deleting a temp file per iteration.

## Behaviour

- No change to coverage results: the simulator still writes LCOV to the path each run and the Go side reads it back the same way. Iterations are sequential, so reuse is safe.
- Error handling on temp-file creation is preserved (returns an `error` result rather than panicking).

## Tests

- Added `TestCoverageTempFileReuse`: runs a multi-iteration campaign with coverage enabled and asserts (a) the simulator is handed the **same** temp-file path on every iteration, (b) the file exists during execution, and (c) it is removed after `Run` returns.
- Updated `TestExecuteInputWithCoverage` to clean up the per-instance temp file when calling `executeInput` directly.

### Verification
- `go build ./...` ✓
- `go test ./internal/fuzz/...` ✓
- `gofmt`/`go vet`/`staticcheck` clean on changed files ✓