### PR TITLE
refactor: extract Host configuration into HostConfig builder struct (#1655)

### DIFF
--- a/simulator/src/context.rs
+++ b/simulator/src/context.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use soroban_env_host::events::HostEvent;
 use soroban_env_host::xdr::{LedgerEntry, LedgerKey};
 
-use crate::runner::{SimHost, SimHostError};
+use crate::runner::{HostConfig, SimHost, SimHostError};
 use crate::snapshot::LedgerSnapshot;
 use crate::types::SimulationRequest;
 
@@ -213,7 +213,7 @@ mod tests {
 
     #[test]
     fn rollback_to_restores_exact_snapshot_and_truncates_future_events() {
-        let host = SimHost::new(None, None, None);
+        let host = SimHost::new(HostConfig::new());
         let mut context = SimulationContext::new(host);
 
         let first_key = contract_data_key(7, 1);

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -507,11 +507,11 @@ fn main() {
     };
 
     // Initialize Host
-    let mut sim_host = runner::SimHost::new(
-        None,
-        request.resource_calibration.clone(),
-        request.memory_limit,
-    );
+    let mut sim_host = runner::SimHost::new(runner::HostConfig {
+        calibration: request.resource_calibration.clone(),
+        memory_limit: request.memory_limit,
+        ..Default::default()
+    });
 
     // --- START: Local WASM Loading Integration (Issue #70) ---
     if let Some(path) = &request.wasm_path {
@@ -1479,7 +1479,7 @@ mod tests {
             STANDARD.encode(entry.to_xdr(soroban_env_host::xdr::Limits::none()).unwrap()),
         );
 
-        let mut sim_host = runner::SimHost::new(None, None, None);
+        let mut sim_host = runner::SimHost::new(runner::HostConfig::new());
         let count = load_ledger_entries(&mut sim_host, &entries).expect("failed to load entries");
         assert_eq!(count, 1);
     }

--- a/simulator/src/main_test.rs
+++ b/simulator/src/main_test.rs
@@ -68,7 +68,7 @@ mod restore_preamble_tests {
             include_linear_memory: false,
         };
         // Simulate main logic: inject restore_preamble into host storage
-        let sim_host = crate::runner::SimHost::new(None, None, None);
+        let sim_host = crate::runner::SimHost::new(crate::runner::HostConfig::new());
         let host = sim_host.inner;
         if let Some(ref preamble) = req.restore_preamble {
             if let Some(obj) = preamble.as_object() {

--- a/simulator/src/memory_limit_test.rs
+++ b/simulator/src/memory_limit_test.rs
@@ -5,7 +5,7 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::runner::SimHost;
+    use crate::runner::{HostConfig, SimHost};
     use crate::types::ResourceCalibration;
     use std::panic;
 
@@ -13,7 +13,10 @@ mod tests {
     fn test_memory_limit_field() {
         // Test that SimHost can be created with a memory limit
         let memory_limit = Some(1000000); // 1MB limit
-        let host = SimHost::new(None, None, memory_limit);
+        let host = SimHost::new(HostConfig {
+            memory_limit,
+            ..Default::default()
+        });
 
         assert_eq!(host.memory_limit, memory_limit);
     }
@@ -21,7 +24,7 @@ mod tests {
     #[test]
     fn test_no_memory_limit() {
         // Test that SimHost can be created without memory limit
-        let host = SimHost::new(None, None, None);
+        let host = SimHost::new(HostConfig::new());
 
         assert_eq!(host.memory_limit, None);
     }
@@ -30,7 +33,10 @@ mod tests {
     fn test_memory_limit_check_no_panic() {
         // Test memory limit checking functionality when within limits
         let memory_limit = Some(1000); // Very small limit
-        let host = SimHost::new(None, None, memory_limit);
+        let host = SimHost::new(HostConfig {
+            memory_limit,
+            ..Default::default()
+        });
 
         // This should not panic as we haven't executed any operations yet
         host.check_memory_limit();
@@ -41,7 +47,10 @@ mod tests {
         // Use catch_unwind to ensure panics from check_memory_limit do not
         // abort the entire test process.
         let memory_limit = Some(100);
-        let host = SimHost::new(None, None, memory_limit);
+        let host = SimHost::new(HostConfig {
+            memory_limit,
+            ..Default::default()
+        });
 
         let result = panic::catch_unwind(|| {
             host.check_memory_limit();

--- a/simulator/src/runner.rs
+++ b/simulator/src/runner.rs
@@ -21,6 +21,43 @@ pub enum SimHostError {
     Snapshot(#[from] SnapshotError),
 }
 
+pub struct HostConfig {
+    pub budget_limits: Option<(u64, u64)>,
+    pub calibration: Option<crate::types::ResourceCalibration>,
+    pub memory_limit: Option<u64>,
+}
+
+impl Default for HostConfig {
+    fn default() -> Self {
+        Self {
+            budget_limits: None,
+            calibration: None,
+            memory_limit: None,
+        }
+    }
+}
+
+impl HostConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn budget_limits(mut self, limits: (u64, u64)) -> Self {
+        self.budget_limits = Some(limits);
+        self
+    }
+
+    pub fn calibration(mut self, calibration: crate::types::ResourceCalibration) -> Self {
+        self.calibration = Some(calibration);
+        self
+    }
+
+    pub fn memory_limit(mut self, limit: u64) -> Self {
+        self.memory_limit = Some(limit);
+        self
+    }
+}
+
 pub struct SimHost {
     pub inner: Host,
     ledger_snapshot: LedgerSnapshot,
@@ -32,28 +69,9 @@ pub struct SimHost {
 
 impl SimHost {
     /// Initialize a new Host with optional budget settings and resource calibration.
-    pub fn new(
-        budget_limits: Option<(u64, u64)>,
-        calibration: Option<crate::types::ResourceCalibration>,
-        memory_limit: Option<u64>,
-    ) -> Self {
-        let budget = Budget::default();
+    pub fn new(config: HostConfig) -> Self {
+        let budget = Self::build_budget(&config);
 
-        if let Some((cpu, mem)) = budget_limits {
-            let _ = budget.reset_limits(cpu, mem);
-        } else if let Some(mem) = memory_limit {
-            // soroban sdk uses u32::MAX for no limit but casted to u64, or u64::MAX.
-            let _ = budget.reset_unlimited();
-            let _ = budget.reset_limits(
-                budget
-                    .get_cpu_insns_consumed()
-                    .unwrap_or(0)
-                    .saturating_add(u32::MAX as u64),
-                mem,
-            );
-        }
-
-        // Host::with_storage_and_budget is available in recent versions
         let host = Host::with_storage_and_budget(Storage::default(), budget);
 
         host.set_diagnostic_level(DiagnosticLevel::Debug)
@@ -62,25 +80,40 @@ impl SimHost {
         Self {
             inner: host,
             ledger_snapshot: LedgerSnapshot::new(),
-            budget_limits,
-            calibration,
-            memory_limit,
+            budget_limits: config.budget_limits,
+            calibration: config.calibration,
+            memory_limit: config.memory_limit,
             pending_events: Vec::new(),
         }
     }
 
     /// Creates a new host initialized with the provided snapshot contents.
     pub fn from_snapshot(
-        budget_limits: Option<(u64, u64)>,
-        calibration: Option<crate::types::ResourceCalibration>,
-        memory_limit: Option<u64>,
+        config: HostConfig,
         snapshot: &LedgerSnapshot,
     ) -> Result<Self, SimHostError> {
+        let budget = Self::build_budget(&config);
+
+        let storage = Self::storage_from_snapshot(snapshot, &budget)?;
+        let host = Host::with_storage_and_budget(storage, budget);
+        host.set_diagnostic_level(DiagnosticLevel::Debug)?;
+
+        Ok(Self {
+            inner: host,
+            ledger_snapshot: snapshot.fork(),
+            budget_limits: config.budget_limits,
+            calibration: config.calibration,
+            memory_limit: config.memory_limit,
+            pending_events: Vec::new(),
+        })
+    }
+
+    fn build_budget(config: &HostConfig) -> Budget {
         let budget = Budget::default();
 
-        if let Some((cpu, mem)) = budget_limits {
+        if let Some((cpu, mem)) = config.budget_limits {
             let _ = budget.reset_limits(cpu, mem);
-        } else if let Some(mem) = memory_limit {
+        } else if let Some(mem) = config.memory_limit {
             let _ = budget.reset_unlimited();
             let _ = budget.reset_limits(
                 budget
@@ -91,28 +124,17 @@ impl SimHost {
             );
         }
 
-        let storage = Self::storage_from_snapshot(snapshot, &budget)?;
-        let host = Host::with_storage_and_budget(storage, budget);
-        host.set_diagnostic_level(DiagnosticLevel::Debug)?;
-
-        Ok(Self {
-            inner: host,
-            ledger_snapshot: snapshot.fork(),
-            budget_limits,
-            calibration,
-            memory_limit,
-            pending_events: Vec::new(),
-        })
+        budget
     }
 
     /// Replaces the current host with a freshly initialized host loaded from the snapshot.
     pub fn restore_from_snapshot(&mut self, snapshot: &LedgerSnapshot) -> Result<(), SimHostError> {
-        let restored = Self::from_snapshot(
-            self.budget_limits,
-            self.calibration.clone(),
-            self.memory_limit,
-            snapshot,
-        )?;
+        let config = HostConfig {
+            budget_limits: self.budget_limits,
+            calibration: self.calibration.clone(),
+            memory_limit: self.memory_limit,
+        };
+        let restored = Self::from_snapshot(config, snapshot)?;
         *self = restored;
         Ok(())
     }
@@ -223,14 +245,14 @@ mod tests {
 
     #[test]
     fn test_host_initialization() {
-        let host = SimHost::new(None, None, None);
+        let host = SimHost::new(HostConfig::new());
         // Basic assertion that host is functional
         assert!(host.inner.budget_cloned().get_cpu_insns_consumed().is_ok());
     }
 
     #[test]
     fn test_configuration() {
-        let mut host = SimHost::new(None, None, None);
+        let mut host = SimHost::new(HostConfig::new());
         // Test setting contract ID (dummy hash)
         let hash = Hash([0u8; 32]);
         host.set_contract_id(hash);
@@ -241,7 +263,7 @@ mod tests {
 
     #[test]
     fn test_simple_value_handling() {
-        let host = SimHost::new(None, None, None);
+        let host = SimHost::new(HostConfig::new());
 
         let val_a = host.val_from_u32(10);
         let val_b = host.val_from_u32(20);
@@ -254,7 +276,7 @@ mod tests {
 
     #[test]
     fn test_restore_from_snapshot_replaces_mutated_storage_and_clears_host_events() {
-        let mut host = SimHost::new(None, None, None);
+        let mut host = SimHost::new(HostConfig::new());
         let first_key = Rc::new(LedgerKey::ContractData(LedgerKeyContractData {
             contract: ScAddress::Contract(ContractId(Hash([1u8; 32]))),
             key: ScVal::U32(1),

--- a/simulator/src/simulator_safety_test.rs
+++ b/simulator/src/simulator_safety_test.rs
@@ -279,7 +279,7 @@ fn main() {
     };
 
     // Initialize Host
-    let sim_host = runner::SimHost::new(None);
+    let sim_host = runner::SimHost::new(runner::HostConfig::new());
     let host = sim_host.inner;
 
     let mut loaded_entries_count = 0;


### PR DESCRIPTION
Closes #1655

## Summary

Extract the optional parameters of `SimHost::new` and `SimHost::from_snapshot` into a `HostConfig` builder struct.

## Changes

- Introduced `HostConfig` struct with `Default` impl and builder methods (`budget_limits`, `calibration`, `memory_limit`)
- Refactored `SimHost::new` and `SimHost::from_snapshot` to accept `HostConfig` instead of individual `Option` parameters
- Extracted duplicated budget initialization logic into a private `build_budget` helper
- Updated all callers across `main.rs`, `context.rs`, and test files to use the new `HostConfig`