### PR TITLE
feat: implement Snapshot deep-copying for Host memory states

### DIFF
--- a/simulator/src/host.rs
+++ b/simulator/src/host.rs
@@ -46,6 +46,20 @@ pub struct SnapshotPair {
     pub after: CapturedSnapshot,
 }
 
+impl SnapshotPair {
+    /// Creates a deep copy of this snapshot pair.
+    ///
+    /// Both the `before` and `after` states are fully materialized and share no
+    /// memory with the original pair. Useful for time-travel debugging where a
+    /// captured pair must survive the live simulation continuing to run.
+    pub fn deep_copy(&self) -> Self {
+        Self {
+            before: self.before.deep_copy(),
+            after: self.after.deep_copy(),
+        }
+    }
+}
+
 /// A single captured snapshot with metadata.
 #[derive(Debug, Clone)]
 pub struct CapturedSnapshot {
@@ -59,6 +73,25 @@ pub struct CapturedSnapshot {
     pub before_id: Option<SnapshotId>,
     /// Whether the host function trapped (only meaningful for After snapshots).
     pub trapped: bool,
+}
+
+impl CapturedSnapshot {
+    /// Creates a deep copy of this captured snapshot.
+    ///
+    /// The returned snapshot's `state` is a fully independent
+    /// [`LedgerSnapshot::deep_copy`] — it shares **no** memory with the
+    /// original and remains valid even as the live simulation mutates or drops
+    /// the captured snapshot. This is what time-travel debugging needs: a
+    /// perfect clone of the Host memory state at a given instruction pointer.
+    pub fn deep_copy(&self) -> Self {
+        Self {
+            id: self.id,
+            host_fn_name: self.host_fn_name.clone(),
+            state: self.state.deep_copy(),
+            before_id: self.before_id,
+            trapped: self.trapped,
+        }
+    }
 }
 
 /// Tracks allocator state across snapshot-and-rollback cycles.
@@ -297,13 +330,39 @@ impl HostSnapshotTracker {
     }
 
     /// Rewinds the tracker to a specific instruction pointer.
+    ///
+    /// Returns a **deep copy** of the state captured at the given instruction
+    /// pointer so time-travel debugging can freely mutate or hold onto the
+    /// result without affecting the tracker's own recorded snapshots (which
+    /// share their base via copy-on-write). Returns `None` if no snapshot was
+    /// captured at that instruction pointer.
     pub fn rewind_to(&mut self, instruction_pointer: u32) -> Option<LedgerSnapshot> {
         for pair in &self.pairs {
             if pair.before.id.as_u64() == instruction_pointer as u64 {
-                return Some(pair.before.state.clone());
+                return Some(pair.before.state.deep_copy());
             }
         }
         None
+    }
+
+    /// Rewinds the tracker to a specific instruction pointer, returning the
+    /// full captured snapshot metadata along with a deep copy of the state.
+    pub fn rewind_to_snapshot(&mut self, instruction_pointer: u32) -> Option<CapturedSnapshot> {
+        for pair in &self.pairs {
+            if pair.before.id.as_u64() == instruction_pointer as u64 {
+                return Some(pair.before.deep_copy());
+            }
+        }
+        None
+    }
+
+    /// Returns a deep copy of all captured snapshot pairs.
+    ///
+    /// Each pair's states are fully materialized and independent of the
+    /// tracker's internal snapshots, suitable for long-lived time-travel
+    /// debugging histories.
+    pub fn deep_copy_pairs(&self) -> Vec<SnapshotPair> {
+        self.pairs.iter().map(SnapshotPair::deep_copy).collect()
     }
 }
 
@@ -482,5 +541,116 @@ mod tests {
     fn test_snapshot_id_display() {
         let id = SnapshotId(42);
         assert_eq!(format!("{}", id), "snap-42");
+    }
+
+    #[test]
+    fn test_rewind_to_returns_deep_copy() {
+        let mut tracker = HostSnapshotTracker::new();
+        let mut state = LedgerSnapshot::new();
+        state.insert(vec![1], create_dummy_entry());
+
+        tracker.take_before_snapshot("storage_put", state, None);
+        let before_id = tracker.pending_before.as_ref().unwrap().id.as_u64() as u32;
+        tracker.take_after_snapshot(LedgerSnapshot::new(), false, None);
+
+        let rewound = tracker.rewind_to(before_id).expect("should rewind");
+        assert!(rewound.get(&[1]).is_some());
+
+        // Mutating the rewound copy must not affect the tracked snapshot.
+        let mut rewound_mut = rewound;
+        rewound_mut.insert(vec![2], create_dummy_entry());
+        assert_eq!(rewound_mut.len(), 2);
+        assert_eq!(tracker.pairs()[0].before.state.len(), 1);
+    }
+
+    #[test]
+    fn test_rewind_to_returns_none_for_unknown_pointer() {
+        let mut tracker = HostSnapshotTracker::new();
+        tracker.take_before_snapshot("fn", LedgerSnapshot::new(), None);
+        tracker.take_after_snapshot(LedgerSnapshot::new(), false, None);
+
+        assert!(tracker.rewind_to(9999).is_none());
+        assert!(tracker.rewind_to_snapshot(9999).is_none());
+    }
+
+    #[test]
+    fn test_rewind_to_snapshot_returns_metadata() {
+        let mut tracker = HostSnapshotTracker::new();
+        let mut state = LedgerSnapshot::new();
+        state.insert(vec![7], create_dummy_entry());
+
+        tracker.take_before_snapshot("storage_get", state, None);
+        let before_id = tracker.pending_before.as_ref().unwrap().id.as_u64() as u32;
+        tracker.take_after_snapshot(LedgerSnapshot::new(), false, None);
+
+        let captured = tracker
+            .rewind_to_snapshot(before_id)
+            .expect("should rewind");
+        assert_eq!(captured.host_fn_name, "storage_get");
+        assert_eq!(captured.before_id, None);
+        assert!(!captured.trapped);
+        assert!(captured.state.get(&[7]).is_some());
+    }
+
+    #[test]
+    fn test_deep_copy_pairs_is_independent() {
+        let mut tracker = HostSnapshotTracker::new();
+        tracker.take_before_snapshot("fn_a", LedgerSnapshot::new(), None);
+        tracker.take_after_snapshot(LedgerSnapshot::new(), false, None);
+
+        let copies = tracker.deep_copy_pairs();
+        assert_eq!(copies.len(), 1);
+        assert_eq!(copies[0].before.host_fn_name, "fn_a");
+        assert_eq!(copies[0].after.before_id, Some(copies[0].before.id));
+    }
+
+    #[test]
+    fn test_captured_snapshot_deep_copy_keeps_metadata() {
+        let mut state = LedgerSnapshot::new();
+        state.insert(vec![3], create_dummy_entry());
+        let captured = CapturedSnapshot {
+            id: SnapshotId(5),
+            host_fn_name: "storage_del".to_string(),
+            state,
+            before_id: Some(SnapshotId(4)),
+            trapped: true,
+        };
+
+        let copy = captured.deep_copy();
+        assert_eq!(copy.id, captured.id);
+        assert_eq!(copy.host_fn_name, captured.host_fn_name);
+        assert_eq!(copy.before_id, captured.before_id);
+        assert_eq!(copy.trapped, captured.trapped);
+        assert!(copy.state.get(&[3]).is_some());
+
+        // Independent state: mutating the copy leaves the original untouched.
+        let mut copy_mut = copy;
+        copy_mut.state.insert(vec![8], create_dummy_entry());
+        assert_eq!(copy_mut.state.len(), 2);
+        assert_eq!(captured.state.len(), 1);
+    }
+
+    /// Helper to build a small ledger entry for host.rs tests.
+    fn create_dummy_entry() -> soroban_env_host::xdr::LedgerEntry {
+        use soroban_env_host::xdr::{
+            AccountEntry, AccountId, LedgerEntry as LE, LedgerEntryData, PublicKey, SequenceNumber,
+            Thresholds, Uint256,
+        };
+        LE {
+            last_modified_ledger_seq: 1,
+            data: LedgerEntryData::Account(AccountEntry {
+                account_id: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([0u8; 32]))),
+                balance: 1000,
+                seq_num: SequenceNumber(1),
+                num_sub_entries: 0,
+                inflation_dest: None,
+                flags: 0,
+                home_domain: Default::default(),
+                thresholds: Thresholds([1, 0, 0, 0]),
+                signers: Default::default(),
+                ext: Default::default(),
+            }),
+            ext: Default::default(),
+        }
     }
 }

--- a/simulator/src/snapshot/mod.rs
+++ b/simulator/src/snapshot/mod.rs
@@ -519,6 +519,46 @@ impl LedgerSnapshot {
             delta: Arc::new(HashMap::new()),
         }
     }
+
+    /// Creates a fully independent deep copy of this snapshot.
+    ///
+    /// Unlike [`clone()`](Self::clone) and [`fork()`](Self::fork) — which share
+    /// the immutable base layer via `Arc` (copy-on-write) — `deep_copy`
+    /// materializes every live entry into a brand-new in-memory base owned
+    /// exclusively by the returned snapshot. The result shares **no** memory
+    /// with `self`: mutating either snapshot afterwards can never affect the
+    /// other, and dropping one does not retain or release the other's entries.
+    ///
+    /// This is the primitive time-travel debugging needs: it produces a perfect,
+    /// standalone clone of the ledger/Host memory state captured at a given
+    /// instruction pointer, safe to hold onto and mutate independently while the
+    /// live simulation continues to evolve.
+    ///
+    /// # Cost
+    ///
+    /// `O(n)` in the number of live entries (base merged with delta), decoding
+    /// every entry eagerly. For read-only sharing, prefer [`clone()`](Self::clone)
+    /// or [`fork()`](Self::fork).
+    pub fn deep_copy(&self) -> Self {
+        let mut entries = match &self.base {
+            BaseStore::InMemory(m) => (**m).clone(),
+            BaseStore::Mmap(m) => m.decode_all(),
+        };
+        for (key, value) in self.delta.iter() {
+            match value {
+                Some(entry) => {
+                    entries.insert(key.clone(), entry.clone());
+                }
+                None => {
+                    entries.remove(key);
+                }
+            }
+        }
+        Self {
+            base: BaseStore::InMemory(Arc::new(entries)),
+            delta: Arc::new(HashMap::new()),
+        }
+    }
 }
 
 impl Default for LedgerSnapshot {
@@ -1137,6 +1177,101 @@ mod tests {
         let mut snapshot = LedgerSnapshot::new();
         snapshot.delete(&[99]); // should not panic
         assert!(snapshot.is_empty());
+    }
+
+    // ------------------------------------------------------------------
+    // deep_copy tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_deep_copy_is_independent_after_insert() {
+        let mut original = LedgerSnapshot::new();
+        original.insert(vec![1], create_dummy_ledger_entry());
+
+        let copy = original.deep_copy();
+
+        // Mutating the copy must not affect the original...
+        let mut copy_mut = copy;
+        copy_mut.insert(vec![2], create_dummy_ledger_entry());
+        assert_eq!(copy_mut.len(), 2);
+        assert!(copy_mut.get(&[2]).is_some());
+
+        // ...and the original is untouched.
+        assert_eq!(original.len(), 1);
+        assert!(original.get(&[2]).is_none());
+    }
+
+    #[test]
+    fn test_deep_copy_merges_delta_and_tombstones() {
+        let mut original = LedgerSnapshot::new();
+        original.insert(vec![1], create_dummy_ledger_entry());
+        original.insert(vec![2], create_dummy_ledger_entry());
+
+        // Modify one entry and delete another so the copy has a non-empty delta.
+        let mut different = create_dummy_ledger_entry();
+        use soroban_env_host::xdr::{LedgerEntryData, SequenceNumber};
+        if let LedgerEntryData::Account(ref mut acc) = different.data {
+            acc.balance = 5555;
+        }
+        original.insert(vec![1], different);
+        original.delete(&[2]);
+
+        let copy = original.deep_copy();
+        // Copy has an empty delta: materialized base only.
+        assert_eq!(copy.len(), 1);
+        assert!(copy.get(&[1]).is_some());
+        assert!(copy.get(&[2]).is_none());
+
+        // The copy reflects the merged state at capture time.
+        let entry = copy.get(&[1]).expect("modified entry present");
+        use soroban_env_host::xdr::LedgerEntryData as LedData;
+        match entry.data {
+            LedData::Account(ref acc) => assert_eq!(acc.balance, 5555),
+            _ => panic!("unexpected entry type"),
+        }
+    }
+
+    #[test]
+    fn test_deep_copy_matches_iter_and_can_restore() {
+        let mut original = LedgerSnapshot::new();
+        original.insert(vec![1], create_dummy_ledger_entry());
+        original.insert(vec![2], create_dummy_ledger_entry());
+
+        let copy = original.deep_copy();
+
+        // Same number of live entries and identical content.
+        assert_eq!(copy.len(), original.len());
+        for (key, entry) in original.iter() {
+            let expected = entry.to_xdr(Limits::none()).unwrap();
+            let actual = copy.get(&key).unwrap().to_xdr(Limits::none()).unwrap();
+            assert_eq!(actual, expected, "entry mismatch for key {key:?}");
+        }
+    }
+
+    #[test]
+    fn test_deep_copy_of_mmap_snapshot_materializes() {
+        let mut snapshot = LedgerSnapshot::new();
+        for i in 0..3u8 {
+            snapshot.insert(vec![i], create_dummy_ledger_entry());
+        }
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("hintents-mmap-deepcopy-{}.bin", std::process::id()));
+        snapshot.to_mmap_file(&path).expect("write failed");
+        let mmap_snapshot = LedgerSnapshot::from_mmap_file(&path).expect("load failed");
+
+        let copy = mmap_snapshot.deep_copy();
+        assert_eq!(copy.len(), 3);
+        assert!(copy.get(&[0]).is_some());
+        assert!(copy.get(&[1]).is_some());
+        assert!(copy.get(&[2]).is_some());
+
+        // The copy is fully independent of the mmap-backed original.
+        let mut copy_mut = copy;
+        copy_mut.insert(vec![9], create_dummy_ledger_entry());
+        assert_eq!(copy_mut.len(), 4);
+        assert_eq!(mmap_snapshot.len(), 3);
+
+        let _ = std::fs::remove_file(&path);
     }
 
     // Helper function to create a dummy ledger entry for testing


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
<!-- Include motivation and context if resolving a specific issue -->

To support time-travel debugging, we need the ability to perfectly clone the Host memory state at a given instruction pointer. This PR implements deep-copying for the `Snapshot` model.

**Files changed:**
- `simulator/src/snapshot.rs` → `simulator/src/snapshot/mod.rs`
- `simulator/src/host.rs`

### Summary of changes

- Added `LedgerSnapshot::deep_copy()` — fully materializes every live entry into a brand-new in-memory base owned exclusively by the returned snapshot. Unlike `clone()`/`fork()` (which share the immutable base layer via `Arc` copy-on-write), `deep_copy` shares **no** memory with the source, so mutating either snapshot afterwards can never affect the other, and dropping one does not retain or release the other's entries. This is the primitive time-travel debugging needs to perfectly clone the Host memory state at a given instruction pointer while the live simulation continues to run.

- Wired deep-copying into the snapshot tracker in `simulator/src/host.rs`:
  - `CapturedSnapshot::deep_copy()` — deep-copies the captured ledger state while preserving snapshot metadata.
  - `SnapshotPair::deep_copy()` — deep-copies a full Before/After pair.
  - `HostSnapshotTracker::rewind_to()` now returns a **deep copy** of the state captured at the given instruction pointer, so callers can freely mutate or hold onto the result without affecting the tracker's own COW-shared snapshots.
  - `HostSnapshotTracker::rewind_to_snapshot()` — returns the full captured snapshot metadata along with a deep copy of the state.
  - `HostSnapshotTracker::deep_copy_pairs()` — returns a fully deep-copied history for long-lived time-travel debugging.

### Tests

Added tests covering:
- Deep-copy independence after insert (mutating the copy leaves the original untouched)
- Delta + tombstone merging into the materialized base
- Content parity with the source via `iter()`
- Mmap-backed snapshot materialization
- Tracker `rewind_to` deep-copy semantics (mutating the rewound copy does not affect the tracked pair)
- `rewind_to_snapshot` metadata preservation
- `deep_copy_pairs` independence
- `CapturedSnapshot::deep_copy` metadata retention + state independence

## Related Issues
<!-- Link to any related issues (e.g. "Fixes #123") -->

- Closes #1693

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chore / Maintenance

## Checklist
- [x] I have followed the guidelines in `CONTRIBUTING.md`.
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the documentation as needed.
- [x] My code passes all local formatting and linting checks (`go fmt`, `golangci-lint`, `cargo fmt`, `cargo clippy`).

## Screenshots / Terminal Output (if applicable)
<!-- If your changes affect the CLI output or UI, please provide screenshots or copy-pasted terminal output here. -->

Local verification:
- `cargo build -p erst-sim` — passes
- `cargo test snapshot::` — 48 passed, 0 failed
- `cargo test host::` — 15 passed, 0 failed
- `cargo clippy` — no new warnings
- `cargo fmt --check` — clean
