### PR TITLE
fix: Visualize Flamegraphs directly inside VS Code webview

### DIFF
--- a/erst_extension/src/commands/profile.ts
+++ b/erst_extension/src/commands/profile.ts
@@ -1,0 +1,83 @@
+// Copyright (c) Hintents Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import { FlamegraphWebview } from '../views/flamegraphWebview';
+
+export interface ProfileFlamegraphPaths {
+    cpuPath: string;
+    memoryPath: string;
+    title?: string;
+}
+
+const supportedExtensions = new Set(['.html', '.htm', '.svg']);
+
+/**
+ * Opens generated CPU and memory flamegraphs in a tabbed VS Code webview.
+ *
+ * The extension's command registration can call this after the profiler writes
+ * both files. Keeping the renderer behind this function avoids exposing VS Code
+ * webview lifecycle details to the command.
+ */
+export async function showProfileFlamegraphs(
+    paths: ProfileFlamegraphPaths,
+    viewColumn: vscode.ViewColumn = vscode.ViewColumn.Beside
+): Promise<void> {
+    try {
+        const [cpu, memory] = await Promise.all([
+            validateFlamegraphPath('CPU', paths.cpuPath),
+            validateFlamegraphPath('Memory', paths.memoryPath)
+        ]);
+
+        FlamegraphWebview.show(
+            {
+                cpu,
+                memory,
+                title: paths.title
+            },
+            viewColumn
+        );
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        void vscode.window.showErrorMessage(`Unable to display flamegraphs: ${message}`);
+    }
+}
+
+async function validateFlamegraphPath(
+    label: string,
+    filePath: string
+): Promise<vscode.Uri> {
+    const normalizedPath = filePath.trim();
+    if (normalizedPath.length === 0) {
+        throw new Error(`${label} flamegraph path is empty.`);
+    }
+
+    const extension = path.extname(normalizedPath).toLowerCase();
+    if (!supportedExtensions.has(extension)) {
+        throw new Error(
+            `${label} flamegraph must be an HTML or SVG file: ${normalizedPath}`
+        );
+    }
+
+    const uri = vscode.Uri.file(normalizedPath);
+    let stat: vscode.FileStat;
+
+    try {
+        stat = await vscode.workspace.fs.stat(uri);
+    } catch {
+        throw new Error(`${label} flamegraph does not exist: ${normalizedPath}`);
+    }
+
+    if ((stat.type & vscode.FileType.File) === 0) {
+        throw new Error(`${label} flamegraph is not a file: ${normalizedPath}`);
+    }
+
+    try {
+        await vscode.workspace.fs.readFile(uri);
+    } catch {
+        throw new Error(`${label} flamegraph is not readable: ${normalizedPath}`);
+    }
+
+    return uri;
+}

--- a/erst_extension/src/views/flamegraphWebview.ts
+++ b/erst_extension/src/views/flamegraphWebview.ts
@@ -1,0 +1,258 @@
+// Copyright (c) Hintents Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+import { randomBytes } from 'node:crypto';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+
+export interface FlamegraphResources {
+    cpu: vscode.Uri;
+    memory: vscode.Uri;
+    title?: string;
+}
+
+export class FlamegraphWebview {
+    private static currentPanel: vscode.WebviewPanel | undefined;
+
+    public static show(
+        resources: FlamegraphResources,
+        viewColumn: vscode.ViewColumn = vscode.ViewColumn.Beside
+    ): void {
+        const localResourceRoots = [
+            parentDirectory(resources.cpu),
+            parentDirectory(resources.memory)
+        ];
+
+        if (FlamegraphWebview.currentPanel) {
+            const panel = FlamegraphWebview.currentPanel;
+            panel.webview.options = {
+                enableScripts: true,
+                localResourceRoots
+            };
+            panel.title = resources.title ?? 'ERST Flamegraphs';
+            panel.webview.html = renderWebview(panel.webview, resources);
+            panel.reveal(viewColumn, true);
+            return;
+        }
+
+        const panel = vscode.window.createWebviewPanel(
+            'erst.flamegraphs',
+            resources.title ?? 'ERST Flamegraphs',
+            viewColumn,
+            {
+                enableScripts: true,
+                retainContextWhenHidden: true,
+                localResourceRoots
+            }
+        );
+
+        FlamegraphWebview.currentPanel = panel;
+        panel.webview.html = renderWebview(panel.webview, resources);
+        panel.onDidDispose(() => {
+            FlamegraphWebview.currentPanel = undefined;
+        });
+    }
+}
+
+function renderWebview(
+    webview: vscode.Webview,
+    resources: FlamegraphResources
+): string {
+    const nonce = randomBytes(16).toString('hex');
+    const cpuSource = escapeAttribute(webview.asWebviewUri(resources.cpu).toString());
+    const memorySource = escapeAttribute(webview.asWebviewUri(resources.memory).toString());
+    const title = escapeHtml(resources.title ?? 'ERST Flamegraphs');
+
+    return `<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta
+        http-equiv="Content-Security-Policy"
+        content="default-src 'none'; frame-src ${webview.cspSource}; style-src 'nonce-${nonce}'; script-src 'nonce-${nonce}';"
+    >
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>${title}</title>
+    <style nonce="${nonce}">
+        :root {
+            color-scheme: light dark;
+        }
+
+        body {
+            display: flex;
+            flex-direction: column;
+            height: 100vh;
+            margin: 0;
+            overflow: hidden;
+            color: var(--vscode-foreground);
+            background: var(--vscode-editor-background);
+            font-family: var(--vscode-font-family);
+        }
+
+        .tabs {
+            display: flex;
+            flex: 0 0 auto;
+            gap: 2px;
+            padding: 8px 12px 0;
+            border-bottom: 1px solid var(--vscode-panel-border);
+            background: var(--vscode-editorGroupHeader-tabsBackground);
+        }
+
+        .tab {
+            min-width: 96px;
+            padding: 8px 14px;
+            border: 0;
+            border-bottom: 2px solid transparent;
+            color: var(--vscode-tab-inactiveForeground);
+            background: transparent;
+            cursor: pointer;
+            font: inherit;
+        }
+
+        .tab:hover {
+            color: var(--vscode-tab-activeForeground);
+            background: var(--vscode-list-hoverBackground);
+        }
+
+        .tab[aria-selected="true"] {
+            color: var(--vscode-tab-activeForeground);
+            border-bottom-color: var(--vscode-focusBorder);
+            background: var(--vscode-tab-activeBackground);
+        }
+
+        .tab:focus-visible {
+            outline: 1px solid var(--vscode-focusBorder);
+            outline-offset: -2px;
+        }
+
+        .graphs {
+            position: relative;
+            flex: 1 1 auto;
+            min-height: 0;
+        }
+
+        .graph {
+            position: absolute;
+            inset: 0;
+        }
+
+        .graph[hidden] {
+            display: none;
+        }
+
+        iframe {
+            width: 100%;
+            height: 100%;
+            border: 0;
+            background: var(--vscode-editor-background);
+        }
+    </style>
+</head>
+<body>
+    <nav class="tabs" role="tablist" aria-label="Flamegraph resource">
+        <button
+            class="tab"
+            id="cpu-tab"
+            type="button"
+            role="tab"
+            aria-selected="true"
+            aria-controls="cpu-graph"
+            data-target="cpu-graph"
+        >
+            CPU
+        </button>
+        <button
+            class="tab"
+            id="memory-tab"
+            type="button"
+            role="tab"
+            aria-selected="false"
+            aria-controls="memory-graph"
+            data-target="memory-graph"
+        >
+            Memory
+        </button>
+    </nav>
+    <main class="graphs">
+        <section
+            class="graph"
+            id="cpu-graph"
+            role="tabpanel"
+            aria-labelledby="cpu-tab"
+        >
+            <iframe
+                title="CPU flamegraph"
+                src="${cpuSource}"
+                sandbox="allow-scripts allow-same-origin"
+            ></iframe>
+        </section>
+        <section
+            class="graph"
+            id="memory-graph"
+            role="tabpanel"
+            aria-labelledby="memory-tab"
+            hidden
+        >
+            <iframe
+                title="Memory flamegraph"
+                src="${memorySource}"
+                sandbox="allow-scripts allow-same-origin"
+            ></iframe>
+        </section>
+    </main>
+    <script nonce="${nonce}">
+        const tabs = Array.from(document.querySelectorAll('[role="tab"]'));
+        const panels = Array.from(document.querySelectorAll('[role="tabpanel"]'));
+
+        function activateTab(tab) {
+            const target = tab.dataset.target;
+
+            for (const candidate of tabs) {
+                candidate.setAttribute(
+                    'aria-selected',
+                    String(candidate === tab)
+                );
+            }
+
+            for (const panel of panels) {
+                panel.hidden = panel.id !== target;
+            }
+        }
+
+        for (const tab of tabs) {
+            tab.addEventListener('click', () => activateTab(tab));
+            tab.addEventListener('keydown', (event) => {
+                if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
+                    return;
+                }
+
+                event.preventDefault();
+                const direction = event.key === 'ArrowRight' ? 1 : -1;
+                const currentIndex = tabs.indexOf(tab);
+                const nextIndex = (currentIndex + direction + tabs.length) % tabs.length;
+                const nextTab = tabs[nextIndex];
+                nextTab.focus();
+                activateTab(nextTab);
+            });
+        }
+    </script>
+</body>
+</html>`;
+}
+
+function parentDirectory(uri: vscode.Uri): vscode.Uri {
+    return vscode.Uri.file(path.dirname(uri.fsPath));
+}
+
+function escapeAttribute(value: string): string {
+    return escapeHtml(value);
+}
+
+function escapeHtml(value: string): string {
+    return value
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;');
+}


### PR DESCRIPTION
# feat: Visualize Flamegraphs directly inside VS Code webview

## Summary

Renders the generated CPU and Memory flamegraphs inside a VS Code webview panel instead of opening them in an external browser. The two profiling outputs are shown in a single tabbed panel — CPU and Memory — where each graph gets the full editor width and switching tabs preserves the loaded graph's state (zoom, search, hover).

## Motivation

Closes #1701. Previously, viewing a profiled flamegraph meant leaving the editor for the browser, breaking the debugging flow. Keeping the flamegraphs in-editor lets contract authors profile and inspect results without a context switch.

## Changes

- **`erst_extension/src/views/flamegraphWebview.ts` (new)** — Owns the webview panel lifecycle:
  - A reusable singleton panel titled "ERST Flamegraphs"; re-running profiling reveals and refreshes the existing panel rather than stacking duplicates.
  - Authorizes only the two flamegraph parent directories via `localResourceRoots`, and converts file paths with `webview.asWebviewUri`.
  - Loads CPU and Memory into separate sandboxed iframes (`allow-scripts allow-same-origin`), keeping both mounted and toggling visibility so interactive state survives tab switches.
  - Nonce-based CSP for the tab controls; `retainContextWhenHidden` so state persists when the panel is backgrounded.
  - Accessible tabs (`role="tab"`/`tabpanel"`, `aria-selected`, arrow-key navigation) themed with VS Code CSS variables.
- **`erst_extension/src/commands/profile.ts` (new)** — Integration entry point `showProfileFlamegraphs({ cpuPath, memoryPath, title? })`:
  - Validates both files exist, are regular files, are readable, and carry an `.html`/`.htm`/`.svg` extension.
  - Surfaces failures as VS Code error messages; a missing or unreadable path produces no partial panel.

## Scope notes

- Per the issue's file list, this only adds the two modules. Command registration in `extension.ts` and `package.json` is **not** wired up — `main` has no existing profile command to extend, so this is left as the integration hook for a follow-up.
- Branched fresh from `main`; unrelated to the earlier fuzz-harness work.

## Verification

- [x] `npm run compile` (tsc) — passes
- [x] `npm run test:unit` — 2/2 pass
- [x] IDE diagnostics clean on both new files
- [ ] `npm run lint` — **could not run**: the repo has no ESLint config file (`ESLint couldn't find a configuration file`); pre-existing, not introduced here
- [ ] Manual in-editor check: run profiling, confirm CPU/Memory tabs render and tab-switching preserves zoom/search

closes: #1701 