### PR TITLE
refactor(simulator): extract host configuration

### DIFF
--- a/simulator/Cargo.lock
+++ b/simulator/Cargo.lock
@@ -868,7 +868,7 @@ dependencies = [
  "libc",
  "libloading",
  "memmap2",
- "object",
+ "object 0.38.1",
  "once_cell",
  "pem-rfc7468",
  "pprof",

--- a/simulator/fuzz/fuzz_targets/simulate.rs
+++ b/simulator/fuzz/fuzz_targets/simulate.rs
@@ -34,7 +34,7 @@
 
 use erst_sim::metering::{check_budget, install_fuzz_limits};
 use erst_sim::metering::{MeteringLimits, RunGuard, TrackingAllocator};
-use erst_sim::runner::SimHost;
+use erst_sim::runner::{HostConfig, SimHost};
 use erst_sim::snapshot::{decode_ledger_entry, decode_ledger_key, LedgerSnapshot};
 use libfuzzer_sys::fuzz_target;
 use soroban_env_host::xdr::{FeeBumpTransactionInnerTx, Limits, Operation};
@@ -88,7 +88,10 @@ fn invoke_envelope(payload: &[u8], limits: &MeteringLimits, guard: &RunGuard<'_>
         return;
     };
 
-    let host = SimHost::new(Some(limits.budget_limits()), None, Some(limits.mem_bytes));
+    let config = HostConfig::default()
+        .with_budget_limits(Some(limits.budget_limits()))
+        .with_memory_limit(Some(limits.mem_bytes));
+    let host = SimHost::new(config);
 
     for operation in operations(&envelope) {
         if guard.check().is_err() {

--- a/simulator/src/context.rs
+++ b/simulator/src/context.rs
@@ -182,6 +182,7 @@ impl SimulationContext {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runner::HostConfig;
     use soroban_env_host::xdr::{
         ContractDataDurability, ContractDataEntry, ContractId, Hash, LedgerEntry, LedgerEntryData,
         LedgerEntryExt, LedgerKey, LedgerKeyContractData, Limits, ScAddress, ScVal, WriteXdr,
@@ -213,7 +214,7 @@ mod tests {
 
     #[test]
     fn rollback_to_restores_exact_snapshot_and_truncates_future_events() {
-        let host = SimHost::new(None, None, None);
+        let host = SimHost::new(HostConfig::default());
         let mut context = SimulationContext::new(host);
 
         let first_key = contract_data_key(7, 1);

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -22,6 +22,7 @@ mod vm;
 mod wasm;
 
 use crate::gas_optimizer::{BudgetMetrics, GasOptimizationAdvisor, CPU_LIMIT, MEMORY_LIMIT};
+use crate::runner::HostConfig;
 use crate::source_mapper::SourceMapper;
 use crate::stack_trace::WasmStackTrace;
 use crate::types::*;
@@ -588,11 +589,10 @@ fn main() {
     };
 
     // Initialize Host
-    let mut sim_host = runner::SimHost::new(
-        None,
-        request.resource_calibration.clone(),
-        request.memory_limit,
-    );
+    let host_config = HostConfig::default()
+        .with_calibration(request.resource_calibration.clone())
+        .with_memory_limit(request.memory_limit);
+    let mut sim_host = runner::SimHost::new(host_config);
 
     // --- START: Local WASM Loading Integration (Issue #70) ---
     if let Some(path) = &request.wasm_path {
@@ -1662,7 +1662,7 @@ mod tests {
             STANDARD.encode(entry.to_xdr(soroban_env_host::xdr::Limits::none()).unwrap()),
         );
 
-        let mut sim_host = runner::SimHost::new(None, None, None);
+        let mut sim_host = runner::SimHost::new(HostConfig::default());
         let count = load_ledger_entries(&mut sim_host, &entries).expect("failed to load entries");
         assert_eq!(count, 1);
     }

--- a/simulator/src/main_test.rs
+++ b/simulator/src/main_test.rs
@@ -75,7 +75,7 @@ mod restore_preamble_tests {
             pprof_output_path: None,
         };
         // Simulate main logic: inject restore_preamble into host storage
-        let sim_host = crate::runner::SimHost::new(None, None, None);
+        let sim_host = crate::runner::SimHost::new(crate::runner::HostConfig::default());
         let host = sim_host.inner;
         if let Some(ref preamble) = req.restore_preamble {
             if let Some(obj) = preamble.as_object() {

--- a/simulator/src/memory_limit_test.rs
+++ b/simulator/src/memory_limit_test.rs
@@ -10,12 +10,12 @@
 #[cfg(test)]
 mod tests {
     use crate::host::AllocTracker;
-    use crate::runner::SimHost;
+    use crate::runner::{HostConfig, SimHost};
 
     #[test]
     fn test_no_memory_limit() {
         // SimHost can be created without any memory limit.
-        let host = SimHost::new(None, None, None);
+        let host = SimHost::new(HostConfig::default());
         host.check_memory_limit(); // should not panic
     }
 
@@ -23,20 +23,20 @@ mod tests {
     fn test_memory_limit_within_bounds_no_panic() {
         // With a small-but-positive limit and zero consumed bytes, the check
         // should not panic.
-        let host = SimHost::new(None, None, Some(1));
+        let host = SimHost::new(HostConfig::default().with_memory_limit(Some(1)));
         host.check_memory_limit();
     }
 
     #[test]
     fn test_memory_limit_large_limit_no_panic() {
-        let host = SimHost::new(None, None, Some(1_000_000));
+        let host = SimHost::new(HostConfig::default().with_memory_limit(Some(1_000_000)));
         host.check_memory_limit();
     }
 
     #[test]
     fn test_memory_limit_check_called_on_fresh_host() {
         // The method must be callable immediately after construction.
-        let host = SimHost::new(None, None, Some(1024));
+        let host = SimHost::new(HostConfig::default().with_memory_limit(Some(1024)));
         host.check_memory_limit();
     }
 
@@ -44,7 +44,7 @@ mod tests {
     fn test_memory_limit_after_snapshot_restore() {
         // After restore_from_snapshot, the memory limit should still be
         // applied to the new Host.
-        let mut host = SimHost::new(None, None, Some(1024));
+        let mut host = SimHost::new(HostConfig::default().with_memory_limit(Some(1024)));
         let snapshot = host.capture_snapshot().expect("snapshot should capture");
         host.restore_from_snapshot(&snapshot)
             .expect("restore should succeed");
@@ -53,7 +53,7 @@ mod tests {
 
     #[test]
     fn test_memory_limit_preserved_across_repeated_restores() {
-        let mut host = SimHost::new(None, None, Some(1024));
+        let mut host = SimHost::new(HostConfig::default().with_memory_limit(Some(1024)));
         for _ in 0..5 {
             let snapshot = host.capture_snapshot().expect("snapshot should capture");
             host.restore_from_snapshot(&snapshot)

--- a/simulator/src/runner.rs
+++ b/simulator/src/runner.rs
@@ -25,12 +25,42 @@ pub enum SimHostError {
     Panic(String),
 }
 
-pub struct SimHost {
-    pub inner: Host,
-    ledger_snapshot: LedgerSnapshot,
+#[derive(Debug, Clone, Default)]
+pub struct HostConfig {
     budget_limits: Option<(u64, u64)>,
     calibration: Option<crate::types::ResourceCalibration>,
     memory_limit: Option<u64>,
+}
+
+impl HostConfig {
+    // The budget-specific builder is also used by the standalone fuzz target.
+    #[allow(dead_code)]
+    #[must_use]
+    pub fn with_budget_limits(mut self, budget_limits: Option<(u64, u64)>) -> Self {
+        self.budget_limits = budget_limits;
+        self
+    }
+
+    #[must_use]
+    pub fn with_calibration(
+        mut self,
+        calibration: Option<crate::types::ResourceCalibration>,
+    ) -> Self {
+        self.calibration = calibration;
+        self
+    }
+
+    #[must_use]
+    pub fn with_memory_limit(mut self, memory_limit: Option<u64>) -> Self {
+        self.memory_limit = memory_limit;
+        self
+    }
+}
+
+pub struct SimHost {
+    pub inner: Host,
+    ledger_snapshot: LedgerSnapshot,
+    config: HostConfig,
     pending_events: Vec<String>,
 }
 
@@ -68,23 +98,15 @@ impl SimHost {
     /// Initialize a new Host with optional budget settings and resource calibration.
     #[instrument(
         level = "debug",
-        fields(
-            budget_limits = ?budget_limits,
-            calibration = ?calibration,
-            memory_limit = ?memory_limit
-        )
+        fields(config = ?config)
     )]
-    pub fn new(
-        budget_limits: Option<(u64, u64)>,
-        calibration: Option<crate::types::ResourceCalibration>,
-        memory_limit: Option<u64>,
-    ) -> Self {
+    pub fn new(config: HostConfig) -> Self {
         debug!("initializing simulator host");
         let budget = Budget::default();
 
-        if let Some((cpu, mem)) = budget_limits {
+        if let Some((cpu, mem)) = config.budget_limits {
             let _ = budget.reset_limits(cpu, mem);
-        } else if let Some(mem) = memory_limit {
+        } else if let Some(mem) = config.memory_limit {
             // soroban sdk uses u32::MAX for no limit but casted to u64, or u64::MAX.
             let _ = budget.reset_unlimited();
             let _ = budget.reset_limits(
@@ -107,9 +129,7 @@ impl SimHost {
         Self {
             inner: host,
             ledger_snapshot: LedgerSnapshot::new(),
-            budget_limits,
-            calibration,
-            memory_limit,
+            config,
             pending_events: Vec::new(),
         }
     }
@@ -117,25 +137,18 @@ impl SimHost {
     /// Creates a new host initialized with the provided snapshot contents.
     #[instrument(
         level = "debug",
-        fields(
-            budget_limits = ?budget_limits,
-            calibration = ?calibration,
-            memory_limit = ?memory_limit,
-            snapshot_len = snapshot.len()
-        )
+        fields(config = ?config, snapshot_len = snapshot.len())
     )]
     pub fn from_snapshot(
-        budget_limits: Option<(u64, u64)>,
-        calibration: Option<crate::types::ResourceCalibration>,
-        memory_limit: Option<u64>,
+        config: HostConfig,
         snapshot: &LedgerSnapshot,
     ) -> Result<Self, SimHostError> {
         debug!("restoring simulator host from snapshot");
         let budget = Budget::default();
 
-        if let Some((cpu, mem)) = budget_limits {
+        if let Some((cpu, mem)) = config.budget_limits {
             let _ = budget.reset_limits(cpu, mem);
-        } else if let Some(mem) = memory_limit {
+        } else if let Some(mem) = config.memory_limit {
             let _ = budget.reset_unlimited();
             let _ = budget.reset_limits(
                 budget
@@ -155,9 +168,7 @@ impl SimHost {
         Ok(Self {
             inner: host,
             ledger_snapshot: snapshot.fork(),
-            budget_limits,
-            calibration,
-            memory_limit,
+            config,
             pending_events: Vec::new(),
         })
     }
@@ -169,7 +180,7 @@ impl SimHost {
     /// Panics with `ERR_MEMORY_LIMIT_EXCEEDED` when the Budget reports more
     /// memory consumed than the configured `memory_limit`.
     pub fn check_memory_limit(&self) {
-        if let Some(limit) = self.memory_limit {
+        if let Some(limit) = self.config.memory_limit {
             if let Ok(consumed) = self.inner.budget_cloned().get_mem_bytes_consumed() {
                 memory::check_memory_limit(consumed, limit);
             }
@@ -195,12 +206,7 @@ impl SimHost {
     #[instrument(level = "debug", fields(snapshot_len = snapshot.len()), skip(self))]
     pub fn restore_from_snapshot(&mut self, snapshot: &LedgerSnapshot) -> Result<(), SimHostError> {
         debug!("restoring current host from snapshot");
-        let restored = Self::from_snapshot(
-            self.budget_limits,
-            self.calibration.clone(),
-            self.memory_limit,
-            snapshot,
-        )?;
+        let restored = Self::from_snapshot(self.config.clone(), snapshot)?;
         // `*self = restored` drops the old SimHost (including the old Soroban Host
         // and its Budget) and moves the freshly-constructed SimHost into place.
         // The old Host's Drop impl frees all its allocations — this is the key
@@ -338,8 +344,8 @@ impl Drop for SimHost {
         // We use std::mem::take to clear it without causing a double borrow
         let _ = std::mem::take(&mut self.ledger_snapshot);
 
-        // Note: budget_limits, calibration, and memory_limit are simple types
-        // that don't require explicit cleanup
+        // HostConfig contains only configuration values and does not require
+        // explicit cleanup.
     }
 }
 
@@ -354,14 +360,14 @@ mod tests {
 
     #[test]
     fn test_host_initialization() {
-        let host = SimHost::new(None, None, None);
+        let host = SimHost::new(HostConfig::default());
         // Basic assertion that host is functional
         assert!(host.inner.budget_cloned().get_cpu_insns_consumed().is_ok());
     }
 
     #[test]
     fn test_panic_recovery_wraps_host_execution() {
-        let host = SimHost::new(None, None, None);
+        let host = SimHost::new(HostConfig::default());
         let result = host.with_panic_recovery(|| panic!("memory violation"));
 
         assert!(
@@ -371,7 +377,7 @@ mod tests {
 
     #[test]
     fn test_configuration() {
-        let mut host = SimHost::new(None, None, None);
+        let mut host = SimHost::new(HostConfig::default());
         // Test setting contract ID (dummy hash)
         let hash = Hash([0u8; 32]);
         host.set_contract_id(hash);
@@ -382,7 +388,7 @@ mod tests {
 
     #[test]
     fn test_simple_value_handling() {
-        let host = SimHost::new(None, None, None);
+        let host = SimHost::new(HostConfig::default());
 
         let val_a = host.val_from_u32(10);
         let val_b = host.val_from_u32(20);
@@ -395,7 +401,7 @@ mod tests {
 
     #[test]
     fn test_restore_from_snapshot_replaces_mutated_storage_and_clears_host_events() {
-        let mut host = SimHost::new(None, None, None);
+        let mut host = SimHost::new(HostConfig::default());
         let first_key = Rc::new(LedgerKey::ContractData(LedgerKeyContractData {
             contract: ScAddress::Contract(ContractId(Hash([1u8; 32]))),
             key: ScVal::U32(1),

--- a/simulator/src/simulator_safety_test.rs
+++ b/simulator/src/simulator_safety_test.rs
@@ -279,7 +279,7 @@ fn main() {
     };
 
     // Initialize Host
-    let sim_host = runner::SimHost::new(None);
+    let sim_host = runner::SimHost::new(runner::HostConfig::default());
     let host = sim_host.inner;
 
     let mut loaded_entries_count = 0;

--- a/simulator/src/test.rs
+++ b/simulator/src/test.rs
@@ -492,7 +492,7 @@ mod contract_execution_tests {
 
         // Create empty operations vector
         let operations: VecM<Operation, 100> = VecM::default();
-        let sim_host = crate::runner::SimHost::new(None, None, None);
+        let sim_host = crate::runner::SimHost::new(crate::runner::HostConfig::default());
         let mut coverage = CoverageTracker::default();
 
         // Should succeed with empty operations


### PR DESCRIPTION
Closes #1655 

Refactored the simulator so Host settings are grouped into a dedicated HostConfig builder instead of being passed as several optional arguments.
Updated host creation, snapshot restoration, tests, and the fuzz target to use the new configuration. Verified everything with formatting, Clippy, and the full simulator test suite.

@dotandev 