### PR TITLE
chore: Integrate OSS-Fuzz continuous fuzzing workflow

### DIFF
--- a/Dockerfile.fuzz
+++ b/Dockerfile.fuzz
@@ -1,0 +1,10 @@
+FROM gcr.io/oss-fuzz-base/base-builder-go
+
+COPY . $SRC/hintents
+WORKDIR $SRC/hintents
+
+RUN echo '#!/bin/bash -eu' > $SRC/build.sh && \
+    echo 'cd $SRC/hintents' >> $SRC/build.sh && \
+    echo 'compile_native_go_fuzzer github.com/dotandev/hintents/internal/decoder FuzzDecodeEnvelope fuzz_decode_envelope' >> $SRC/build.sh && \
+    echo 'compile_native_go_fuzzer github.com/dotandev/hintents/internal/decoder FuzzDecodeEnvelopeBytes fuzz_decode_envelope_bytes' >> $SRC/build.sh && \
+    chmod +x $SRC/build.sh

--- a/project.yaml
+++ b/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://github.com/dotandev/hintents"
+language: go
+primary_contact: "jesuswrites20043@gmail.com"
+main_repo: "https://github.com/dotandev/hintents"
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address


### PR DESCRIPTION
Closes #1708

Connect our fuzz targets to Google's OSS-Fuzz platform for continuous cluster fuzzing.

Changes included:
* **`Dockerfile.fuzz`**: Implements the base builder (`gcr.io/oss-fuzz-base/base-builder-go`), copies the repository, and provisions a `build.sh` inline to run `compile_native_go_fuzzer` for the two targets inside `internal/decoder` (`FuzzDecodeEnvelope` and `FuzzDecodeEnvelopeBytes`).
* **`project.yaml`**: Provides the OSS-Fuzz metadata including language configuration (`go`), fuzzing engines (`libfuzzer`), sanitizers (`address`), and primary contact details.