### PR TITLE
Handle simulator host panics gracefully

### DIFF
--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -27,8 +27,9 @@ use base64::Engine as _;
 use soroban_env_host::xdr::{ReadXdr, WriteXdr};
 use soroban_env_host::{
     xdr::{Operation, OperationBody},
-    Host, HostError,
+    Host,
 };
+use std::any::Any;
 use std::collections::HashMap;
 use std::env;
 use std::fs;
@@ -85,6 +86,87 @@ fn send_error(msg: String) {
         println!("{{\"status\": \"error\", \"error\": \"Internal serialization error\"}}");
     }
     std::process::exit(1);
+}
+
+fn panic_info_to_string(panic_info: &(dyn Any + Send)) -> String {
+    if let Some(s) = panic_info.downcast_ref::<&str>() {
+        s.to_string()
+    } else if let Some(s) = panic_info.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "Unknown panic".to_string()
+    }
+}
+
+fn catch_unwind_safe<T, F>(f: F) -> Result<T, String>
+where
+    F: FnOnce() -> T,
+{
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f))
+        .map_err(|panic_info| panic_info_to_string(&panic_info))
+}
+
+fn emit_panic_response(
+    panic_msg: String,
+    source_mapper: Option<&SourceMapper>,
+    harness_logs: &[String],
+    lcov_report: &Option<String>,
+    lcov_report_path: &Option<String>,
+) {
+    let mut wasm_trace = WasmStackTrace::from_panic(&panic_msg);
+    if let Some(mapper) = source_mapper {
+        eprintln!("Attempting to resolve sources for Panic trace...");
+        wasm_trace.resolve_sources(mapper);
+        if wasm_trace
+            .frames
+            .iter()
+            .any(|f| f.source_location.is_some())
+        {
+            eprintln!("Source locations resolved for Panic trace.");
+        } else {
+            eprintln!("No source locations resolved for Panic trace.");
+        }
+    }
+
+    let memory_limit_exceeded = panic_msg.contains(ERR_MEMORY_LIMIT_EXCEEDED);
+
+    let response = SimulationResponse {
+        status: "error".to_string(),
+        error: Some(if memory_limit_exceeded {
+            panic_msg.clone()
+        } else {
+            format!("Simulator panicked: {panic_msg}")
+        }),
+        error_code: if memory_limit_exceeded {
+            Some(ERR_MEMORY_LIMIT_EXCEEDED.to_string())
+        } else {
+            None
+        },
+        lcov_report: lcov_report.clone(),
+        lcov_report_path: lcov_report_path.clone(),
+        events: vec![],
+        diagnostic_events: vec![],
+        categorized_events: vec![],
+        logs: {
+            let mut logs = vec![format!("PANIC: {panic_msg}")];
+            logs.extend_from_slice(harness_logs);
+            logs
+        },
+        flamegraph: None,
+        optimization_report: None,
+        budget_usage: None,
+        source_location: None,
+        stack_trace: Some(wasm_trace),
+        wasm_offset: None,
+        linear_memory_dump: None,
+        asset_anomalies: vec![],
+    };
+    if let Ok(json) = serde_json::to_string(&response) {
+        println!("{}", json);
+    } else {
+        eprintln!("Failed to serialize panic response");
+        println!("{{\"status\": \"error\", \"error\": \"Internal serialization error\"}}");
+    }
 }
 
 #[derive(Default)]
@@ -173,13 +255,14 @@ fn load_ledger_entries(
 }
 
 fn execute_operations(
-    host: &Host,
+    sim_host: &runner::SimHost,
     operations: &[Operation],
     request: &SimulationRequest,
     memory_limit: Option<u64>,
     coverage: &mut CoverageTracker,
-) -> Result<Vec<String>, HostError> {
+) -> Result<Vec<String>, crate::runner::SimHostError> {
     let mut logs = Vec::new();
+    let host = &sim_host.inner;
     check_memory_limit_or_panic(host, memory_limit);
     for op in operations {
         coverage.record_operation(op);
@@ -193,14 +276,16 @@ fn execute_operations(
                 {
                     logs.push(format!("Mock signature verification: {:?}", mock_result));
                     if !mock_result {
-                        return Err(soroban_env_host::HostError::from((
-                            soroban_env_host::xdr::ScErrorType::Context,
-                            soroban_env_host::xdr::ScErrorCode::InvalidInput,
-                        )));
+                        return Err(crate::runner::SimHostError::Host(
+                            soroban_env_host::HostError::from((
+                                soroban_env_host::xdr::ScErrorType::Context,
+                                soroban_env_host::xdr::ScErrorCode::InvalidInput,
+                            )),
+                        ));
                     }
                 }
 
-                let val = host.invoke_function(invoke_op.host_function.clone())?;
+                let val = sim_host.invoke_function(invoke_op.host_function.clone())?;
                 logs.push(format!("Result: {val:?}"));
                 check_memory_limit_or_panic(host, memory_limit);
             }
@@ -567,7 +652,7 @@ fn main() {
     let mut coverage = CoverageTracker::default();
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         execute_operations(
-            host,
+            &sim_host,
             operations,
             &request,
             request.memory_limit,
@@ -575,9 +660,27 @@ fn main() {
         )
     }));
 
-    let budget = host.budget_cloned();
-    let cpu_insns = budget.get_cpu_insns_consumed().unwrap_or(0);
-    let mem_bytes = budget.get_mem_bytes_consumed().unwrap_or(0);
+    let mut lcov_report = None;
+    let mut lcov_report_path = None;
+
+    let (budget, cpu_insns, mem_bytes) = match catch_unwind_safe(|| {
+        let budget = host.budget_cloned();
+        let cpu_insns = budget.get_cpu_insns_consumed().unwrap_or(0);
+        let mem_bytes = budget.get_mem_bytes_consumed().unwrap_or(0);
+        (budget, cpu_insns, mem_bytes)
+    }) {
+        Ok(values) => values,
+        Err(panic_msg) => {
+            emit_panic_response(
+                panic_msg,
+                source_mapper.as_ref(),
+                &harness_logs,
+                &lcov_report,
+                &lcov_report_path,
+            );
+            return;
+        }
+    };
 
     let cpu_usage_percent = (cpu_insns as f64 / CPU_LIMIT as f64) * 100.0;
     let memory_usage_percent = (mem_bytes as f64 / MEMORY_LIMIT as f64) * 100.0;
@@ -621,8 +724,6 @@ fn main() {
         }
     }
 
-    let mut lcov_report = None;
-    let mut lcov_report_path = None;
     if request.enable_coverage {
         let source_file = request
             .wasm_path
@@ -649,8 +750,8 @@ fn main() {
             let mut asset_tracker = asset_tracker::AssetTracker::new(request.enable_asset_safety);
 
             let (events, diagnostic_events): (Vec<String>, Vec<DiagnosticEvent>) =
-                match sim_host.inner.get_events() {
-                    Ok(evs) => {
+                match catch_unwind_safe(|| sim_host.events().map_err(|err| format!("{err:?}"))) {
+                    Ok(Ok(evs)) => {
                         let mut raw_events: Vec<String> = Vec::with_capacity(evs.0.len());
                         let diag_events: Vec<DiagnosticEvent> = (evs.0)
                             .iter()
@@ -717,16 +818,52 @@ fn main() {
                             .collect();
                         (raw_events, diag_events)
                     }
-                    Err(_) => (
-                        vec!["Failed to retrieve events".to_string()],
-                        Vec::<DiagnosticEvent>::new(),
-                    ),
+                    Ok(Err(err_msg)) => {
+                        emit_panic_response(
+                            format!("Host event retrieval failed: {err_msg}"),
+                            source_mapper.as_ref(),
+                            &harness_logs,
+                            &lcov_report,
+                            &lcov_report_path,
+                        );
+                        return;
+                    }
+                    Err(panic_msg) => {
+                        emit_panic_response(
+                            panic_msg,
+                            source_mapper.as_ref(),
+                            &harness_logs,
+                            &lcov_report,
+                            &lcov_report_path,
+                        );
+                        return;
+                    }
                 };
 
-            let categorized_events = match host.get_events() {
-                Ok(evs) => categorize_events(&evs, Some(cpu_insns), Some(mem_bytes)),
-                Err(_) => vec![],
-            };
+            let categorized_events =
+                match catch_unwind_safe(|| sim_host.events().map_err(|err| format!("{err:?}"))) {
+                    Ok(Ok(evs)) => categorize_events(&evs, Some(cpu_insns), Some(mem_bytes)),
+                    Ok(Err(err_msg)) => {
+                        emit_panic_response(
+                            format!("Host event retrieval failed: {err_msg}"),
+                            source_mapper.as_ref(),
+                            &harness_logs,
+                            &lcov_report,
+                            &lcov_report_path,
+                        );
+                        return;
+                    }
+                    Err(panic_msg) => {
+                        emit_panic_response(
+                            panic_msg,
+                            source_mapper.as_ref(),
+                            &harness_logs,
+                            &lcov_report,
+                            &lcov_report_path,
+                        );
+                        return;
+                    }
+                };
 
             let mut final_logs = vec![
                 format!("Host Initialized with Budget: {:?}", budget),
@@ -741,13 +878,33 @@ fn main() {
                     final_logs.push(format!("First linked SnapshotID: {snapshot_id}"));
                 }
             }
-            let contract_debug_logs: Vec<String> = match host.get_events() {
-                Ok(ref evs) => debug_host_fn::extract_debug_logs(evs)
-                    .into_iter()
-                    .map(|msg| format!("[debug] {}", msg))
-                    .collect(),
-                Err(_) => vec![],
-            };
+            let contract_debug_logs: Vec<String> =
+                match catch_unwind_safe(|| sim_host.events().map_err(|err| format!("{err:?}"))) {
+                    Ok(Ok(evs)) => debug_host_fn::extract_debug_logs(&evs)
+                        .into_iter()
+                        .map(|msg| format!("[debug] {}", msg))
+                        .collect(),
+                    Ok(Err(err_msg)) => {
+                        emit_panic_response(
+                            format!("Host event retrieval failed: {err_msg}"),
+                            source_mapper.as_ref(),
+                            &harness_logs,
+                            &lcov_report,
+                            &lcov_report_path,
+                        );
+                        return;
+                    }
+                    Err(panic_msg) => {
+                        emit_panic_response(
+                            panic_msg,
+                            source_mapper.as_ref(),
+                            &harness_logs,
+                            &lcov_report,
+                            &lcov_report_path,
+                        );
+                        return;
+                    }
+                };
             final_logs.extend(contract_debug_logs);
             final_logs.extend(exec_logs);
 
@@ -871,10 +1028,30 @@ fn main() {
                 format!("Memory Bytes Used: {}", mem_bytes),
             ];
 
-            let _categorized_events = match host.get_events() {
-                Ok(evs) => categorize_events(&evs, Some(cpu_insns), Some(mem_bytes)),
-                Err(_) => vec![],
-            };
+            let _categorized_events =
+                match catch_unwind_safe(|| sim_host.events().map_err(|err| format!("{err:?}"))) {
+                    Ok(Ok(evs)) => categorize_events(&evs, Some(cpu_insns), Some(mem_bytes)),
+                    Ok(Err(err_msg)) => {
+                        emit_panic_response(
+                            format!("Host event retrieval failed: {err_msg}"),
+                            source_mapper.as_ref(),
+                            &harness_logs,
+                            &lcov_report,
+                            &lcov_report_path,
+                        );
+                        return;
+                    }
+                    Err(panic_msg) => {
+                        emit_panic_response(
+                            panic_msg,
+                            source_mapper.as_ref(),
+                            &harness_logs,
+                            &lcov_report,
+                            &lcov_report_path,
+                        );
+                        return;
+                    }
+                };
 
             // Heuristic to ignore Rust stdlib panic wrappers and find the actual source point
             let mut user_panic_point = None;

--- a/simulator/src/runner.rs
+++ b/simulator/src/runner.rs
@@ -6,7 +6,7 @@ use soroban_env_host::{
     budget::Budget,
     events::{Events, HostEvent},
     storage::{AccessType, Footprint, FootprintMap, Storage, StorageMap},
-    xdr::{Hash, Limits, ScErrorCode, ScErrorType, WriteXdr},
+    xdr::{Hash, HostFunction, Limits, ScErrorCode, ScErrorType, ScVal, WriteXdr},
     DiagnosticLevel, Error as EnvError, Host, HostError, TryIntoVal, Val,
 };
 use std::rc::Rc;
@@ -19,6 +19,8 @@ pub enum SimHostError {
     Host(#[from] HostError),
     #[error(transparent)]
     Snapshot(#[from] SnapshotError),
+    #[error("host execution panicked: {0}")]
+    Panic(String),
 }
 
 pub struct SimHost {
@@ -31,6 +33,36 @@ pub struct SimHost {
 }
 
 impl SimHost {
+    fn panic_payload_to_string(panic_info: &(dyn std::any::Any + Send)) -> String {
+        if let Some(s) = panic_info.downcast_ref::<String>() {
+            s.clone()
+        } else if let Some(s) = panic_info.downcast_ref::<&'static str>() {
+            (*s).to_string()
+        } else if let Some(s) = panic_info.downcast_ref::<&str>() {
+            (*s).to_string()
+        } else {
+            "Unknown panic".to_string()
+        }
+    }
+
+    pub fn with_panic_recovery<T, F>(&self, f: F) -> Result<T, SimHostError>
+    where
+        F: FnOnce() -> T,
+    {
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+            Ok(result) => Ok(result),
+            Err(panic_info) => {
+                let message = Self::panic_payload_to_string(panic_info.as_ref());
+                Err(SimHostError::Panic(message))
+            }
+        }
+    }
+
+    pub fn invoke_function(&self, host_function: HostFunction) -> Result<ScVal, SimHostError> {
+        self.with_panic_recovery(|| self.inner.invoke_function(host_function))
+            .and_then(|result| result.map_err(SimHostError::Host))
+    }
+
     /// Initialize a new Host with optional budget settings and resource calibration.
     pub fn new(
         budget_limits: Option<(u64, u64)>,
@@ -247,6 +279,16 @@ mod tests {
         let host = SimHost::new(None, None, None);
         // Basic assertion that host is functional
         assert!(host.inner.budget_cloned().get_cpu_insns_consumed().is_ok());
+    }
+
+    #[test]
+    fn test_panic_recovery_wraps_host_execution() {
+        let host = SimHost::new(None, None, None);
+        let result = host.with_panic_recovery(|| panic!("memory violation"));
+
+        assert!(
+            matches!(result, Err(SimHostError::Panic(message)) if message.contains("memory violation"))
+        );
     }
 
     #[test]

--- a/simulator/src/test.rs
+++ b/simulator/src/test.rs
@@ -492,7 +492,7 @@ mod contract_execution_tests {
 
         // Create empty operations vector
         let operations: VecM<Operation, 100> = VecM::default();
-        let host = soroban_env_host::Host::default();
+        let sim_host = crate::runner::SimHost::new(None, None, None);
         let mut coverage = CoverageTracker::default();
 
         // Should succeed with empty operations
@@ -523,7 +523,7 @@ mod contract_execution_tests {
             include_linear_memory: false,
             enable_asset_safety: false,
         };
-        let result = execute_operations(&host, &operations, &request, None, &mut coverage);
+        let result = execute_operations(&sim_host, &operations, &request, None, &mut coverage);
         assert!(result.is_ok());
 
         let logs = result.unwrap();


### PR DESCRIPTION
closes #1661 
When WASM execution encounters severe memory violations, the host might still panic in edge cases. Wrap execution with catch_unwind safely.

Files to change:
simulator/src/runner.rs