### PR TITLE
feat: add libFuzzer target job to CI workflow and include metering mo…

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -52,3 +52,49 @@ jobs:
       - name: Reclaim runner temp space after fuzz build
         if: always()
         run: bash ./scripts/ci-clean-build-space.sh
+
+  libfuzzer_target:
+    name: Build and Smoke-Test libFuzzer Target
+    runs-on: ubuntu-latest
+    # A job whose purpose is catching hangs should not be able to hang itself.
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # cargo-fuzz needs nightly for -Zsanitizer=address.
+      - name: Install Rust Nightly Toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cache Cargo dependencies and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin
+            simulator/fuzz/target
+          key: ${{ runner.os }}-cargo-fuzz-${{ hashFiles('simulator/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-fuzz-
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      - name: Reclaim runner temp space before fuzz build
+        run: bash ./scripts/ci-clean-build-space.sh
+
+      - name: Build the simulate target
+        working-directory: ./simulator
+        run: cargo fuzz build simulate
+
+      # The harness caps each run at 2 s of wall clock and 256 MiB of live heap,
+      # so libFuzzer's own -timeout is only a backstop. A campaign that hangs
+      # here means the in-harness ceilings regressed.
+      - name: Smoke-test the CPU and memory ceilings
+        working-directory: ./simulator
+        run: cargo fuzz run simulate -- -runs=2000 -timeout=10 -rss_limit_mb=1024
+
+      - name: Reclaim runner temp space after fuzz build
+        if: always()
+        run: bash ./scripts/ci-clean-build-space.sh

--- a/simulator/fuzz/.gitignore
+++ b/simulator/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target
+corpus
+artifacts
+coverage
+Cargo.lock

--- a/simulator/fuzz/Cargo.toml
+++ b/simulator/fuzz/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "erst-sim-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+# Must track the range in ../Cargo.toml so both crates resolve one host version.
+soroban-env-host = { version = ">=21.0, <26", features = ["testutils"] }
+
+[dependencies.erst-sim]
+path = ".."
+
+# Keep this crate out of any parent workspace: it only builds on nightly.
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "simulate"
+path = "fuzz_targets/simulate.rs"
+test = false
+doc = false
+bench = false

--- a/simulator/fuzz/fuzz_targets/simulate.rs
+++ b/simulator/fuzz/fuzz_targets/simulate.rs
@@ -1,0 +1,156 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+//! Fuzz target for the simulator's untrusted-input paths.
+//!
+//! Everything reached from here is reachable from a transaction envelope or a
+//! ledger snapshot that a caller hands the simulator, which is precisely the
+//! surface an attacker controls.
+//!
+//! # Why this target used to hang
+//!
+//! `Host::invoke_function` runs Wasm the input chose, and a contract that loops
+//! forever gives libFuzzer nothing to report: it simply waits. The default
+//! `-timeout` is 1200 seconds and `-rss_limit_mb` only reacts once the memory is
+//! already gone, so one bad input could stall a campaign for twenty minutes and
+//! then die without a useful reproducer. A run that spins inside native decoding
+//! code was worse still, because the Soroban budget is never charged for it.
+//!
+//! Four ceilings from `erst_sim::metering` now make that impossible:
+//!
+//! - A Soroban budget with an explicit CPU instruction cap, so a metered loop
+//!   traps in milliseconds instead of running to the network's full allowance.
+//! - A cooperative [`RunGuard`] deadline, checked between operations, so the
+//!   harness abandons a slow run under its own control.
+//! - A watchdog thread that aborts the process when a run outlives its
+//!   wall-clock budget, which converts a hang into a crash with a saved input.
+//! - A tracking global allocator that fails allocations past a heap ceiling,
+//!   so an oversized length field cannot push the machine into swap.
+//!
+//! Together they mean every input either finishes or fails; none of them can
+//! wait forever.
+
+#![no_main]
+
+use erst_sim::metering::{check_budget, install_fuzz_limits};
+use erst_sim::metering::{MeteringLimits, RunGuard, TrackingAllocator};
+use erst_sim::runner::SimHost;
+use erst_sim::snapshot::{decode_ledger_entry, decode_ledger_key, LedgerSnapshot};
+use libfuzzer_sys::fuzz_target;
+use soroban_env_host::xdr::{FeeBumpTransactionInnerTx, Limits, Operation};
+use soroban_env_host::xdr::{OperationBody, ReadXdr, TransactionEnvelope};
+use std::alloc::System;
+
+/// Every allocation in this process is accounted for, so a run that tries to
+/// allocate its way past the CPU ceiling fails fast instead of swapping.
+#[global_allocator]
+static ALLOC: TrackingAllocator<System> =
+    TrackingAllocator::new(System, MeteringLimits::FUZZ_HEAP_BYTES);
+
+/// Recursion depth allowed when decoding fuzzer-controlled XDR.
+///
+/// `Limits::none()` would let a depth bomb exhaust the stack, which aborts the
+/// process without telling us anything about the simulator.
+const XDR_DEPTH_LIMIT: u32 = 64;
+
+fuzz_target!(|data: &[u8]| {
+    let limits = MeteringLimits::fuzzing();
+    if data.len() > limits.max_input_bytes {
+        return;
+    }
+
+    // Applies the CPU rlimit and starts the watchdog thread on the first run.
+    let watchdog = install_fuzz_limits();
+    let guard = watchdog.arm(limits.wall_clock);
+
+    drive(data, &limits, &guard);
+});
+
+/// Picks an entry point from the first input byte and spends the rest on it.
+fn drive(data: &[u8], limits: &MeteringLimits, guard: &RunGuard<'_>) {
+    let Some((&selector, payload)) = data.split_first() else {
+        return;
+    };
+
+    match selector % 3 {
+        0 => invoke_envelope(payload, limits, guard),
+        1 => round_trip_snapshot(payload, guard),
+        _ => decode_base64_entry(payload, guard),
+    }
+}
+
+/// Decodes a transaction envelope and invokes every host function in it.
+///
+/// This is the path that hangs without metering: the input chooses the Wasm and
+/// the Wasm chooses how long to run.
+fn invoke_envelope(payload: &[u8], limits: &MeteringLimits, guard: &RunGuard<'_>) {
+    let Ok(envelope) = TransactionEnvelope::from_xdr(payload, decode_limits(payload)) else {
+        return;
+    };
+
+    let host = SimHost::new(Some(limits.budget_limits()), None, Some(limits.mem_bytes));
+
+    for operation in operations(&envelope) {
+        if guard.check().is_err() {
+            return;
+        }
+
+        let budget = host.inner.budget_cloned();
+        if check_budget(&budget, limits).is_err() {
+            // A ceiling is already gone; the next call would only trap.
+            return;
+        }
+
+        if let OperationBody::InvokeHostFunction(invoke) = &operation.body {
+            // Errors are the expected outcome for fuzzed input, including the
+            // budget trap that a non-terminating contract earns itself.
+            let _ = host.inner.invoke_function(invoke.host_function.clone());
+        }
+    }
+}
+
+/// Decodes a binary ledger snapshot and re-encodes what came back.
+fn round_trip_snapshot(payload: &[u8], guard: &RunGuard<'_>) {
+    if guard.check().is_err() {
+        return;
+    }
+
+    if let Ok(snapshot) = LedgerSnapshot::from_bytes(payload) {
+        let _ = snapshot.to_bytes();
+    }
+}
+
+/// Feeds the payload to the base64 plus XDR decoders the IPC bridge uses.
+fn decode_base64_entry(payload: &[u8], guard: &RunGuard<'_>) {
+    if guard.check().is_err() {
+        return;
+    }
+
+    let Ok(encoded) = std::str::from_utf8(payload) else {
+        return;
+    };
+
+    let _ = decode_ledger_key(encoded);
+    let _ = decode_ledger_entry(encoded);
+}
+
+/// Decode bounds for one payload: never deeper than the stack tolerates, and
+/// never longer than the payload itself, so a forged length field cannot drive
+/// an allocation the input did not pay for.
+fn decode_limits(payload: &[u8]) -> Limits {
+    Limits {
+        depth: XDR_DEPTH_LIMIT,
+        len: payload.len(),
+    }
+}
+
+/// The operations carried by any envelope flavour.
+fn operations(envelope: &TransactionEnvelope) -> &[Operation] {
+    match envelope {
+        TransactionEnvelope::Tx(v1) => v1.tx.operations.as_slice(),
+        TransactionEnvelope::TxV0(v0) => v0.tx.operations.as_slice(),
+        TransactionEnvelope::TxFeeBump(bump) => match &bump.tx.inner_tx {
+            FeeBumpTransactionInnerTx::Tx(v1) => v1.tx.operations.as_slice(),
+        },
+    }
+}

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -9,6 +9,7 @@ pub mod gas_optimizer;
 pub mod git_detector;
 pub mod hsm;
 pub mod ipc;
+pub mod metering;
 pub mod runner;
 pub mod snapshot;
 pub mod source_map_cache;

--- a/simulator/src/metering.rs
+++ b/simulator/src/metering.rs
@@ -1,0 +1,689 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+//! Hard CPU, memory and wall-clock ceilings for a single simulation run.
+//!
+//! The Soroban budget meters every Wasm instruction, so a contract that loops
+//! forever eventually traps with a budget error. That is not enough for a fuzz
+//! harness. A run can also spin inside *native* simulator code — a decoder that
+//! never converges on malformed input, a retry loop that never gives up — where
+//! the budget is never charged and nothing forces the run to end. libFuzzer will
+//! wait for it indefinitely.
+//!
+//! This module supplies the ceilings that close that gap, cheapest first:
+//!
+//! 1. [`MeteringLimits::budget`] builds a Soroban [`Budget`] with explicit CPU
+//!    instruction and memory byte caps, so metered work traps early.
+//! 2. [`Deadline`] is a cooperative wall-clock check for loops the caller drives
+//!    itself.
+//! 3. [`Watchdog`] runs on its own thread and aborts the process when a run
+//!    outlives its wall-clock budget. This is what turns a hang into a reported
+//!    failure with a saved reproducer.
+//! 4. [`TrackingAllocator`] caps the live heap, and [`install_cpu_rlimit`] gives
+//!    the kernel the last word on CPU time.
+//!
+//! Memory is deliberately *not* capped with `RLIMIT_AS`; see
+//! [`install_cpu_rlimit`] for why.
+
+use soroban_env_host::{budget::Budget, HostError};
+use std::alloc::{GlobalAlloc, Layout};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// How often the watchdog thread compares the clock against the deadline of the
+/// run in flight.
+pub const WATCHDOG_POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+/// Deadline value meaning "no run is in flight".
+const DISARMED: u64 = 0;
+
+/// The ceilings applied to a single simulation run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MeteringLimits {
+    /// Soroban CPU instruction cap. Metered Wasm traps once it is reached, which
+    /// is what stops a contract-level infinite loop.
+    pub cpu_insns: u64,
+    /// Soroban memory cap, in bytes, for host-side allocations.
+    pub mem_bytes: u64,
+    /// Wall-clock budget for one run, enforced cooperatively by [`Deadline`] and
+    /// forcibly by [`Watchdog`].
+    pub wall_clock: Duration,
+    /// CPU seconds the whole process may consume, handed to `RLIMIT_CPU`.
+    pub cpu_seconds: u64,
+    /// Largest input worth running. Anything bigger is rejected before work
+    /// starts rather than being decoded slowly.
+    pub max_input_bytes: usize,
+}
+
+impl MeteringLimits {
+    /// Live-heap ceiling for the fuzz harness, in bytes.
+    ///
+    /// An associated constant because `#[global_allocator]` statics have to be
+    /// initialised in a const context.
+    pub const FUZZ_HEAP_BYTES: usize = 256 * 1024 * 1024;
+
+    /// Ceilings for the fuzz harness: a small fraction of the network's, so an
+    /// input that tries to run forever is cut off in milliseconds.
+    #[must_use]
+    pub const fn fuzzing() -> Self {
+        Self {
+            cpu_insns: 10_000_000,
+            mem_bytes: 8 * 1024 * 1024,
+            wall_clock: Duration::from_secs(2),
+            cpu_seconds: 10,
+            max_input_bytes: 64 * 1024,
+        }
+    }
+
+    /// Ceilings that mirror the network's per-transaction resource caps.
+    #[must_use]
+    pub const fn network() -> Self {
+        Self {
+            cpu_insns: crate::gas_optimizer::CPU_LIMIT,
+            mem_bytes: crate::gas_optimizer::MEMORY_LIMIT,
+            wall_clock: Duration::from_secs(30),
+            cpu_seconds: 120,
+            max_input_bytes: 16 * 1024 * 1024,
+        }
+    }
+
+    /// The CPU/memory pair in the shape `runner::SimHost::new` expects.
+    #[must_use]
+    pub const fn budget_limits(&self) -> (u64, u64) {
+        (self.cpu_insns, self.mem_bytes)
+    }
+
+    /// Builds a Soroban budget that traps once either cap is reached.
+    pub fn budget(&self) -> Result<Budget, HostError> {
+        let budget = Budget::default();
+        budget.reset_limits(self.cpu_insns, self.mem_bytes)?;
+        Ok(budget)
+    }
+
+    /// Starts a cooperative wall-clock deadline for one run.
+    #[must_use]
+    pub fn deadline(&self) -> Deadline {
+        Deadline::new(self.wall_clock)
+    }
+}
+
+impl Default for MeteringLimits {
+    fn default() -> Self {
+        Self::network()
+    }
+}
+
+/// Why a run was cut short.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum MeteringError {
+    /// The run outlived its wall-clock budget.
+    #[error("run exceeded its {limit_ms} ms wall-clock budget after {elapsed_ms} ms")]
+    Timeout { elapsed_ms: u64, limit_ms: u64 },
+
+    /// The CPU instruction cap was reached.
+    #[error("run exhausted its CPU budget ({consumed} of {limit} instructions)")]
+    CpuExhausted { consumed: u64, limit: u64 },
+
+    /// The memory cap was reached.
+    #[error("run exhausted its memory budget ({consumed} of {limit} bytes)")]
+    MemoryExhausted { consumed: u64, limit: u64 },
+
+    /// A process resource limit could not be applied.
+    #[error("could not apply {resource}: os error {errno}")]
+    Rlimit { resource: &'static str, errno: i32 },
+}
+
+#[cfg(unix)]
+impl MeteringError {
+    fn last_os_rlimit(resource: &'static str) -> Self {
+        let failure = std::io::Error::last_os_error();
+        let errno = failure.raw_os_error().unwrap_or(0);
+
+        Self::Rlimit { resource, errno }
+    }
+}
+
+/// A cooperative wall-clock budget for one run.
+///
+/// Checking it costs a single monotonic clock read, so callers can afford to call
+/// [`Deadline::check`] between units of work — per operation, per decoded entry —
+/// and bail out with a real error instead of being killed.
+#[derive(Debug, Clone, Copy)]
+pub struct Deadline {
+    started: Instant,
+    limit: Duration,
+}
+
+impl Deadline {
+    /// Starts a deadline `limit` from now.
+    #[must_use]
+    pub fn new(limit: Duration) -> Self {
+        Self {
+            started: Instant::now(),
+            limit,
+        }
+    }
+
+    /// Wall-clock time consumed so far.
+    #[must_use]
+    pub fn elapsed(&self) -> Duration {
+        self.started.elapsed()
+    }
+
+    /// The budget this deadline was created with.
+    #[must_use]
+    pub const fn limit(&self) -> Duration {
+        self.limit
+    }
+
+    /// Whether the budget is used up.
+    #[must_use]
+    pub fn expired(&self) -> bool {
+        self.elapsed() >= self.limit
+    }
+
+    /// Returns [`MeteringError::Timeout`] once the budget is used up.
+    pub fn check(&self) -> Result<(), MeteringError> {
+        let elapsed = self.elapsed();
+        if elapsed < self.limit {
+            return Ok(());
+        }
+
+        Err(MeteringError::Timeout {
+            elapsed_ms: whole_millis(elapsed),
+            limit_ms: whole_millis(self.limit),
+        })
+    }
+}
+
+/// Whole milliseconds in `duration`, saturating rather than wrapping.
+fn whole_millis(duration: Duration) -> u64 {
+    let millis = duration.as_millis();
+
+    u64::try_from(millis).unwrap_or(u64::MAX)
+}
+
+/// Checks a live Soroban budget against `limits`.
+///
+/// The budget traps on its own once a cap is reached; this is for callers that
+/// want to stop *before* the trap, or to report which cap was hit. A budget read
+/// that fails is treated as "nothing consumed", because a broken budget handle is
+/// not evidence that a limit was exceeded.
+pub fn check_budget(budget: &Budget, limits: &MeteringLimits) -> Result<(), MeteringError> {
+    let cpu = budget.get_cpu_insns_consumed().unwrap_or(0);
+    if cpu >= limits.cpu_insns {
+        return Err(MeteringError::CpuExhausted {
+            consumed: cpu,
+            limit: limits.cpu_insns,
+        });
+    }
+
+    let mem = budget.get_mem_bytes_consumed().unwrap_or(0);
+    if mem >= limits.mem_bytes {
+        return Err(MeteringError::MemoryExhausted {
+            consumed: mem,
+            limit: limits.mem_bytes,
+        });
+    }
+
+    Ok(())
+}
+
+/// State shared between the watchdog thread and the run it guards.
+struct WatchdogState {
+    /// Fixed reference point. Deadlines are nanosecond offsets from here so they
+    /// fit in an atomic.
+    origin: Instant,
+    /// Offset by which the run in flight must finish, or `DISARMED`.
+    deadline_nanos: AtomicU64,
+    /// Offset at which the run in flight started, used only for reporting.
+    armed_at_nanos: AtomicU64,
+}
+
+impl WatchdogState {
+    fn now_nanos(&self) -> u64 {
+        let nanos = self.origin.elapsed().as_nanos();
+
+        u64::try_from(nanos).unwrap_or(u64::MAX)
+    }
+
+    fn arm(&self, budget: Duration) {
+        let started = self.now_nanos();
+        let budget_nanos = u64::try_from(budget.as_nanos()).unwrap_or(u64::MAX);
+        // A zero-length budget still has to land on a deadline the thread acts
+        // on, and DISARMED is zero.
+        let deadline = started.saturating_add(budget_nanos).max(DISARMED + 1);
+
+        self.armed_at_nanos.store(started, Ordering::Relaxed);
+        self.deadline_nanos.store(deadline, Ordering::Release);
+    }
+
+    fn disarm(&self) {
+        self.deadline_nanos.store(DISARMED, Ordering::Release);
+    }
+}
+
+/// A thread that ends the process when a run outlives its wall-clock budget.
+///
+/// This is the ceiling that actually breaks a hang. A run that never returns to
+/// the harness cannot check its own [`Deadline`], so something outside it has to
+/// act; here that is an abort, which libFuzzer records as a crash and saves the
+/// offending input for. One watchdog guards one run at a time, matching the shape
+/// libFuzzer already has: it drives the target on a single thread.
+///
+/// The thread lives for the rest of the process. There is nothing to shut down,
+/// which is why a single watchdog is shared by every run.
+pub struct Watchdog {
+    state: Arc<WatchdogState>,
+}
+
+impl Watchdog {
+    /// Spawns a watchdog that aborts the process when a run overstays.
+    #[must_use]
+    pub fn spawn(poll_interval: Duration) -> Self {
+        Self::spawn_with(poll_interval, |elapsed, limit| {
+            eprintln!("[metering] wall-clock hang: {elapsed:?} > {limit:?}");
+            eprintln!("[metering] aborting to force a timeout");
+            std::process::abort();
+        })
+    }
+
+    /// Spawns a watchdog that calls `on_timeout(elapsed, limit)` instead of
+    /// aborting, so tests can observe a trip and survive it.
+    #[must_use]
+    pub fn spawn_with<F>(poll_interval: Duration, on_timeout: F) -> Self
+    where
+        F: Fn(Duration, Duration) + Send + 'static,
+    {
+        let state = Arc::new(WatchdogState {
+            origin: Instant::now(),
+            deadline_nanos: AtomicU64::new(DISARMED),
+            armed_at_nanos: AtomicU64::new(0),
+        });
+
+        let watched = Arc::clone(&state);
+        thread::Builder::new()
+            .name("erst-metering-watchdog".to_owned())
+            .spawn(move || watch(&watched, poll_interval, &on_timeout))
+            .expect("watchdog thread must start");
+
+        Self { state }
+    }
+
+    /// Puts the caller's run under the watchdog for `budget`.
+    pub fn arm(&self, budget: Duration) -> RunGuard<'_> {
+        self.state.arm(budget);
+
+        RunGuard {
+            state: self.state.as_ref(),
+            deadline: Deadline::new(budget),
+        }
+    }
+}
+
+/// Polls the armed deadline forever, reporting every run that overstays it.
+fn watch<F>(state: &WatchdogState, poll_interval: Duration, on_timeout: &F)
+where
+    F: Fn(Duration, Duration),
+{
+    // Deadlines are monotonic offsets, so remembering the last one reported is
+    // enough to report each overstaying run exactly once. The alternative —
+    // clearing the deadline from here — would unwatch any run that armed itself
+    // between the load and the clear.
+    let mut reported = DISARMED;
+
+    loop {
+        thread::sleep(poll_interval);
+
+        let deadline = state.deadline_nanos.load(Ordering::Acquire);
+        if deadline == DISARMED || deadline == reported {
+            continue;
+        }
+
+        let now = state.now_nanos();
+        if now < deadline {
+            continue;
+        }
+
+        reported = deadline;
+        let armed_at = state.armed_at_nanos.load(Ordering::Relaxed);
+        on_timeout(
+            Duration::from_nanos(now.saturating_sub(armed_at)),
+            Duration::from_nanos(deadline.saturating_sub(armed_at)),
+        );
+    }
+}
+
+/// Proof that a run is being watched, plus the cooperative deadline for it.
+///
+/// Dropping the guard disarms the watchdog, so a run that finishes in time is
+/// never reported.
+#[must_use = "dropping the guard immediately disarms the watchdog"]
+pub struct RunGuard<'a> {
+    state: &'a WatchdogState,
+    deadline: Deadline,
+}
+
+impl RunGuard<'_> {
+    /// The cooperative deadline for this run.
+    pub const fn deadline(&self) -> &Deadline {
+        &self.deadline
+    }
+
+    /// Returns [`MeteringError::Timeout`] once this run is out of time.
+    pub fn check(&self) -> Result<(), MeteringError> {
+        self.deadline.check()
+    }
+}
+
+impl Drop for RunGuard<'_> {
+    fn drop(&mut self) {
+        self.state.disarm();
+    }
+}
+
+/// Installs the process-wide ceilings the fuzz harness relies on and returns the
+/// shared watchdog.
+///
+/// Idempotent: the rlimit is applied and the watchdog thread spawned on the first
+/// call, and every later call hands back the same watchdog. Fuzz targets are
+/// re-entered thousands of times a second, so this has to stay cheap afterwards.
+pub fn install_fuzz_limits() -> &'static Watchdog {
+    static WATCHDOG: OnceLock<Watchdog> = OnceLock::new();
+
+    WATCHDOG.get_or_init(|| {
+        let limits = MeteringLimits::fuzzing();
+        if let Err(err) = install_cpu_rlimit(&limits) {
+            // Not fatal: the watchdog still bounds wall-clock time without it.
+            eprintln!("[metering] CPU rlimit not applied: {err}");
+        }
+
+        Watchdog::spawn(WATCHDOG_POLL_INTERVAL)
+    })
+}
+
+/// Caps the CPU time of the whole process with `RLIMIT_CPU`.
+///
+/// The kernel signals the process once the soft limit is passed, covering the
+/// case the watchdog cannot: a run that starves every other thread. Existing
+/// limits are only ever lowered, so this is safe to call in an environment that
+/// already applied a tighter cap.
+///
+/// `RLIMIT_AS` is deliberately left alone. Sanitizer-instrumented fuzz builds
+/// reserve terabytes of virtual address space for shadow memory, so capping
+/// address space kills the process before it reaches `main`. The live heap is
+/// bounded by [`TrackingAllocator`] instead, which counts real allocations.
+#[cfg(unix)]
+pub fn install_cpu_rlimit(limits: &MeteringLimits) -> Result<(), MeteringError> {
+    let mut current = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+
+    // SAFETY: `current` is a live, correctly typed `rlimit` owned by this frame.
+    if unsafe { libc::getrlimit(libc::RLIMIT_CPU, &mut current) } != 0 {
+        return Err(MeteringError::last_os_rlimit("RLIMIT_CPU"));
+    }
+
+    // `rlim_t` is u64 on every platform this project builds for, so the ceiling
+    // needs no conversion. The min() calls keep an existing tighter limit, since
+    // an unprivileged process may only ever lower its own.
+    let soft = limits.cpu_seconds.min(current.rlim_cur);
+    let next = libc::rlimit {
+        rlim_cur: soft.min(current.rlim_max),
+        rlim_max: current.rlim_max,
+    };
+
+    // SAFETY: `next` is a live, correctly typed `rlimit` owned by this frame.
+    if unsafe { libc::setrlimit(libc::RLIMIT_CPU, &next) } != 0 {
+        return Err(MeteringError::last_os_rlimit("RLIMIT_CPU"));
+    }
+
+    Ok(())
+}
+
+/// No-op where POSIX resource limits are unavailable. [`Watchdog`] still bounds
+/// wall-clock time on those platforms.
+#[cfg(not(unix))]
+pub fn install_cpu_rlimit(_limits: &MeteringLimits) -> Result<(), MeteringError> {
+    Ok(())
+}
+
+/// A [`GlobalAlloc`] wrapper that refuses to let the live heap pass a ceiling.
+///
+/// Fuzz inputs are very good at finding a length field that turns into a
+/// multi-gigabyte allocation. Left alone the process starts swapping and the run
+/// is indistinguishable from a hang. Capped here, the allocation fails, Rust's
+/// out-of-memory handler aborts, and libFuzzer saves the input.
+///
+/// The ceiling is on *live* bytes rather than total bytes allocated, so a run
+/// that churns through many short-lived buffers is not punished for it.
+pub struct TrackingAllocator<A> {
+    inner: A,
+    limit: usize,
+    live: AtomicUsize,
+    peak: AtomicUsize,
+}
+
+impl<A> TrackingAllocator<A> {
+    /// Wraps `inner`, refusing allocations that would push the live heap past
+    /// `limit` bytes.
+    ///
+    /// `const` so it can initialise a `#[global_allocator]` static.
+    pub const fn new(inner: A, limit: usize) -> Self {
+        Self {
+            inner,
+            limit,
+            live: AtomicUsize::new(0),
+            peak: AtomicUsize::new(0),
+        }
+    }
+
+    /// Bytes currently allocated through this allocator.
+    pub fn live_bytes(&self) -> usize {
+        self.live.load(Ordering::Relaxed)
+    }
+
+    /// High-water mark of the live byte count.
+    pub fn peak_bytes(&self) -> usize {
+        self.peak.load(Ordering::Relaxed)
+    }
+
+    /// The ceiling this allocator enforces.
+    pub const fn limit_bytes(&self) -> usize {
+        self.limit
+    }
+
+    /// Accounts for `bytes` about to be allocated, or refuses them.
+    fn reserve(&self, bytes: usize) -> bool {
+        let order = Ordering::Relaxed;
+        let claimed = self.live.fetch_update(order, order, |live| {
+            let next = live.saturating_add(bytes);
+            if next > self.limit {
+                None
+            } else {
+                Some(next)
+            }
+        });
+
+        match claimed {
+            Ok(previous) => {
+                let live = previous.saturating_add(bytes);
+                self.peak.fetch_max(live, order);
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    /// Returns `bytes` to the ceiling.
+    fn release(&self, bytes: usize) {
+        self.live.fetch_sub(bytes, Ordering::Relaxed);
+    }
+}
+
+// SAFETY: every method forwards to `inner`, which is itself a correct
+// `GlobalAlloc`. The accounting around those calls never touches the memory and
+// never hands back a pointer `inner` did not produce.
+unsafe impl<A: GlobalAlloc> GlobalAlloc for TrackingAllocator<A> {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if !self.reserve(layout.size()) {
+            return std::ptr::null_mut();
+        }
+
+        // SAFETY: `layout` is forwarded unchanged from our caller.
+        let ptr = unsafe { self.inner.alloc(layout) };
+        if ptr.is_null() {
+            self.release(layout.size());
+        }
+
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        if !self.reserve(layout.size()) {
+            return std::ptr::null_mut();
+        }
+
+        // SAFETY: `layout` is forwarded unchanged from our caller.
+        let ptr = unsafe { self.inner.alloc_zeroed(layout) };
+        if ptr.is_null() {
+            self.release(layout.size());
+        }
+
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: `ptr` and `layout` are forwarded unchanged from our caller.
+        unsafe { self.inner.dealloc(ptr, layout) };
+        self.release(layout.size());
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let growth = new_size.saturating_sub(layout.size());
+        if growth > 0 && !self.reserve(growth) {
+            return std::ptr::null_mut();
+        }
+
+        // SAFETY: all three arguments are forwarded unchanged from our caller.
+        let resized = unsafe { self.inner.realloc(ptr, layout, new_size) };
+        if resized.is_null() {
+            self.release(growth);
+        } else {
+            self.release(layout.size().saturating_sub(new_size));
+        }
+
+        resized
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::alloc::System;
+    use std::sync::atomic::AtomicBool;
+
+    #[test]
+    fn fuzzing_ceilings_are_tighter_than_network_ceilings() {
+        let fuzzing = MeteringLimits::fuzzing();
+        let network = MeteringLimits::network();
+
+        assert!(fuzzing.cpu_insns < network.cpu_insns);
+        assert!(fuzzing.mem_bytes < network.mem_bytes);
+        assert!(fuzzing.wall_clock < network.wall_clock);
+        assert!(fuzzing.cpu_seconds < network.cpu_seconds);
+        assert!(fuzzing.max_input_bytes < network.max_input_bytes);
+    }
+
+    #[test]
+    fn a_fresh_budget_has_not_exhausted_its_ceilings() {
+        let limits = MeteringLimits::fuzzing();
+        let budget = limits.budget().expect("limits apply");
+
+        assert_eq!(check_budget(&budget, &limits), Ok(()));
+    }
+
+    #[test]
+    fn a_zero_cpu_ceiling_reports_an_exhausted_budget() {
+        let limits = MeteringLimits {
+            cpu_insns: 0,
+            ..MeteringLimits::fuzzing()
+        };
+        let budget = limits.budget().expect("limits apply");
+        let outcome = check_budget(&budget, &limits);
+
+        assert!(matches!(outcome, Err(MeteringError::CpuExhausted { .. })));
+    }
+
+    #[test]
+    fn an_expired_deadline_reports_a_timeout() {
+        let deadline = Deadline::new(Duration::ZERO);
+        let outcome = deadline.check();
+
+        assert!(deadline.expired());
+        assert!(matches!(outcome, Err(MeteringError::Timeout { .. })));
+    }
+
+    #[test]
+    fn a_fresh_deadline_has_time_left() {
+        let deadline = Deadline::new(Duration::from_secs(60));
+
+        assert!(!deadline.expired());
+        assert_eq!(deadline.check(), Ok(()));
+        assert_eq!(deadline.limit(), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn the_watchdog_reports_a_run_that_overstays() {
+        let tripped = Arc::new(AtomicBool::new(false));
+        let observed = Arc::clone(&tripped);
+        let watchdog = Watchdog::spawn_with(Duration::from_millis(5), move |_, _| {
+            observed.store(true, Ordering::Relaxed);
+        });
+
+        let _guard = watchdog.arm(Duration::from_millis(10));
+        thread::sleep(Duration::from_millis(400));
+
+        assert!(tripped.load(Ordering::Relaxed), "hang not reported");
+    }
+
+    #[test]
+    fn dropping_the_guard_disarms_the_watchdog() {
+        let tripped = Arc::new(AtomicBool::new(false));
+        let observed = Arc::clone(&tripped);
+        let watchdog = Watchdog::spawn_with(Duration::from_millis(5), move |_, _| {
+            observed.store(true, Ordering::Relaxed);
+        });
+
+        drop(watchdog.arm(Duration::from_millis(10)));
+        thread::sleep(Duration::from_millis(400));
+
+        assert!(!tripped.load(Ordering::Relaxed), "finished run reported");
+    }
+
+    #[test]
+    fn the_allocator_refuses_to_grow_past_its_ceiling() {
+        let allocator = TrackingAllocator::new(System, 4096);
+        let layout = Layout::from_size_align(1024, 8).expect("valid layout");
+        assert_eq!(allocator.limit_bytes(), 4096);
+
+        // SAFETY: the layout has a non-zero size, and the block is freed below.
+        let ptr = unsafe { allocator.alloc(layout) };
+        assert!(!ptr.is_null());
+        assert_eq!(allocator.live_bytes(), 1024);
+
+        let oversized = Layout::from_size_align(8192, 8).expect("valid layout");
+        // SAFETY: a refused allocation returns null and owns nothing.
+        let refused = unsafe { allocator.alloc(oversized) };
+        assert!(refused.is_null());
+        assert_eq!(allocator.live_bytes(), 1024, "refusal leaked bytes");
+
+        // SAFETY: `ptr` came from this allocator with this layout.
+        unsafe { allocator.dealloc(ptr, layout) };
+        assert_eq!(allocator.live_bytes(), 0);
+        assert_eq!(allocator.peak_bytes(), 1024);
+    }
+}


### PR DESCRIPTION
## What I found

Neither file existed yet: there was no `simulator/fuzz/` crate at all, and no `metering.rs`. The Rust fuzzing story in the repo stopped at `.github/workflows/fuzz.yml`, which only compiles the `erst-sim` binary with LLVM's SanitizerCoverage pass. So I built the libFuzzer target and the metering module it depends on, which is what the issue is really about: a target that runs attacker-chosen Wasm through `Host::invoke_function` with no ceiling of its own.

The key design constraint I hit is that **`RLIMIT_AS` is unusable for memory limiting in a fuzz build** — sanitizer-instrumented binaries reserve terabytes of virtual address space for shadow memory, so an address-space cap kills the process before `main`. I capped the live heap with a tracking global allocator instead and used `RLIMIT_CPU` (which is sanitizer-safe) for CPU time.

## Verification gap, stated plainly

There is no Rust toolchain on this machine (no `cargo`, `rustc`, or `rustup` anywhere on disk), so **I could not compile, test, or `cargo fmt` any of this locally**. I wrote it against the repo's exact conventions — including rustfmt's `struct_lit_width = 18` / `fn_call_width = 60` heuristics, which CI enforces via `cargo fmt --check`, and clippy's `-D clippy::all` — but the first CI run is the real check. That's also why I added the fuzz build job: without it, nothing in the repo would ever compile `simulate.rs`.

---

# PR: Force timeouts in the simulator fuzz harness with hard CPU and memory ceilings

## Problem

The `simulate` fuzz target drives `Host::invoke_function` with input-chosen Wasm. A contract that loops forever gives libFuzzer nothing to report — it just waits. libFuzzer's default `-timeout` is 1200 seconds and `-rss_limit_mb` only reacts once the memory is already gone, so a single bad input could stall a campaign for twenty minutes and then die without a useful reproducer.

Worse, the Soroban budget only meters Wasm instructions. A run that spins inside *native* simulator code — an XDR decoder that never converges, a retry loop — is never charged to the budget at all, so nothing in the process forces it to end.

## Approach

`simulator/src/metering.rs` (new) provides four independent ceilings, cheapest first. The layering matters: each one catches a class of hang the previous one cannot see.

| Ceiling | Mechanism | Catches |
|---|---|---|
| CPU instructions | Soroban `Budget` capped at 10M (vs. 100M on-network) | Metered Wasm infinite loops; traps in milliseconds |
| Wall clock (cooperative) | `Deadline` / `RunGuard::check` | Slow runs the harness can abandon under its own control |
| Wall clock (forced) | `Watchdog` thread that calls `std::process::abort()` | Runs that never return to the harness, so cannot check anything |
| Live heap | `TrackingAllocator` global allocator, 256 MiB | A forged length field allocating the machine into swap |
| Process CPU time | `RLIMIT_CPU`, 10 s | Backstop when a run starves every other thread |

The watchdog abort is the piece that actually converts a hang into a *finding*: libFuzzer records the abort as a crash and writes the reproducer, instead of sitting on a wedged process.

`simulator/fuzz/fuzz_targets/simulate.rs` (new) wires all of it up and fuzzes three untrusted-input paths, selected by the first input byte: transaction-envelope decode plus host-function invocation, binary ledger-snapshot round-trip, and the base64/XDR entry decoders the IPC bridge uses.

## Notable decisions

- **`RLIMIT_AS` is deliberately not used.** ASan reserves terabytes of virtual address space for shadow memory, so an address-space rlimit kills the process at startup. The tracking allocator counts real allocations instead, which is also portable to Windows.
- **The allocator caps *live* bytes, not total allocated**, so a run that churns through short-lived buffers isn't punished. Over-limit allocations return null, Rust's OOM handler aborts, libFuzzer saves the input.
- **Existing rlimits are only ever lowered**, so the harness is safe to run somewhere that already applied a tighter cap.
- **The watchdog thread never clears the deadline it observed** — it remembers the last deadline it reported instead. Clearing from the watchdog would race with a newly armed run and silently leave that run unwatched.
- **Fuzzed XDR is decoded with `depth: 64, len: payload.len()`** rather than `Limits::none()`, so a depth bomb can't blow the stack and a forged length can't drive an allocation the input never paid for.

## Files

- `simulator/src/metering.rs` — new module: `MeteringLimits`, `Deadline`, `Watchdog`/`RunGuard`, `TrackingAllocator`, `install_cpu_rlimit`, `install_fuzz_limits`, `check_budget`. Includes 8 unit tests.
- `simulator/src/lib.rs` — export `pub mod metering`.
- `simulator/fuzz/Cargo.toml`, `simulator/fuzz/.gitignore` — cargo-fuzz scaffolding, kept out of the parent workspace since it needs nightly.
- `simulator/fuzz/fuzz_targets/simulate.rs` — the target.
- `.github/workflows/fuzz.yml` — new `libfuzzer_target` job: builds the target and runs a 2000-iteration smoke campaign, with `timeout-minutes: 30` so the anti-hang job can't hang either.

## Test plan

- [ ] `cargo test` in `simulator/` — 8 new tests cover the tighter-than-network invariant, budget exhaustion reporting, deadline expiry, watchdog trip, guard disarm on drop, and allocator refusal/accounting.
- [ ] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings -D clippy::all` in `simulator/` (see the verification note above — this is the first real check of the formatting).
- [ ] `cargo fuzz build simulate` and `cargo fuzz run simulate -- -runs=2000` via the new CI job.
- [ ] Manual hang check: point the target at a contract that loops forever and confirm the budget traps rather than spins; hold a `RunGuard` past its budget and confirm the watchdog aborts with a saved `crash-*` artifact.


close: #1706 