### PR TITLE
feat(sim): implement Snapshot deep-copying for Host memory states

### DIFF
--- a/simulator/src/host.rs
+++ b/simulator/src/host.rs
@@ -1,31 +1,53 @@
 // Copyright 2026 Erst Users
 // SPDX-License-Identifier: Apache-2.0
 
-//! Before/After snapshot capture around host function calls.
+//! SimHost: Host memory state management and snapshot infrastructure.
 //!
-//! Every host function invocation produces a paired snapshot:
-//! - **Before**: the ledger state immediately prior to the call
-//! - **After**: the ledger state immediately after the call returns
+//! This module owns the full runtime state of a simulated Soroban host at
+//! every instruction boundary. It provides:
 //!
-//! If the host function traps, the After snapshot is still recorded with
-//! `trapped = true` so callers can inspect the state at the point of failure.
+//! - [`HostMemoryState`]: A complete, deep-copyable snapshot of all mutable
+//!   host state at a given instruction pointer. Used by the time-travel
+//!   debugger to jump back to any previously observed execution point.
 //!
-//! # Allocator Safety
+//! - [`CapturedSnapshot`]: A single ledger-state snapshot with metadata
+//!   (host function name, snapshot ID, trap flag).
 //!
-//! The [`HostSnapshotTracker`] optionally integrates an [`AllocTracker`] that
-//! records the `Budget` memory consumption at each before-snapshot and validates
-//! consistency after rollback.
+//! - [`SnapshotPair`]: A before/after pair around one host function call.
+//!
+//! - [`HostSnapshotTracker`]: Manages sequential capture of snapshot pairs
+//!   across a full transaction execution.
+//!
+//! - [`AllocTracker`]: Records Budget memory consumption across
+//!   snapshot/rollback cycles so allocator consistency can be validated.
+//!
+//! # Deep Copying vs Forking
+//!
+//! `clone()` on a [`crate::snapshot::LedgerSnapshot`] shares the underlying
+//! `Arc`-wrapped allocations (shallow clone). `fork()` merges delta into a
+//! new shared base — still Arc-shared. **`deep_copy()`** materializes every
+//! live entry into a brand-new allocation: the copy and the original share
+//! nothing.
+//!
+//! Always use `deep_copy()` when capturing a checkpoint for time-travel; use
+//! `fork()` for rollback-optimised COW derivation; use `clone()` for cheap
+//! read-sharing when neither needs to mutate independently.
 
 #![allow(dead_code)]
 
 use crate::snapshot::LedgerSnapshot;
 use std::fmt;
 
+// ---------------------------------------------------------------------------
+// SnapshotId
+// ---------------------------------------------------------------------------
+
 /// Unique identifier for a snapshot.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SnapshotId(u64);
 
 impl SnapshotId {
+    /// Returns the raw numeric value of this ID.
     pub fn as_u64(self) -> u64 {
         self.0
     }
@@ -37,16 +59,11 @@ impl fmt::Display for SnapshotId {
     }
 }
 
-/// A paired Before/After snapshot around a single host function call.
-#[derive(Debug, Clone)]
-pub struct SnapshotPair {
-    /// Snapshot taken before the host function executes.
-    pub before: CapturedSnapshot,
-    /// Snapshot taken after the host function returns (or traps).
-    pub after: CapturedSnapshot,
-}
+// ---------------------------------------------------------------------------
+// CapturedSnapshot
+// ---------------------------------------------------------------------------
 
-/// A single captured snapshot with metadata.
+/// A single captured ledger-state snapshot with execution metadata.
 #[derive(Debug, Clone)]
 pub struct CapturedSnapshot {
     /// Unique identifier for this snapshot.
@@ -61,11 +78,124 @@ pub struct CapturedSnapshot {
     pub trapped: bool,
 }
 
+impl CapturedSnapshot {
+    /// Returns a fully independent deep copy of this `CapturedSnapshot`.
+    ///
+    /// The returned value shares **no** allocations with `self`. Mutating the
+    /// copy's `state` will not affect `self.state`, and vice-versa.
+    ///
+    /// Metadata fields (`id`, `host_fn_name`, `before_id`, `trapped`) are
+    /// cheaply cloned via their standard `Clone` impl.
+    pub fn deep_copy(&self) -> Self {
+        Self {
+            id: self.id,
+            host_fn_name: self.host_fn_name.clone(),
+            state: self.state.deep_copy(),
+            before_id: self.before_id,
+            trapped: self.trapped,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SnapshotPair
+// ---------------------------------------------------------------------------
+
+/// A paired Before/After snapshot around a single host function call.
+#[derive(Debug, Clone)]
+pub struct SnapshotPair {
+    /// Snapshot taken before the host function executes.
+    pub before: CapturedSnapshot,
+    /// Snapshot taken after the host function returns (or traps).
+    pub after: CapturedSnapshot,
+}
+
+impl SnapshotPair {
+    /// Returns a fully independent deep copy of this `SnapshotPair`.
+    ///
+    /// Both `before` and `after` are deep-copied; neither shares any
+    /// allocation with the corresponding field in `self`.
+    pub fn deep_copy(&self) -> Self {
+        Self {
+            before: self.before.deep_copy(),
+            after: self.after.deep_copy(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HostMemoryState
+// ---------------------------------------------------------------------------
+
+/// Complete, deep-copyable state of the simulated host at a given instruction
+/// pointer.
+///
+/// A [`HostMemoryState`] is the primary unit exchanged by the time-travel
+/// engine: capturing one at instruction *N* and restoring it later resets
+/// the simulation to exactly the memory layout it had at that point.
+///
+/// # Isolation guarantee
+///
+/// Every field that contains heap-allocated data is **deep-copied** when the
+/// struct is constructed via [`HostMemoryState::capture`] or cloned via
+/// [`HostMemoryState::deep_copy`].  There is no Arc-sharing between a
+/// checkpoint and the live host: mutations to the live host after a checkpoint
+/// are invisible to the checkpoint, and restoring a checkpoint does not modify
+/// the live host's allocations.
+#[derive(Debug, Clone)]
+pub struct HostMemoryState {
+    /// The WASM instruction pointer at the moment of capture.
+    pub instruction_pointer: u32,
+    /// The ledger state at the moment of capture — deeply owned.
+    pub ledger_state: LedgerSnapshot,
+    /// The host function being executed when this state was captured.
+    pub host_fn_name: String,
+    /// Whether the host trapped immediately before/after this capture.
+    pub trapped: bool,
+}
+
+impl HostMemoryState {
+    /// Captures the current host memory state at `instruction_pointer`.
+    ///
+    /// `ledger_state` is **deep-copied** so the returned value is independent
+    /// of the live host regardless of subsequent mutations.
+    pub fn capture(
+        instruction_pointer: u32,
+        ledger_state: &LedgerSnapshot,
+        host_fn_name: &str,
+        trapped: bool,
+    ) -> Self {
+        Self {
+            instruction_pointer,
+            ledger_state: ledger_state.deep_copy(),
+            host_fn_name: host_fn_name.to_string(),
+            trapped,
+        }
+    }
+
+    /// Returns a fully independent deep copy of this `HostMemoryState`.
+    ///
+    /// Equivalent to calling `capture(…)` with each field, but avoids
+    /// re-encoding the host function name.
+    pub fn deep_copy(&self) -> Self {
+        Self {
+            instruction_pointer: self.instruction_pointer,
+            ledger_state: self.ledger_state.deep_copy(),
+            host_fn_name: self.host_fn_name.clone(),
+            trapped: self.trapped,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AllocTracker
+// ---------------------------------------------------------------------------
+
 /// Tracks allocator state across snapshot-and-rollback cycles.
 ///
-/// Each snapshot checkpoint records the `Budget` memory consumption at that point.
-/// A subsequent rollback resets the expected baseline; the tracker verifies that
-/// the new `Host` starts with the correct allocator state.
+/// Each snapshot checkpoint records the `Budget` memory consumption at that
+/// point. A subsequent rollback resets the expected baseline; the tracker
+/// verifies that the new `Host` starts with the correct allocator state.
 ///
 /// # Debug-mode invariant checks
 ///
@@ -99,7 +229,7 @@ impl AllocTracker {
     ///
     /// # Arguments
     /// * `memory_bytes` – The current Budget memory consumption
-    ///   (obtained via [`Budget::get_mem_bytes_consumed`]).
+    ///   (obtained via `Budget::get_mem_bytes_consumed`).
     pub fn snapshot(&mut self, memory_bytes: u64) {
         self.snapshotted_memory_bytes = memory_bytes;
         self.snapshot_count = self.snapshot_count.saturating_add(1);
@@ -115,8 +245,9 @@ impl AllocTracker {
     /// and the new `Host` is in place.
     ///
     /// # Arguments
-    /// * `restored_memory_bytes` – The memory consumption of the newly restored
-    ///   `Host`'s Budget (expected to be 0 after a fresh construction).
+    /// * `restored_memory_bytes` – The memory consumption of the newly
+    ///   restored `Host`'s Budget (expected to be 0 after a fresh
+    ///   construction).
     pub fn record_rollback(&mut self, restored_memory_bytes: u64) {
         self.rollback_count = self.rollback_count.saturating_add(1);
         // The restored Host has a fresh Budget — consumption should be zero.
@@ -158,7 +289,17 @@ impl Default for AllocTracker {
     }
 }
 
+// ---------------------------------------------------------------------------
+// HostSnapshotTracker
+// ---------------------------------------------------------------------------
+
 /// Manages snapshot capture around host function calls.
+///
+/// Records sequential [`SnapshotPair`]s as a transaction executes.  The
+/// tracker also exposes [`HostSnapshotTracker::deep_copy_at`] for the
+/// time-travel engine: given an instruction pointer it returns a
+/// [`HostMemoryState`] that is fully independent of the tracker's internal
+/// storage.
 pub struct HostSnapshotTracker {
     next_id: u64,
     pairs: Vec<SnapshotPair>,
@@ -201,7 +342,7 @@ impl HostSnapshotTracker {
         self.alloc_tracker.as_mut()
     }
 
-    /// Allocate the next snapshot ID.
+    /// Allocates the next snapshot ID.
     fn next_snapshot_id(&mut self) -> SnapshotId {
         let id = SnapshotId(self.next_id);
         self.next_id += 1;
@@ -296,10 +437,38 @@ impl HostSnapshotTracker {
         self.pending_before.take()
     }
 
+    /// Returns a deep copy of the [`HostMemoryState`] at `instruction_pointer`.
+    ///
+    /// Searches the recorded pairs for a before-snapshot whose ID matches
+    /// `instruction_pointer`. If found, every allocation in the snapshot is
+    /// independently copied before it is returned — the result shares nothing
+    /// with the tracker's internal storage, satisfying the time-travel
+    /// isolation invariant.
+    ///
+    /// Returns `None` if `instruction_pointer` does not correspond to any
+    /// recorded before-snapshot.
+    pub fn deep_copy_at(&self, instruction_pointer: u32) -> Option<HostMemoryState> {
+        for pair in &self.pairs {
+            if pair.before.id.as_u64() == u64::from(instruction_pointer) {
+                return Some(HostMemoryState::capture(
+                    instruction_pointer,
+                    &pair.before.state,
+                    &pair.before.host_fn_name,
+                    pair.before.trapped,
+                ));
+            }
+        }
+        None
+    }
+
     /// Rewinds the tracker to a specific instruction pointer.
+    ///
+    /// Returns a **shallow clone** of the before-snapshot at that point.
+    /// Prefer [`deep_copy_at`](Self::deep_copy_at) when the caller needs
+    /// mutation isolation.
     pub fn rewind_to(&mut self, instruction_pointer: u32) -> Option<LedgerSnapshot> {
         for pair in &self.pairs {
-            if pair.before.id.as_u64() == instruction_pointer as u64 {
+            if pair.before.id.as_u64() == u64::from(instruction_pointer) {
                 return Some(pair.before.state.clone());
             }
         }
@@ -313,6 +482,10 @@ impl Default for HostSnapshotTracker {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -320,6 +493,41 @@ mod tests {
     fn empty_snapshot() -> LedgerSnapshot {
         LedgerSnapshot::new()
     }
+
+    /// Build a snapshot with `n` entries keyed by sequential bytes.
+    fn populated_snapshot(n: u8) -> LedgerSnapshot {
+        use soroban_env_host::xdr::{
+            AccountEntry, AccountId, LedgerEntry, LedgerEntryData, PublicKey, SequenceNumber,
+            Thresholds, Uint256,
+        };
+
+        let mut snap = LedgerSnapshot::new();
+        for i in 0..n {
+            let account_id = AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([i; 32])));
+            let entry = LedgerEntry {
+                last_modified_ledger_seq: u32::from(i),
+                data: LedgerEntryData::Account(AccountEntry {
+                    account_id,
+                    balance: i64::from(i) * 1000,
+                    seq_num: SequenceNumber(i64::from(i)),
+                    num_sub_entries: 0,
+                    inflation_dest: None,
+                    flags: 0,
+                    home_domain: Default::default(),
+                    thresholds: Thresholds([1, 0, 0, 0]),
+                    signers: Default::default(),
+                    ext: Default::default(),
+                }),
+                ext: Default::default(),
+            };
+            snap.insert(vec![i], entry);
+        }
+        snap
+    }
+
+    // ------------------------------------------------------------------
+    // HostSnapshotTracker — existing behaviour (regression guard)
+    // ------------------------------------------------------------------
 
     #[test]
     fn test_basic_before_after_pair() {
@@ -397,7 +605,6 @@ mod tests {
             .flat_map(|p| [p.before.id, p.after.id])
             .collect();
 
-        // All IDs must be distinct
         for (i, a) in all_ids.iter().enumerate() {
             for b in &all_ids[i + 1..] {
                 assert_ne!(a, b, "snapshot IDs must be unique");
@@ -443,11 +650,9 @@ mod tests {
         let alloc_tracker = AllocTracker::new();
         let mut tracker = HostSnapshotTracker::with_alloc_tracker(alloc_tracker);
 
-        // Cycle 1
         tracker.take_before_snapshot("fn1", empty_snapshot(), Some(100));
         tracker.take_after_snapshot(empty_snapshot(), false, Some(0));
 
-        // Cycle 2
         tracker.take_before_snapshot("fn2", empty_snapshot(), Some(200));
         tracker.take_after_snapshot(empty_snapshot(), false, Some(0));
 
@@ -459,7 +664,6 @@ mod tests {
 
     #[test]
     fn test_tracker_without_memory_records_no_error() {
-        // When no memory_bytes is provided, the alloc tracker should not record
         let alloc_tracker = AllocTracker::new();
         let mut tracker = HostSnapshotTracker::with_alloc_tracker(alloc_tracker);
 
@@ -481,6 +685,218 @@ mod tests {
     #[test]
     fn test_snapshot_id_display() {
         let id = SnapshotId(42);
-        assert_eq!(format!("{}", id), "snap-42");
+        assert_eq!(format!("{id}"), "snap-42");
+    }
+
+    // ------------------------------------------------------------------
+    // deep_copy isolation invariant
+    // ------------------------------------------------------------------
+
+    /// Core isolation test: mutating the original after deep_copy must not
+    /// affect the copy, and mutating the copy must not affect the original.
+    #[test]
+    fn test_ledger_snapshot_deep_copy_is_isolated() {
+        let original = populated_snapshot(4);
+        let copy = original.deep_copy();
+
+        // Both start with the same entries.
+        assert_eq!(original.len(), copy.len());
+
+        // Insert a new key into the original — the copy must be unaffected.
+        let mut mutated_original = original;
+        mutated_original.insert(vec![0xAA], {
+            use soroban_env_host::xdr::{
+                AccountEntry, AccountId, LedgerEntry, LedgerEntryData, PublicKey, SequenceNumber,
+                Thresholds, Uint256,
+            };
+            LedgerEntry {
+                last_modified_ledger_seq: 99,
+                data: LedgerEntryData::Account(AccountEntry {
+                    account_id: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([0xAA; 32]))),
+                    balance: 9999,
+                    seq_num: SequenceNumber(99),
+                    num_sub_entries: 0,
+                    inflation_dest: None,
+                    flags: 0,
+                    home_domain: Default::default(),
+                    thresholds: Thresholds([1, 0, 0, 0]),
+                    signers: Default::default(),
+                    ext: Default::default(),
+                }),
+                ext: Default::default(),
+            }
+        });
+
+        // copy must still have only the original 4 entries.
+        assert_eq!(copy.len(), 4, "deep copy was affected by mutation of original");
+        assert!(copy.get(&[0xAA]).is_none(), "deep copy saw a key inserted after the copy");
+    }
+
+    /// Mutating the copy must not affect the original.
+    #[test]
+    fn test_ledger_snapshot_deep_copy_mutation_of_copy_does_not_affect_original() {
+        let original = populated_snapshot(3);
+        let mut copy = original.deep_copy();
+
+        // Delete key [0] from the copy.
+        copy.delete(&[0]);
+
+        // Original must still have 3 entries.
+        assert_eq!(original.len(), 3, "original was affected by deletion in copy");
+        assert!(original.get(&[0]).is_some(), "original lost entry after copy was mutated");
+    }
+
+    /// `CapturedSnapshot::deep_copy` produces an isolated ledger state.
+    #[test]
+    fn test_captured_snapshot_deep_copy_is_isolated() {
+        let state = populated_snapshot(2);
+        let original = CapturedSnapshot {
+            id: SnapshotId(1),
+            host_fn_name: "test_fn".to_string(),
+            state,
+            before_id: None,
+            trapped: false,
+        };
+
+        let mut copy = original.deep_copy();
+        copy.state.insert(vec![0xFF], {
+            use soroban_env_host::xdr::{
+                AccountEntry, AccountId, LedgerEntry, LedgerEntryData, PublicKey, SequenceNumber,
+                Thresholds, Uint256,
+            };
+            LedgerEntry {
+                last_modified_ledger_seq: 1,
+                data: LedgerEntryData::Account(AccountEntry {
+                    account_id: AccountId(PublicKey::PublicKeyTypeEd25519(Uint256([0xFF; 32]))),
+                    balance: 1,
+                    seq_num: SequenceNumber(1),
+                    num_sub_entries: 0,
+                    inflation_dest: None,
+                    flags: 0,
+                    home_domain: Default::default(),
+                    thresholds: Thresholds([1, 0, 0, 0]),
+                    signers: Default::default(),
+                    ext: Default::default(),
+                }),
+                ext: Default::default(),
+            }
+        });
+
+        assert_eq!(
+            original.state.len(),
+            2,
+            "original CapturedSnapshot.state was affected by copy mutation"
+        );
+    }
+
+    /// `SnapshotPair::deep_copy` deep-copies both before and after.
+    #[test]
+    fn test_snapshot_pair_deep_copy_both_sides_isolated() {
+        let state_before = populated_snapshot(2);
+        let state_after = populated_snapshot(3);
+
+        let before = CapturedSnapshot {
+            id: SnapshotId(0),
+            host_fn_name: "put".to_string(),
+            state: state_before,
+            before_id: None,
+            trapped: false,
+        };
+        let after = CapturedSnapshot {
+            id: SnapshotId(1),
+            host_fn_name: "put".to_string(),
+            state: state_after,
+            before_id: Some(SnapshotId(0)),
+            trapped: false,
+        };
+
+        let pair = SnapshotPair { before, after };
+        let mut copy = pair.deep_copy();
+
+        // Mutate both sides of the copy.
+        copy.before.state.delete(&[0]);
+        copy.after.state.delete(&[0]);
+        copy.after.state.delete(&[1]);
+
+        // Originals must be unaffected.
+        assert_eq!(pair.before.state.len(), 2, "pair.before.state was mutated through deep copy");
+        assert_eq!(pair.after.state.len(), 3, "pair.after.state was mutated through deep copy");
+    }
+
+    /// `HostMemoryState::capture` deep-copies the passed-in state.
+    #[test]
+    fn test_host_memory_state_capture_is_independent() {
+        let mut live_state = populated_snapshot(5);
+        let checkpoint = HostMemoryState::capture(42, &live_state, "contract_call", false);
+
+        // Mutate live state after capture.
+        live_state.delete(&[0]);
+        live_state.delete(&[1]);
+
+        // Checkpoint must still have all 5 entries.
+        assert_eq!(
+            checkpoint.ledger_state.len(),
+            5,
+            "HostMemoryState.ledger_state was affected by mutations after capture"
+        );
+        assert_eq!(checkpoint.instruction_pointer, 42);
+        assert_eq!(checkpoint.host_fn_name, "contract_call");
+        assert!(!checkpoint.trapped);
+    }
+
+    /// `HostMemoryState::deep_copy` returns a second independent copy.
+    #[test]
+    fn test_host_memory_state_deep_copy_is_independent() {
+        let state = populated_snapshot(3);
+        let original = HostMemoryState::capture(7, &state, "fn_x", false);
+        let mut copy = original.deep_copy();
+
+        copy.ledger_state.delete(&[0]);
+
+        assert_eq!(
+            original.ledger_state.len(),
+            3,
+            "HostMemoryState deep copy affected original"
+        );
+    }
+
+    /// `HostSnapshotTracker::deep_copy_at` returns an isolated checkpoint.
+    #[test]
+    fn test_tracker_deep_copy_at_is_isolated() {
+        let mut tracker = HostSnapshotTracker::new();
+
+        // Snapshot 0 — before ID = 0.
+        let state_before = populated_snapshot(3);
+        tracker.take_before_snapshot("fn_a", state_before, None);
+        tracker.take_after_snapshot(populated_snapshot(3), false, None);
+
+        // The before snapshot's ID is 0.
+        let mut checkpoint = tracker
+            .deep_copy_at(0)
+            .expect("expected a checkpoint at IP 0");
+
+        // Mutate the checkpoint.
+        checkpoint.ledger_state.delete(&[0]);
+
+        // The tracker's internal state must be unaffected.
+        let tracker_state = tracker.rewind_to(0).expect("rewind_to should still work");
+        assert_eq!(
+            tracker_state.len(),
+            3,
+            "tracker's internal snapshot was mutated through deep_copy_at result"
+        );
+    }
+
+    /// `deep_copy_at` returns `None` for an unknown instruction pointer.
+    #[test]
+    fn test_tracker_deep_copy_at_unknown_ip_returns_none() {
+        let mut tracker = HostSnapshotTracker::new();
+        tracker.take_before_snapshot("fn", empty_snapshot(), None);
+        tracker.take_after_snapshot(empty_snapshot(), false, None);
+
+        assert!(
+            tracker.deep_copy_at(999).is_none(),
+            "expected None for unknown instruction pointer"
+        );
     }
 }

--- a/simulator/src/snapshot/mod.rs
+++ b/simulator/src/snapshot/mod.rs
@@ -474,6 +474,33 @@ impl LedgerSnapshot {
         delta.apply_to(self)
     }
 
+    /// Returns a fully independent deep copy of this snapshot.
+    ///
+    /// Unlike `clone()` (which shares the `Arc`-wrapped base and delta with
+    /// the original) and `fork()` (which shares the merged base via `Arc`),
+    /// `deep_copy()` materializes every entry — base **and** delta — into a
+    /// brand-new `Arc<HashMap>` that shares **no** allocation with the original.
+    ///
+    /// This is the correct choice for time-travel checkpointing: after
+    /// `deep_copy()` the caller can freely mutate either the original or the
+    /// copy without either observation affecting the other.
+    ///
+    /// # Cost
+    ///
+    /// O(n) in the number of live entries. Every XDR-backed entry in an
+    /// mmap base is decoded exactly once during the copy. For large ledger
+    /// loads, prefer `fork()` when mutation isolation is not required.
+    pub fn deep_copy(&self) -> Self {
+        // Collect all live entries (base merged with delta).
+        let materialized: HashMap<Vec<u8>, LedgerEntry> = self.iter().collect();
+
+        Self {
+            base: BaseStore::InMemory(Arc::new(materialized)),
+            // Fresh, independent delta — not shared with the original.
+            delta: Arc::new(HashMap::new()),
+        }
+    }
+
     /// Creates a forked snapshot optimized for sharing read-only state.
     ///
     /// This method merges the current delta into the base (creating a new Arc)
@@ -1137,6 +1164,124 @@ mod tests {
         let mut snapshot = LedgerSnapshot::new();
         snapshot.delete(&[99]); // should not panic
         assert!(snapshot.is_empty());
+    }
+
+    // ------------------------------------------------------------------
+    // deep_copy isolation invariant
+    // ------------------------------------------------------------------
+
+    /// Inserting into the original after deep_copy must not affect the copy.
+    #[test]
+    fn test_deep_copy_original_mutation_does_not_affect_copy() {
+        let original = build_snapshot(4);
+        let copy = original.deep_copy();
+
+        let mut mutated = original;
+        mutated.insert(vec![0xFF], create_dummy_ledger_entry());
+
+        assert_eq!(
+            copy.len(),
+            4,
+            "deep copy len changed after original was mutated"
+        );
+        assert!(
+            copy.get(&[0xFF]).is_none(),
+            "deep copy saw key inserted after copy was taken"
+        );
+    }
+
+    /// Deleting from the copy must not affect the original.
+    #[test]
+    fn test_deep_copy_copy_mutation_does_not_affect_original() {
+        let original = build_snapshot(3);
+        let mut copy = original.deep_copy();
+
+        copy.delete(&[0]);
+
+        assert_eq!(
+            original.len(),
+            3,
+            "original len changed after copy was mutated"
+        );
+        assert!(
+            original.get(&[0]).is_some(),
+            "original lost entry after copy was mutated"
+        );
+    }
+
+    /// Two deep copies of the same snapshot are mutually independent.
+    #[test]
+    fn test_two_deep_copies_are_independent() {
+        let original = build_snapshot(2);
+        let mut copy_a = original.deep_copy();
+        let mut copy_b = original.deep_copy();
+
+        copy_a.insert(vec![0xAA], create_dummy_ledger_entry());
+        copy_b.insert(vec![0xBB], create_dummy_ledger_entry());
+
+        assert!(copy_a.get(&[0xBB]).is_none(), "copy_a saw copy_b's insert");
+        assert!(copy_b.get(&[0xAA]).is_none(), "copy_b saw copy_a's insert");
+    }
+
+    /// deep_copy of an empty snapshot produces a valid empty snapshot.
+    #[test]
+    fn test_deep_copy_empty_snapshot() {
+        let original = LedgerSnapshot::new();
+        let copy = original.deep_copy();
+        assert!(copy.is_empty());
+    }
+
+    /// deep_copy preserves all entries faithfully.
+    #[test]
+    fn test_deep_copy_entries_match_original() {
+        let original = build_snapshot(5);
+        let copy = original.deep_copy();
+
+        assert_eq!(original.len(), copy.len());
+        for i in 0u8..5 {
+            let orig_entry = original.get(&[i]).expect("original missing entry");
+            let copy_entry = copy.get(&[i]).expect("copy missing entry");
+            let orig_xdr = orig_entry.to_xdr(Limits::none()).unwrap();
+            let copy_xdr = copy_entry.to_xdr(Limits::none()).unwrap();
+            assert_eq!(orig_xdr, copy_xdr, "entry {i} differs between original and copy");
+        }
+    }
+
+    /// deep_copy on a snapshot with a non-empty delta includes delta entries.
+    #[test]
+    fn test_deep_copy_includes_delta_entries() {
+        let mut original = build_snapshot(2);
+        // Add an entry to the delta layer (not the base).
+        original.insert(vec![0xCC], create_dummy_ledger_entry());
+        assert_eq!(original.len(), 3);
+
+        let copy = original.deep_copy();
+        assert_eq!(copy.len(), 3);
+        assert!(copy.get(&[0xCC]).is_some(), "deep copy missing delta entry");
+    }
+
+    /// deep_copy on a snapshot with a tombstone in the delta excludes that entry.
+    #[test]
+    fn test_deep_copy_excludes_tombstoned_entries() {
+        let mut original = build_snapshot(3);
+        original.delete(&[0]); // tombstone key [0]
+        assert_eq!(original.len(), 2);
+
+        let copy = original.deep_copy();
+        assert_eq!(copy.len(), 2);
+        assert!(copy.get(&[0]).is_none(), "deep copy included tombstoned entry");
+    }
+
+    // ------------------------------------------------------------------
+    // Helper functions
+    // ------------------------------------------------------------------
+
+    fn build_snapshot(n: u8) -> LedgerSnapshot {
+        let mut snap = LedgerSnapshot::new();
+        for i in 0..n {
+            snap.insert(vec![i], create_dummy_ledger_entry());
+        }
+        snap
     }
 
     // Helper function to create a dummy ledger entry for testing


### PR DESCRIPTION
Add deep_copy() to LedgerSnapshot, CapturedSnapshot, SnapshotPair, and the new HostMemoryState struct to support time-travel debugging.

- LedgerSnapshot::deep_copy() materializes all live entries (base + delta, including mmap-backed) into a fresh Arc<HashMap> with no shared allocations. Unlike clone() (Arc-shared) and fork() (new shared base), deep_copy() guarantees full allocation independence between the original and the copy.

- CapturedSnapshot::deep_copy() and SnapshotPair::deep_copy() propagate the isolation guarantee through the pair types used by HostSnapshotTracker.

- HostMemoryState is a new struct that records the complete host state at a given instruction_pointer. HostMemoryState::capture() immediately deep-copies the passed LedgerSnapshot so the checkpoint is immune to subsequent mutations on the live host.

- HostSnapshotTracker::deep_copy_at(ip) looks up the before-snapshot matching an instruction pointer and returns an isolated HostMemoryState. The existing rewind_to() is preserved as the shallow-clone path.

Isolation invariants are enforced by tests in both modules:
- Mutating the original after deep_copy does not affect the copy
- Mutating the copy does not affect the original
- Two independent copies of the same snapshot do not observe each other
- Delta entries and tombstones are handled correctly across the copy

Closes #1693

