### PR TITLE
feat(visualizer): structured JSON output for ledger state diffs

### DIFF
--- a/internal/visualizer/simdiff.go
+++ b/internal/visualizer/simdiff.go
@@ -6,7 +6,10 @@
 package visualizer
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"sort"
 	"strings"
 )
@@ -77,12 +80,8 @@ func DiffLedgerEntries(before, after map[string]string) []LedgerDiffEntry {
 	return entries
 }
 
-// RenderLedgerStateDiff prints a colored before/after diff of ledger state changes
-// to stdout. Unchanged entries are omitted unless showUnchanged is true.
-func RenderLedgerStateDiff(before, after map[string]string, showUnchanged bool) {
-	entries := DiffLedgerEntries(before, after)
-
-	added, removed, modified, unchanged := 0, 0, 0, 0
+// summarizeLedgerDiff counts the change kinds across a set of diff entries.
+func summarizeLedgerDiff(entries []LedgerDiffEntry) (added, removed, modified, unchanged int) {
 	for _, e := range entries {
 		switch e.ChangeKind {
 		case ledgerAdded:
@@ -95,35 +94,55 @@ func RenderLedgerStateDiff(before, after map[string]string, showUnchanged bool) 
 			unchanged++
 		}
 	}
+	return added, removed, modified, unchanged
+}
 
-	printLedgerDiffHeader(len(before), len(after), added, removed, modified)
+// RenderLedgerStateDiff prints a colored before/after diff of ledger state changes
+// to stdout. Unchanged entries are omitted unless showUnchanged is true.
+//
+// It is a thin convenience wrapper around RenderLedgerStateDiffTo; callers that
+// need to capture the output (tests, headless integrations) should target an
+// explicit io.Writer instead.
+func RenderLedgerStateDiff(before, after map[string]string, showUnchanged bool) {
+	RenderLedgerStateDiffTo(os.Stdout, before, after, showUnchanged)
+}
+
+// RenderLedgerStateDiffTo writes a colored before/after diff of ledger state
+// changes to w. Unchanged entries are omitted unless showUnchanged is true.
+// The formatting is identical to RenderLedgerStateDiff; only the IO target
+// differs, which keeps the rendering logic decoupled from stdout.
+func RenderLedgerStateDiffTo(w io.Writer, before, after map[string]string, showUnchanged bool) {
+	entries := DiffLedgerEntries(before, after)
+	added, removed, modified, unchanged := summarizeLedgerDiff(entries)
+
+	printLedgerDiffHeader(w, len(before), len(after), added, removed, modified)
 
 	if added+removed+modified == 0 {
-		fmt.Printf("\n  %s Ledger state is identical — no entries changed.\n\n",
+		fmt.Fprintf(w, "\n  %s Ledger state is identical — no entries changed.\n\n",
 			Colorize("[=]", "dim"))
 		return
 	}
 
 	// Column headers — pad manually to avoid ANSI escape codes skewing %-*s width.
-	fmt.Println()
+	fmt.Fprintln(w)
 	beforeHeader := Colorize("BEFORE", "dim") + strings.Repeat(" ", ledgerColWidth-len("BEFORE"))
 	afterHeader := Colorize("AFTER", "dim") + strings.Repeat(" ", ledgerColWidth-len("AFTER"))
-	fmt.Printf("  %-4s  %s%s%s\n", "", beforeHeader, ledgerColSep, afterHeader)
-	fmt.Printf("  %s\n", Colorize(strings.Repeat("─", 4+2+ledgerColWidth*2+len(ledgerColSep)), "dim"))
+	fmt.Fprintf(w, "  %-4s  %s%s%s\n", "", beforeHeader, ledgerColSep, afterHeader)
+	fmt.Fprintf(w, "  %s\n", Colorize(strings.Repeat("─", 4+2+ledgerColWidth*2+len(ledgerColSep)), "dim"))
 
 	for _, e := range entries {
 		if e.ChangeKind == ledgerUnchanged && !showUnchanged {
 			continue
 		}
-		renderLedgerEntry(e)
+		renderLedgerEntry(w, e)
 	}
 
-	fmt.Println()
-	printLedgerDiffSummary(added, removed, modified, unchanged)
+	fmt.Fprintln(w)
+	printLedgerDiffSummary(w, added, removed, modified, unchanged)
 }
 
-// renderLedgerEntry prints a single ledger entry diff row.
-func renderLedgerEntry(e LedgerDiffEntry) {
+// renderLedgerEntry writes a single ledger entry diff row to w.
+func renderLedgerEntry(w io.Writer, e LedgerDiffEntry) {
 	marker, beforeColor, afterColor := ledgerEntryStyle(e.ChangeKind)
 
 	// Truncate long base64 values for readability; full values are in the raw XDR.
@@ -138,11 +157,11 @@ func renderLedgerEntry(e LedgerDiffEntry) {
 	// Shorten the key for display.
 	keyDisplay := shortenLedgerKey(e.Key)
 
-	fmt.Printf("  %s   %s\n",
+	fmt.Fprintf(w, "  %s   %s\n",
 		Colorize(marker, ledgerChangeColor(e.ChangeKind)),
 		Colorize(keyDisplay, "dim"),
 	)
-	fmt.Printf("       %s%s%s\n",
+	fmt.Fprintf(w, "       %s%s%s\n",
 		Colorize(beforePadded, beforeColor),
 		ledgerColSep,
 		Colorize(afterPadded, afterColor),
@@ -209,39 +228,158 @@ func shortenLedgerKey(key string) string {
 	return key[:8] + "…" + key[len(key)-8:]
 }
 
-// printLedgerDiffHeader prints the section header for the ledger state diff.
-func printLedgerDiffHeader(beforeCount, afterCount, added, removed, modified int) {
+// printLedgerDiffHeader writes the section header for the ledger state diff to w.
+func printLedgerDiffHeader(w io.Writer, beforeCount, afterCount, added, removed, modified int) {
 	sep := strings.Repeat("═", ledgerColWidth*2+len(ledgerColSep)+8)
-	fmt.Println()
-	fmt.Println(Colorize("╔"+sep+"╗", "cyan"))
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, Colorize("╔"+sep+"╗", "cyan"))
 	title := "  LEDGER STATE DIFF  ─  Before vs After Transaction  "
 	pad := len(sep) - len(title)
 	if pad < 0 {
 		pad = 0
 	}
-	fmt.Printf(Colorize("║", "cyan")+"%s"+strings.Repeat(" ", pad)+Colorize("║", "cyan")+"\n", title)
-	fmt.Println(Colorize("╚"+sep+"╝", "cyan"))
+	fmt.Fprintf(w, Colorize("║", "cyan")+"%s"+strings.Repeat(" ", pad)+Colorize("║", "cyan")+"\n", title)
+	fmt.Fprintln(w, Colorize("╚"+sep+"╝", "cyan"))
 
-	fmt.Printf("\n  Entries before: %s   after: %s\n",
+	fmt.Fprintf(w, "\n  Entries before: %s   after: %s\n",
 		Colorize(fmt.Sprintf("%d", beforeCount), "dim"),
 		Colorize(fmt.Sprintf("%d", afterCount), "dim"),
 	)
-	fmt.Printf("  Changes: %s added  %s removed  %s modified\n",
+	fmt.Fprintf(w, "  Changes: %s added  %s removed  %s modified\n",
 		Colorize(fmt.Sprintf("+%d", added), "green"),
 		Colorize(fmt.Sprintf("-%d", removed), "red"),
 		Colorize(fmt.Sprintf("~%d", modified), "yellow"),
 	)
 }
 
-// printLedgerDiffSummary prints the summary footer for the ledger state diff.
-func printLedgerDiffSummary(added, removed, modified, unchanged int) {
+// printLedgerDiffSummary writes the summary footer for the ledger state diff to w.
+func printLedgerDiffSummary(w io.Writer, added, removed, modified, unchanged int) {
 	sep := strings.Repeat("─", ledgerColWidth*2+len(ledgerColSep)+8)
-	fmt.Println(Colorize("  "+sep, "dim"))
-	fmt.Printf("  %s  %s added  %s removed  %s modified  %s unchanged\n\n",
+	fmt.Fprintln(w, Colorize("  "+sep, "dim"))
+	fmt.Fprintf(w, "  %s  %s added  %s removed  %s modified  %s unchanged\n\n",
 		Colorize("Summary:", "bold"),
 		Colorize(fmt.Sprintf("%d", added), "green"),
 		Colorize(fmt.Sprintf("%d", removed), "red"),
 		Colorize(fmt.Sprintf("%d", modified), "yellow"),
 		Colorize(fmt.Sprintf("%d", unchanged), "dim"),
 	)
+}
+
+// LedgerDiffChange is the JSON-friendly name of a ledger entry's change kind.
+type LedgerDiffChange string
+
+const (
+	ChangeAdded     LedgerDiffChange = "added"
+	ChangeRemoved   LedgerDiffChange = "removed"
+	ChangeModified  LedgerDiffChange = "modified"
+	ChangeUnchanged LedgerDiffChange = "unchanged"
+)
+
+// LedgerDiffEntryReport is a single ledger entry change in structured,
+// machine-readable form suitable for headless (non-terminal) integration.
+// Before is nil when the entry did not exist before the transaction; After is
+// nil when the entry was removed. Both are populated for modified/unchanged
+// entries.
+type LedgerDiffEntryReport struct {
+	Key    string           `json:"key"`
+	Change LedgerDiffChange `json:"change"`
+	Before *string          `json:"before"`
+	After  *string          `json:"after"`
+}
+
+// LedgerStateDiffReport is the structured form of a ledger state diff. It carries
+// the same information RenderLedgerStateDiff prints, minus the ANSI colors and
+// terminal layout, so it can be serialized to JSON and consumed by other tools.
+type LedgerStateDiffReport struct {
+	BeforeCount int                     `json:"before_count"`
+	AfterCount  int                     `json:"after_count"`
+	Added       int                     `json:"added"`
+	Removed     int                     `json:"removed"`
+	Modified    int                     `json:"modified"`
+	Unchanged   int                     `json:"unchanged"`
+	Entries     []LedgerDiffEntryReport `json:"entries"`
+}
+
+// ledgerChangeName maps an internal change kind to its JSON-friendly name.
+func ledgerChangeName(kind ledgerChangeKind) LedgerDiffChange {
+	switch kind {
+	case ledgerAdded:
+		return ChangeAdded
+	case ledgerRemoved:
+		return ChangeRemoved
+	case ledgerModified:
+		return ChangeModified
+	default:
+		return ChangeUnchanged
+	}
+}
+
+// BuildLedgerStateDiffReport computes a structured, JSON-serializable diff of two
+// ledger entry maps. Unchanged entries are included in Entries only when
+// includeUnchanged is true, mirroring the showUnchanged behavior of
+// RenderLedgerStateDiff; the summary counters always reflect the full diff.
+func BuildLedgerStateDiffReport(before, after map[string]string, includeUnchanged bool) LedgerStateDiffReport {
+	entries := DiffLedgerEntries(before, after)
+	added, removed, modified, unchanged := summarizeLedgerDiff(entries)
+
+	report := LedgerStateDiffReport{
+		BeforeCount: len(before),
+		AfterCount:  len(after),
+		Added:       added,
+		Removed:     removed,
+		Modified:    modified,
+		Unchanged:   unchanged,
+		Entries:     make([]LedgerDiffEntryReport, 0, len(entries)),
+	}
+
+	for _, e := range entries {
+		if e.ChangeKind == ledgerUnchanged && !includeUnchanged {
+			continue
+		}
+
+		item := LedgerDiffEntryReport{
+			Key:    e.Key,
+			Change: ledgerChangeName(e.ChangeKind),
+		}
+
+		// Populate before/after pointers based on the change kind so an absent
+		// side is encoded as JSON null rather than an empty string.
+		switch e.ChangeKind {
+		case ledgerAdded:
+			av := e.After
+			item.After = &av
+		case ledgerRemoved:
+			bv := e.Before
+			item.Before = &bv
+		default: // modified or unchanged: present on both sides
+			bv, av := e.Before, e.After
+			item.Before = &bv
+			item.After = &av
+		}
+
+		report.Entries = append(report.Entries, item)
+	}
+
+	return report
+}
+
+// MarshalLedgerStateDiffJSON returns the indented JSON encoding of the structured
+// ledger state diff between two ledger entry maps.
+func MarshalLedgerStateDiffJSON(before, after map[string]string, includeUnchanged bool) ([]byte, error) {
+	return json.MarshalIndent(BuildLedgerStateDiffReport(before, after, includeUnchanged), "", "  ")
+}
+
+// RenderLedgerStateDiffJSON writes the structured ledger state diff as indented
+// JSON (followed by a trailing newline) to w. It is the headless counterpart of
+// RenderLedgerStateDiff, intended for machine consumption rather than a terminal.
+func RenderLedgerStateDiffJSON(w io.Writer, before, after map[string]string, includeUnchanged bool) error {
+	data, err := MarshalLedgerStateDiffJSON(before, after, includeUnchanged)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(data); err != nil {
+		return err
+	}
+	_, err = io.WriteString(w, "\n")
+	return err
 }

--- a/internal/visualizer/simdiff_test.go
+++ b/internal/visualizer/simdiff_test.go
@@ -4,6 +4,9 @@
 package visualizer
 
 import (
+	"bytes"
+	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -93,6 +96,140 @@ func TestShortenLedgerKey(t *testing.T) {
 					tt.key, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestBuildLedgerStateDiffReport(t *testing.T) {
+	before := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3",
+	}
+	after := map[string]string{
+		"key1": "value1",     // unchanged
+		"key2": "value2_new", // modified
+		"key4": "value4",     // added
+		// key3 removed
+	}
+
+	report := BuildLedgerStateDiffReport(before, after, false)
+
+	if report.BeforeCount != 3 || report.AfterCount != 3 {
+		t.Errorf("counts: before=%d after=%d, want 3/3", report.BeforeCount, report.AfterCount)
+	}
+	if report.Added != 1 || report.Removed != 1 || report.Modified != 1 || report.Unchanged != 1 {
+		t.Errorf("summary: added=%d removed=%d modified=%d unchanged=%d, want 1/1/1/1",
+			report.Added, report.Removed, report.Modified, report.Unchanged)
+	}
+
+	// includeUnchanged=false drops the unchanged entry but keeps the counters.
+	if len(report.Entries) != 3 {
+		t.Fatalf("expected 3 entries with includeUnchanged=false, got %d", len(report.Entries))
+	}
+
+	byKey := make(map[string]LedgerDiffEntryReport, len(report.Entries))
+	for _, e := range report.Entries {
+		byKey[e.Key] = e
+	}
+
+	added, ok := byKey["key4"]
+	if !ok || added.Change != ChangeAdded {
+		t.Fatalf("key4 should be added, got %+v", added)
+	}
+	if added.Before != nil {
+		t.Errorf("added entry must have nil Before, got %q", *added.Before)
+	}
+	if added.After == nil || *added.After != "value4" {
+		t.Errorf("added entry After = %v, want value4", added.After)
+	}
+
+	removed, ok := byKey["key3"]
+	if !ok || removed.Change != ChangeRemoved {
+		t.Fatalf("key3 should be removed, got %+v", removed)
+	}
+	if removed.After != nil {
+		t.Errorf("removed entry must have nil After, got %q", *removed.After)
+	}
+	if removed.Before == nil || *removed.Before != "value3" {
+		t.Errorf("removed entry Before = %v, want value3", removed.Before)
+	}
+
+	modified, ok := byKey["key2"]
+	if !ok || modified.Change != ChangeModified {
+		t.Fatalf("key2 should be modified, got %+v", modified)
+	}
+	if modified.Before == nil || *modified.Before != "value2" || modified.After == nil || *modified.After != "value2_new" {
+		t.Errorf("modified entry = %+v, want before=value2 after=value2_new", modified)
+	}
+}
+
+func TestBuildLedgerStateDiffReportIncludeUnchanged(t *testing.T) {
+	before := map[string]string{"key1": "value1", "key2": "value2"}
+	after := map[string]string{"key1": "value1", "key2": "value2_new"}
+
+	report := BuildLedgerStateDiffReport(before, after, true)
+	if len(report.Entries) != 2 {
+		t.Fatalf("expected 2 entries with includeUnchanged=true, got %d", len(report.Entries))
+	}
+
+	var sawUnchanged bool
+	for _, e := range report.Entries {
+		if e.Change == ChangeUnchanged {
+			sawUnchanged = true
+			if e.Before == nil || e.After == nil || *e.Before != *e.After {
+				t.Errorf("unchanged entry should have equal before/after, got %+v", e)
+			}
+		}
+	}
+	if !sawUnchanged {
+		t.Error("expected an unchanged entry to be included")
+	}
+}
+
+func TestRenderLedgerStateDiffJSON(t *testing.T) {
+	before := map[string]string{"key1": "value1"}
+	after := map[string]string{"key1": "value1_new", "key2": "value2"}
+
+	var buf bytes.Buffer
+	if err := RenderLedgerStateDiffJSON(&buf, before, after, false); err != nil {
+		t.Fatalf("RenderLedgerStateDiffJSON returned error: %v", err)
+	}
+
+	// Output must be valid JSON deserializing back into the report shape.
+	var decoded LedgerStateDiffReport
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, buf.String())
+	}
+
+	if decoded.Added != 1 || decoded.Modified != 1 {
+		t.Errorf("decoded summary added=%d modified=%d, want 1/1", decoded.Added, decoded.Modified)
+	}
+	if len(decoded.Entries) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(decoded.Entries))
+	}
+
+	// The JSON must be free of ANSI escape codes (headless integration).
+	if strings.Contains(buf.String(), "\x1b[") {
+		t.Error("JSON output should not contain ANSI escape codes")
+	}
+}
+
+func TestRenderLedgerStateDiffToWritesToWriter(t *testing.T) {
+	before := map[string]string{"key1": "value1"}
+	after := map[string]string{"key1": "value1_changed"}
+
+	var buf bytes.Buffer
+	RenderLedgerStateDiffTo(&buf, before, after, false)
+
+	out := buf.String()
+	if out == "" {
+		t.Fatal("expected rendered output, got empty string")
+	}
+	if !strings.Contains(out, "LEDGER STATE DIFF") {
+		t.Errorf("rendered output missing header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Summary:") {
+		t.Errorf("rendered output missing summary, got:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #1559.

`RenderLedgerStateDiff` in `internal/visualizer/simdiff.go` wrote the diff straight to stdout using ANSI escape codes, so the ledger state diff could not be consumed programmatically. This separates the **formatting** from the **IO** and adds a structured, machine-readable JSON representation for headless integration.

## Changes

- **IO separation:** rendering logic now lives in `RenderLedgerStateDiffTo(w io.Writer, ...)`. `RenderLedgerStateDiff(...)` is a thin wrapper that targets `os.Stdout`, so existing terminal output is byte-for-byte unchanged. The `printLedgerDiffHeader` / `renderLedgerEntry` / `printLedgerDiffSummary` helpers take an `io.Writer`.
- **Structured JSON:**
  - `LedgerStateDiffReport` and `LedgerDiffEntryReport` value types with JSON tags. An absent before/after side is encoded as JSON `null` (distinguished from an empty string via the change kind).
  - `BuildLedgerStateDiffReport(before, after, includeUnchanged)` returns the structured object.
  - `MarshalLedgerStateDiffJSON(...)` returns indented JSON bytes.
  - `RenderLedgerStateDiffJSON(w io.Writer, ...)` writes the JSON to any writer.
- Shared change-kind counting factored into `summarizeLedgerDiff`.

The summary counters always reflect the full diff; `includeUnchanged` only controls whether unchanged entries appear in `entries` (mirroring `showUnchanged` in the terminal renderer).

## Tests

- `TestBuildLedgerStateDiffReport` — counts + per-entry before/after pointers for added/removed/modified.
- `TestBuildLedgerStateDiffReportIncludeUnchanged` — unchanged entries included only when requested.
- `TestRenderLedgerStateDiffJSON` — output is valid JSON that round-trips into the report and contains no ANSI escape codes.
- `TestRenderLedgerStateDiffToWritesToWriter` — terminal renderer writes to an arbitrary `io.Writer`.

### Verification
- `go build ./...` ✓ (existing caller in `internal/cmd/debug.go` compiles unchanged)
- `go test ./internal/visualizer/...` ✓
- `gofmt`/`go vet`/`staticcheck` clean on changed files ✓