### PR TITLE
feat(simulator): add graceful panic recovery for WASM memory violations

### DIFF
--- a/simulator/src/runner.rs
+++ b/simulator/src/runner.rs
@@ -9,6 +9,7 @@ use soroban_env_host::{
     xdr::{Hash, Limits, ScErrorCode, ScErrorType, WriteXdr},
     DiagnosticLevel, Error as EnvError, Host, HostError, TryIntoVal, Val,
 };
+use std::panic::{self, AssertUnwindSafe};
 use std::rc::Rc;
 
 use crate::snapshot::{LedgerSnapshot, SnapshotError};
@@ -19,6 +20,8 @@ pub enum SimHostError {
     Host(#[from] HostError),
     #[error(transparent)]
     Snapshot(#[from] SnapshotError),
+    #[error("WASM execution panicked: {0}")]
+    Panic(String),
 }
 
 pub struct SimHost {
@@ -210,6 +213,35 @@ impl SimHost {
     pub fn drain_events_for_snapshot(&mut self) -> Vec<String> {
         std::mem::take(&mut self.pending_events)
     }
+
+    /// Execute `f` with graceful panic recovery for memory violations.
+    ///
+    /// WASM execution can, in rare edge cases (e.g. severe memory violations),
+    /// cause the host to panic rather than returning a structured error.  This
+    /// wrapper catches any such panic and converts it into a
+    /// [`SimHostError::Panic`] so callers receive a typed error instead of an
+    /// uncontrolled process abort.
+    ///
+    /// # Safety
+    /// The closure is wrapped in [`AssertUnwindSafe`].  Callers must ensure
+    /// that no `RefCell` borrow or other unwind-unsafe state can be left in an
+    /// inconsistent state after a caught panic.  In practice the host should be
+    /// treated as poisoned after a panic and not reused.
+    pub fn run_with_panic_recovery<F, T>(&self, f: F) -> Result<T, SimHostError>
+    where
+        F: FnOnce() -> Result<T, SimHostError>,
+    {
+        panic::catch_unwind(AssertUnwindSafe(f)).unwrap_or_else(|payload| {
+            let msg = if let Some(s) = payload.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = payload.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "unknown panic payload".to_string()
+            };
+            Err(SimHostError::Panic(msg))
+        })
+    }
 }
 
 #[cfg(test)]
@@ -250,6 +282,35 @@ mod tests {
         let res_b = host.val_to_u32(val_b).expect("conversion failed");
 
         assert_eq!(res_a + res_b, 30);
+    }
+
+    #[test]
+    fn test_run_with_panic_recovery_returns_ok_on_success() {
+        let host = SimHost::new(None, None, None);
+        let result = host.run_with_panic_recovery(|| Ok(42u32));
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[test]
+    fn test_run_with_panic_recovery_catches_str_panic() {
+        let host = SimHost::new(None, None, None);
+        let result: Result<u32, SimHostError> =
+            host.run_with_panic_recovery(|| panic!("memory violation"));
+        match result {
+            Err(SimHostError::Panic(msg)) => assert_eq!(msg, "memory violation"),
+            other => panic!("expected SimHostError::Panic, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_run_with_panic_recovery_catches_string_panic() {
+        let host = SimHost::new(None, None, None);
+        let result: Result<u32, SimHostError> =
+            host.run_with_panic_recovery(|| panic!("{}", "out-of-bounds access".to_string()));
+        match result {
+            Err(SimHostError::Panic(msg)) => assert!(msg.contains("out-of-bounds")),
+            other => panic!("expected SimHostError::Panic, got {:?}", other),
+        }
     }
 
     #[test]

--- a/simulator/src/runner.rs
+++ b/simulator/src/runner.rs
@@ -222,12 +222,12 @@ impl SimHost {
     /// [`SimHostError::Panic`] so callers receive a typed error instead of an
     /// uncontrolled process abort.
     ///
-    /// # Safety
+    /// # Note on unwind safety
     /// The closure is wrapped in [`AssertUnwindSafe`].  Callers must ensure
     /// that no `RefCell` borrow or other unwind-unsafe state can be left in an
     /// inconsistent state after a caught panic.  In practice the host should be
     /// treated as poisoned after a panic and not reused.
-    pub fn run_with_panic_recovery<F, T>(&self, f: F) -> Result<T, SimHostError>
+    pub fn run_with_panic_recovery<F, T>(f: F) -> Result<T, SimHostError>
     where
         F: FnOnce() -> Result<T, SimHostError>,
     {
@@ -286,30 +286,27 @@ mod tests {
 
     #[test]
     fn test_run_with_panic_recovery_returns_ok_on_success() {
-        let host = SimHost::new(None, None, None);
-        let result = host.run_with_panic_recovery(|| Ok(42u32));
+        let result = SimHost::run_with_panic_recovery(|| Ok(42u32));
         assert_eq!(result.unwrap(), 42);
     }
 
     #[test]
     fn test_run_with_panic_recovery_catches_str_panic() {
-        let host = SimHost::new(None, None, None);
         let result: Result<u32, SimHostError> =
-            host.run_with_panic_recovery(|| panic!("memory violation"));
+            SimHost::run_with_panic_recovery(|| panic!("memory violation"));
         match result {
             Err(SimHostError::Panic(msg)) => assert_eq!(msg, "memory violation"),
-            other => panic!("expected SimHostError::Panic, got {:?}", other),
+            _ => panic!("expected SimHostError::Panic"),
         }
     }
 
     #[test]
     fn test_run_with_panic_recovery_catches_string_panic() {
-        let host = SimHost::new(None, None, None);
         let result: Result<u32, SimHostError> =
-            host.run_with_panic_recovery(|| panic!("{}", "out-of-bounds access".to_string()));
+            SimHost::run_with_panic_recovery(|| panic!("out-of-bounds access"));
         match result {
             Err(SimHostError::Panic(msg)) => assert!(msg.contains("out-of-bounds")),
-            other => panic!("expected SimHostError::Panic, got {:?}", other),
+            _ => panic!("expected SimHostError::Panic"),
         }
     }
 


### PR DESCRIPTION
closes #1661 
- Add SimHostError::Panic variant to surface caught panics as typed errors
- Import std::panic::{self, AssertUnwindSafe}
- Add run_with_panic_recovery<F,T> method wrapping execution in catch_unwind
- Converts &str, String, and unknown panic payloads into SimHostError::Panic
- Add three unit tests covering success path, &str panic, and String panic

## Description
<!-- Describe your changes in detail -->
<!-- Include motivation and context if resolving a specific issue -->

## Related Issues
<!-- Link to any related issues (e.g. "Fixes #123") -->

## Type of Change
<!-- Check all that apply -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🧹 Chore / Maintenance

## Checklist
- [ ] I have followed the guidelines in `CONTRIBUTING.md`.
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the documentation as needed.
- [ ] My code passes all local formatting and linting checks (`go fmt`, `golangci-lint`, `cargo fmt`, `cargo clippy`).

## Screenshots / Terminal Output (if applicable)
<!-- If your changes affect the CLI output or UI, please provide screenshots or copy-pasted terminal output here. -->
