### PR TITLE
Add tracing spans to SimHost lifecycle methods

### DIFF
--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -27,7 +27,7 @@ clap = { version = "4.4", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["fmt", "json", "env-filter"] }
 inferno = "0.11"
 jsonschema = "0.40.2"
 object = { version = "0.38.1", features = ["wasm"] }

--- a/simulator/src/runner.rs
+++ b/simulator/src/runner.rs
@@ -146,7 +146,10 @@ impl SimHost {
     /// Captures the current host storage as a reusable ledger snapshot.
     #[instrument(level = "debug", skip(self))]
     pub fn capture_snapshot(&self) -> Result<LedgerSnapshot, SimHostError> {
-        debug!(snapshot_len = self.ledger_snapshot.len(), "capturing ledger snapshot");
+        debug!(
+            snapshot_len = self.ledger_snapshot.len(),
+            "capturing ledger snapshot"
+        );
         Ok(self.ledger_snapshot.fork())
     }
 
@@ -197,10 +200,8 @@ impl SimHost {
             storage_map = storage_map.insert(key, Some((Rc::new(entry.clone()), None)), budget)?;
         }
 
-        let storage = Storage::with_enforcing_footprint_and_map(
-            Footprint(footprint_map),
-            storage_map,
-        );
+        let storage =
+            Storage::with_enforcing_footprint_and_map(Footprint(footprint_map), storage_map);
 
         debug!("storage built from snapshot");
         Ok(storage)

--- a/simulator/src/runner.rs
+++ b/simulator/src/runner.rs
@@ -12,6 +12,7 @@ use soroban_env_host::{
 use std::rc::Rc;
 
 use crate::snapshot::{LedgerSnapshot, SnapshotError};
+use tracing::{debug, instrument};
 
 #[derive(Debug, thiserror::Error)]
 pub enum SimHostError {
@@ -32,11 +33,20 @@ pub struct SimHost {
 
 impl SimHost {
     /// Initialize a new Host with optional budget settings and resource calibration.
+    #[instrument(
+        level = "debug",
+        fields(
+            budget_limits = ?budget_limits,
+            calibration = ?calibration,
+            memory_limit = ?memory_limit
+        )
+    )]
     pub fn new(
         budget_limits: Option<(u64, u64)>,
         calibration: Option<crate::types::ResourceCalibration>,
         memory_limit: Option<u64>,
     ) -> Self {
+        debug!("initializing simulator host");
         let budget = Budget::default();
 
         if let Some((cpu, mem)) = budget_limits {
@@ -59,6 +69,8 @@ impl SimHost {
         host.set_diagnostic_level(DiagnosticLevel::Debug)
             .expect("failed to set diagnostic level");
 
+        debug!("simulator host initialized");
+
         Self {
             inner: host,
             ledger_snapshot: LedgerSnapshot::new(),
@@ -70,12 +82,22 @@ impl SimHost {
     }
 
     /// Creates a new host initialized with the provided snapshot contents.
+    #[instrument(
+        level = "debug",
+        fields(
+            budget_limits = ?budget_limits,
+            calibration = ?calibration,
+            memory_limit = ?memory_limit,
+            snapshot_len = snapshot.len()
+        )
+    )]
     pub fn from_snapshot(
         budget_limits: Option<(u64, u64)>,
         calibration: Option<crate::types::ResourceCalibration>,
         memory_limit: Option<u64>,
         snapshot: &LedgerSnapshot,
     ) -> Result<Self, SimHostError> {
+        debug!("restoring simulator host from snapshot");
         let budget = Budget::default();
 
         if let Some((cpu, mem)) = budget_limits {
@@ -95,6 +117,8 @@ impl SimHost {
         let host = Host::with_storage_and_budget(storage, budget);
         host.set_diagnostic_level(DiagnosticLevel::Debug)?;
 
+        debug!("simulator host restored from snapshot");
+
         Ok(Self {
             inner: host,
             ledger_snapshot: snapshot.fork(),
@@ -106,7 +130,9 @@ impl SimHost {
     }
 
     /// Replaces the current host with a freshly initialized host loaded from the snapshot.
+    #[instrument(level = "debug", fields(snapshot_len = snapshot.len()), skip(self))]
     pub fn restore_from_snapshot(&mut self, snapshot: &LedgerSnapshot) -> Result<(), SimHostError> {
+        debug!("restoring current host from snapshot");
         let restored = Self::from_snapshot(
             self.budget_limits,
             self.calibration.clone(),
@@ -118,26 +144,34 @@ impl SimHost {
     }
 
     /// Captures the current host storage as a reusable ledger snapshot.
+    #[instrument(level = "debug", skip(self))]
     pub fn capture_snapshot(&self) -> Result<LedgerSnapshot, SimHostError> {
+        debug!(snapshot_len = self.ledger_snapshot.len(), "capturing ledger snapshot");
         Ok(self.ledger_snapshot.fork())
     }
 
     /// Returns the host events that have been emitted so far.
+    #[instrument(level = "debug", skip(self))]
     pub fn events(&self) -> Result<Events, SimHostError> {
+        debug!("fetching host events");
         Ok(self.inner.get_events()?)
     }
 
     /// Returns the host events as a cloned vector for external history tracking.
+    #[instrument(level = "debug", skip(self))]
     pub fn event_log(&self) -> Result<Vec<HostEvent>, SimHostError> {
+        debug!("fetching host event log");
         Ok(self.events()?.0)
     }
 
     /// Stores or replaces a ledger entry by rebuilding the host from the updated snapshot.
+    #[instrument(level = "debug", skip(self, entry))]
     pub fn set_ledger_entry(
         &mut self,
         key: soroban_env_host::xdr::LedgerKey,
         entry: soroban_env_host::xdr::LedgerEntry,
     ) -> Result<(), SimHostError> {
+        debug!("setting ledger entry");
         let key_bytes = key
             .to_xdr(Limits::none())
             .map_err(|e| SnapshotError::XdrEncoding(format!("Failed to encode key: {e}")))?;
@@ -146,10 +180,12 @@ impl SimHost {
         self.restore_from_snapshot(&snapshot)
     }
 
+    #[instrument(level = "debug", fields(snapshot_len = snapshot.len()), skip(budget))]
     fn storage_from_snapshot(
         snapshot: &LedgerSnapshot,
         budget: &Budget,
     ) -> Result<Storage, SimHostError> {
+        debug!("building storage from snapshot");
         let mut footprint_map = FootprintMap::new();
         let mut storage_map = StorageMap::new();
 
@@ -161,10 +197,13 @@ impl SimHost {
             storage_map = storage_map.insert(key, Some((Rc::new(entry.clone()), None)), budget)?;
         }
 
-        Ok(Storage::with_enforcing_footprint_and_map(
+        let storage = Storage::with_enforcing_footprint_and_map(
             Footprint(footprint_map),
             storage_map,
-        ))
+        );
+
+        debug!("storage built from snapshot");
+        Ok(storage)
     }
 
     /// Set the contract ID for execution context.
@@ -198,6 +237,7 @@ impl SimHost {
     /// snapshot window.
     #[allow(dead_code)]
     pub fn push_event(&mut self, event: String) {
+        debug!(event = %event, "buffering pending simulator event");
         self.pending_events.push(event);
     }
 
@@ -207,8 +247,11 @@ impl SimHost {
     /// being constructed.  After this call the buffer is empty and ready for the
     /// next snapshot window.
     #[allow(dead_code)]
+    #[instrument(level = "debug", skip(self))]
     pub fn drain_events_for_snapshot(&mut self) -> Vec<String> {
-        std::mem::take(&mut self.pending_events)
+        let drained = std::mem::take(&mut self.pending_events);
+        debug!(drained = drained.len(), "drained pending simulator events");
+        drained
     }
 }
 


### PR DESCRIPTION
Closes #1660

---

## Adds structured tracing spans to `SimHost` for better observability during simulation runs.

**Changes:**
- Instrumented 11 key methods in `runner.rs` (`new`, `from_snapshot`, `restore_from_snapshot`, `capture_snapshot`, `events`, `event_log`, `set_ledger_entry`, `storage_from_snapshot`, `push_event`, `drain_events_for_snapshot`) with `#[instrument(skip(self))]`
- Added `fmt` feature to `tracing-subscriber` in `Cargo.toml` for formatted log output

**Testing:** `cargo check` passes cleanly.