### PR TITLE
feat(trace): upgrade TUI search from exact-match to fuzzy-finding

### DIFF
--- a/internal/trace/model.go
+++ b/internal/trace/model.go
@@ -431,19 +431,29 @@ func (m *Model) resetPanel() {
 
 func (m *Model) buildSearchMatches() {
 	m.searchMatches = nil
-	q := strings.ToLower(m.searchQuery)
-	if q == "" {
+	if m.searchQuery == "" {
 		return
 	}
 	for i := range m.trace.States {
 		s := &m.trace.States[i]
-		if strings.Contains(strings.ToLower(s.Operation), q) ||
-			strings.Contains(strings.ToLower(s.ContractID), q) ||
-			strings.Contains(strings.ToLower(s.Function), q) ||
-			strings.Contains(strings.ToLower(s.Error), q) {
+		if fuzzyMatchAny(m.searchQuery, s.Operation, s.ContractID, s.Function, s.Error) {
 			m.searchMatches = append(m.searchMatches, i)
 		}
 	}
+}
+
+// fuzzyMatchAny returns true if query fuzzy-matches any of the given fields.
+func fuzzyMatchAny(query string, fields ...string) bool {
+	for _, f := range fields {
+		if f == "" {
+			continue
+		}
+		score, _ := FuzzyMatch(query, f, false)
+		if score >= 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func (m Model) nextMatch() (Model, tea.Cmd) {


### PR DESCRIPTION
## Summary

Upgrade the current exact-match search in the TUI to use fuzzy-finding (ctrl+p style).

## Changes

- Replaced exact substring matching (`strings.Contains`) in `buildSearchMatches()` with the existing `FuzzyMatch` function
- Added `fuzzyMatchAny` helper that checks if a query fuzzy-matches any of the given fields
- Maintains backward compatibility with case-insensitive matching

## Implementation Details

The `buildSearchMatches()` function in `internal/trace/model.go` now uses the existing `FuzzyMatch` function from `fuzzy.go` instead of `strings.Contains`. This enables fuzzy searching where users can type partial or abbreviated queries to find trace events.

Example: typing "tst" will now match "test", "testing", "contest" etc.

## Testing

- Existing search tests continue to pass
- Fuzzy matching is already tested in `fuzzy_test.go` and `search_test.go`
- No new dependencies added

## Related

Closes #1717
