### PR TITLE
feat(trace): add collapsible cross-contract tree view

### DIFF
--- a/internal/trace/treeviewer_mouse.go
+++ b/internal/trace/treeviewer_mouse.go
@@ -54,18 +54,10 @@ func (tv *TreeViewerWithMouse) StartWithMouse() error {
 	}
 	defer func() { _ = tv.mouseTracker.Disable() }() //nolint:errcheck // Best-effort mouse tracking disable on exit
 
-	// Build initial tree
+	// Build initial tree from the execution trace, nesting cross-contract steps.
 	nodes := make([]*TraceNode, 0)
-	if tv.trace != nil && len(tv.trace.States) > 0 {
-		// For now, create a simplified tree from trace states
-		root := NewTraceNode("root", "trace")
-		for i, state := range tv.trace.States {
-			node := NewTraceNode(fmt.Sprintf("step-%d", i), state.Operation)
-			node.Function = state.Function
-			node.ContractID = state.ContractID
-			node.Error = state.Error
-			root.AddChild(node)
-		}
+	if tv.trace != nil {
+		root := tv.trace.BuildTraceTree()
 		nodes = append(nodes, root)
 	}
 

--- a/internal/trace/tui.go
+++ b/internal/trace/tui.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package trace
+
+import "fmt"
+
+// BuildTraceTree converts a flat execution trace into a collapsible tree where
+// cross-contract transitions become nested children.
+func BuildTraceTree(trace *ExecutionTrace) *TraceNode {
+	if trace == nil {
+		return NewTraceNode("root", "trace")
+	}
+	return trace.BuildTraceTree()
+}
+
+// BuildTraceTree converts the execution trace into a collapsible tree view.
+func (t *ExecutionTrace) BuildTraceTree() *TraceNode {
+	root := NewTraceNode("root", "trace")
+	root.Expanded = true
+
+	if t == nil || len(t.States) == 0 {
+		return root
+	}
+
+	var previous *TraceNode
+	for i, state := range t.States {
+		node := NewTraceNode(fmt.Sprintf("step-%d", i), "state")
+		node.ContractID = state.ContractID
+		node.Function = state.Function
+		node.Error = state.Error
+		node.EventData = state.Operation
+		switch {
+		case state.EventType != "":
+			node.Type = state.EventType
+		case state.ContractID != "":
+			node.Type = "contract_call"
+		}
+
+		if previous == nil {
+			root.AddChild(node)
+		} else if previous.ContractID != "" && state.ContractID != "" && state.ContractID != previous.ContractID {
+			previous.AddChild(node)
+		} else if previous.Parent != nil {
+			previous.Parent.AddChild(node)
+		} else {
+			root.AddChild(node)
+		}
+
+		previous = node
+	}
+
+	return root
+}

--- a/internal/trace/tui_test.go
+++ b/internal/trace/tui_test.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package trace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildTraceTree_UsesCrossContractCallsAsNestedNodes(t *testing.T) {
+	trace := NewExecutionTrace("tx", 1)
+	trace.AddState(ExecutionState{Operation: "call", ContractID: "A", Function: "deposit"})
+	trace.AddState(ExecutionState{Operation: "call", ContractID: "B", Function: "swap"})
+	trace.AddState(ExecutionState{Operation: "call", ContractID: "C", Function: "approve"})
+
+	root := BuildTraceTree(trace)
+	require.NotNil(t, root)
+	require.Len(t, root.Children, 1)
+	require.Equal(t, "A", root.Children[0].ContractID)
+	require.Len(t, root.Children[0].Children, 1)
+	require.Equal(t, "B", root.Children[0].Children[0].ContractID)
+	require.Len(t, root.Children[0].Children[0].Children, 1)
+	require.Equal(t, "C", root.Children[0].Children[0].Children[0].ContractID)
+}

--- a/internal/trace/views/tree.go
+++ b/internal/trace/views/tree.go
@@ -1,0 +1,11 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+package views
+
+import "github.com/dotandev/hintents/internal/trace"
+
+// BuildTraceTreeView creates a collapsible tree from a flat execution trace.
+func BuildTraceTreeView(trace *trace.ExecutionTrace) *trace.TraceNode {
+	return trace.BuildTraceTree()
+}


### PR DESCRIPTION
## Description

This PR adds a collapsible tree view for nested cross-contract calls in the trace UI so execution traces are no longer rendered as a flat list.

The new tree builder groups cross-contract transitions into nested nodes that can be expanded and collapsed directly in the interactive trace viewer.

## Related Issues

Fixes #1718

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have followed the guidelines in `CONTRIBUTING.md`.
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the documentation as needed.
- [ ] My code passes all local formatting and linting checks (`go fmt`, `golangci-lint`, `cargo fmt`, `cargo clippy`).

## Screenshots / Terminal Output (if applicable)

N/A


Closes #1718