### PR TITLE
fix(sim): add proactive WASM data section bounds checking

### DIFF
--- a/simulator/src/decoder.rs
+++ b/simulator/src/decoder.rs
@@ -1,0 +1,275 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+//! Proactive WASM data-section bounds checking.
+//!
+//! A malicious actor can craft a WASM module whose declared data section
+//! claims an enormous amount of initialiser bytes.  Naively handing such a
+//! module to a parser or runtime allocates memory proportional to the
+//! declared size *before* any execution budget kicks in, exhausting the
+//! simulator process and potentially the host OS.
+//!
+//! [`validate_data_section`] walks only the `DataSection` payload of the
+//! WASM binary — it does not instantiate the module — and returns an error
+//! if either:
+//!
+//! * the total initialiser byte count exceeds [`crate::memory::MAX_DATA_SECTION_SIZE`], or
+//! * the number of individual data segments exceeds [`crate::memory::MAX_DATA_SEGMENT_COUNT`].
+//!
+//! Call this function on raw WASM bytes **before** passing them to any
+//! higher-level parser, runtime, or source-map analyser.
+
+use crate::memory::{MAX_DATA_SECTION_SIZE, MAX_DATA_SEGMENT_COUNT};
+use wasmparser::{DataKind, Parser, Payload};
+
+/// Errors that can be returned by [`validate_data_section`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum DataSectionError {
+    /// The WASM binary could not be parsed.
+    ParseError(String),
+    /// The number of data segments exceeds [`MAX_DATA_SEGMENT_COUNT`].
+    TooManySegments {
+        /// Actual segment count found in the module.
+        count: usize,
+        /// Configured segment limit.
+        limit: usize,
+    },
+    /// The combined initialiser data size exceeds [`MAX_DATA_SECTION_SIZE`].
+    TotalSizeTooLarge {
+        /// Total bytes found in all data segments.
+        total: usize,
+        /// Configured byte limit.
+        limit: usize,
+    },
+}
+
+impl std::fmt::Display for DataSectionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DataSectionError::ParseError(msg) => {
+                write!(f, "failed to parse WASM data section: {msg}")
+            }
+            DataSectionError::TooManySegments { count, limit } => write!(
+                f,
+                "WASM data section contains {count} segments (limit {limit}): \
+                 possible memory exhaustion attack"
+            ),
+            DataSectionError::TotalSizeTooLarge { total, limit } => write!(
+                f,
+                "WASM data section total size is {total} bytes (limit {limit}): \
+                 possible memory exhaustion attack"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DataSectionError {}
+
+/// Validate the data section of a WASM module *without* instantiating it.
+///
+/// Iterates over every `DataSection` payload in `wasm_bytes` and checks:
+///
+/// 1. That the segment count does not exceed [`MAX_DATA_SEGMENT_COUNT`].
+/// 2. That the combined initialiser byte count does not exceed [`MAX_DATA_SECTION_SIZE`].
+///
+/// Both checks happen incrementally — the function short-circuits on the
+/// first violation so we never accumulate more state than necessary.
+///
+/// # Errors
+///
+/// Returns [`DataSectionError`] when a limit is exceeded or when the bytes
+/// cannot be parsed as a valid WASM module.
+pub fn validate_data_section(wasm_bytes: &[u8]) -> Result<(), DataSectionError> {
+    let mut segment_count: usize = 0;
+    let mut total_size: usize = 0;
+
+    for payload in Parser::new(0).parse_all(wasm_bytes) {
+        let payload = payload.map_err(|e| DataSectionError::ParseError(e.to_string()))?;
+
+        if let Payload::DataSection(reader) = payload {
+            for data in reader {
+                let data = data.map_err(|e| DataSectionError::ParseError(e.to_string()))?;
+
+                // Count only active and passive segments; both consume memory on
+                // instantiation.  Declared segments (DataKind::Passive with no
+                // init expr) are included because they still back the data count
+                // import and can be bulk-copied at runtime.
+                let seg_len = match &data.kind {
+                    DataKind::Active { .. } | DataKind::Passive => data.data.len(),
+                };
+
+                segment_count = segment_count.saturating_add(1);
+                if segment_count > MAX_DATA_SEGMENT_COUNT {
+                    return Err(DataSectionError::TooManySegments {
+                        count: segment_count,
+                        limit: MAX_DATA_SEGMENT_COUNT,
+                    });
+                }
+
+                total_size = total_size.saturating_add(seg_len);
+                if total_size > MAX_DATA_SECTION_SIZE {
+                    return Err(DataSectionError::TotalSizeTooLarge {
+                        total: total_size,
+                        limit: MAX_DATA_SECTION_SIZE,
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    /// Minimal valid WASM module with no data section.
+    fn empty_module() -> Vec<u8> {
+        wat::parse_str("(module)").expect("wat parse failed")
+    }
+
+    /// WASM module with one data segment of the given byte count.
+    fn module_with_data(byte_count: usize) -> Vec<u8> {
+        // Build a module that has a memory and a single active data segment.
+        // The segment is filled with zeros.
+        let data_str = "\\00".repeat(byte_count);
+        let wat = format!(
+            r#"(module
+                (memory 1)
+                (data (i32.const 0) "{data_str}")
+            )"#
+        );
+        wat::parse_str(&wat).expect("wat parse failed")
+    }
+
+    /// WASM module with `n` data segments each containing one byte.
+    fn module_with_n_segments(n: usize) -> Vec<u8> {
+        // Each segment writes a zero byte at offset `i`.
+        let mut segments = String::new();
+        for i in 0..n {
+            segments.push_str(&format!(r#"(data (i32.const {i}) "\00")"#));
+            segments.push('\n');
+        }
+        let wat = format!(
+            r#"(module
+                (memory 1)
+                {segments}
+            )"#
+        );
+        wat::parse_str(&wat).expect("wat parse failed")
+    }
+
+    // ------------------------------------------------------------------
+    // Positive cases
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_valid_empty_module() {
+        assert!(validate_data_section(&empty_module()).is_ok());
+    }
+
+    #[test]
+    fn test_valid_small_data_segment() {
+        // 1 KiB of data — well within limits
+        let wasm = module_with_data(1024);
+        assert!(validate_data_section(&wasm).is_ok());
+    }
+
+    #[test]
+    fn test_valid_data_at_exact_size_limit() {
+        let wasm = module_with_data(MAX_DATA_SECTION_SIZE);
+        assert!(validate_data_section(&wasm).is_ok());
+    }
+
+    #[test]
+    fn test_valid_segments_at_exact_count_limit() {
+        let wasm = module_with_n_segments(MAX_DATA_SEGMENT_COUNT);
+        assert!(validate_data_section(&wasm).is_ok());
+    }
+
+    // ------------------------------------------------------------------
+    // Negative cases — size
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_rejects_data_section_one_byte_over_limit() {
+        let wasm = module_with_data(MAX_DATA_SECTION_SIZE + 1);
+        let err = validate_data_section(&wasm).unwrap_err();
+        assert!(
+            matches!(err, DataSectionError::TotalSizeTooLarge { .. }),
+            "expected TotalSizeTooLarge, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_rejects_data_section_far_over_limit() {
+        // 2× limit
+        let wasm = module_with_data(MAX_DATA_SECTION_SIZE * 2);
+        let err = validate_data_section(&wasm).unwrap_err();
+        assert!(matches!(err, DataSectionError::TotalSizeTooLarge { .. }));
+    }
+
+    #[test]
+    fn test_error_message_contains_totals_for_size() {
+        let over = MAX_DATA_SECTION_SIZE + 1;
+        let wasm = module_with_data(over);
+        let err = validate_data_section(&wasm).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("bytes"),
+            "error message should mention byte count: {msg}"
+        );
+        assert!(
+            msg.contains("memory exhaustion"),
+            "error message should call out memory exhaustion: {msg}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Negative cases — segment count
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_rejects_too_many_segments() {
+        let wasm = module_with_n_segments(MAX_DATA_SEGMENT_COUNT + 1);
+        let err = validate_data_section(&wasm).unwrap_err();
+        assert!(
+            matches!(err, DataSectionError::TooManySegments { .. }),
+            "expected TooManySegments, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_error_message_contains_count_for_segments() {
+        let wasm = module_with_n_segments(MAX_DATA_SEGMENT_COUNT + 1);
+        let err = validate_data_section(&wasm).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("segments"),
+            "error message should mention segment count: {msg}"
+        );
+        assert!(
+            msg.contains("memory exhaustion"),
+            "error message should call out memory exhaustion: {msg}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Edge case — invalid WASM bytes
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_rejects_invalid_wasm_bytes() {
+        let junk = b"this is not wasm at all";
+        let err = validate_data_section(junk).unwrap_err();
+        assert!(
+            matches!(err, DataSectionError::ParseError(_)),
+            "expected ParseError, got: {err}"
+        );
+    }
+}

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod asset_tracker;
 pub mod context;
+pub mod decoder;
 pub mod gas_optimizer;
 pub mod git_detector;
 pub mod host;

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -6,6 +6,7 @@ mod asset_tracker;
 mod config;
 mod context;
 mod debug_host_fn;
+mod decoder;
 mod events;
 mod gas_optimizer;
 mod git_detector;
@@ -566,6 +567,13 @@ fn main() {
     let source_mapper = if let Some(wasm_base64) = &request.contract_wasm {
         match base64::engine::general_purpose::STANDARD.decode(wasm_base64) {
             Ok(wasm_bytes) => {
+                // Reject modules whose data section exceeds safe bounds *before*
+                // handing bytes to any allocating parser or runtime.  A crafted
+                // module with a massive declared data section would otherwise
+                // exhaust simulator memory before the Soroban budget fires.
+                if let Err(e) = decoder::validate_data_section(&wasm_bytes) {
+                    return send_error(format!("WASM data section validation failed: {e}"));
+                }
                 if let Err(e) = vm::enforce_soroban_compatibility(&wasm_bytes) {
                     return send_error(format!("Strict VM enforcement failed: {}", e));
                 }

--- a/simulator/src/memory.rs
+++ b/simulator/src/memory.rs
@@ -3,14 +3,49 @@
 
 //! Memory-limit enforcement for the simulator runtime.
 //!
-//! Provides the [`check_memory_limit`] helper used by the runtime to panic when
-//! the configured hard memory limit is exceeded (mimicking live Soroban network
-//! constraints).
+//! Provides:
+//!
+//! * [`check_memory_limit`] — panics when the Soroban budget reports more
+//!   memory consumed than the configured hard limit (mimicking live network
+//!   constraints).
+//! * [`MAX_DATA_SECTION_SIZE`] / [`MAX_DATA_SEGMENT_COUNT`] — compile-time
+//!   caps used by [`crate::decoder`] to reject crafted WASM modules *before*
+//!   any allocation takes place.
+//! * [`check_data_section`] — convenience wrapper that converts a
+//!   [`crate::decoder::DataSectionError`] into a `Result<(), String>`.
 //!
 //! # Allocator Rollback Safety
 //!
-//! Allocator-state tracking lives in [`crate::host::AllocTracker`]; this module
-//! only handles the threshold check.
+//! Allocator-state tracking lives in [`crate::host::AllocTracker`]; this
+//! module only handles the threshold checks.
+
+use crate::decoder::{validate_data_section, DataSectionError};
+
+/// Maximum combined byte size of all data-section initialisers in a single
+/// WASM module.  Soroban's network limit for the entire contract binary is
+/// 64 KiB; 128 KiB for data gives headroom for test fixtures while still
+/// bounding adversarial inputs well below any OOM threshold.
+pub const MAX_DATA_SECTION_SIZE: usize = 128 * 1024; // 128 KiB
+
+/// Maximum number of individual data segments permitted in a WASM module.
+/// Each segment incurs bookkeeping overhead regardless of its byte count,
+/// so we cap segment count independently of total size.
+pub const MAX_DATA_SEGMENT_COUNT: usize = 512;
+
+/// Validate the data section of `wasm_bytes` against the hard limits defined
+/// in this module.
+///
+/// This is a thin wrapper around [`validate_data_section`] that converts the
+/// strongly-typed [`DataSectionError`] into a `Result<(), String>` suitable
+/// for inline use in the simulation pipeline.
+///
+/// # Errors
+///
+/// Returns `Err(message)` when the data section exceeds [`MAX_DATA_SECTION_SIZE`],
+/// [`MAX_DATA_SEGMENT_COUNT`], or when `wasm_bytes` cannot be parsed.
+pub fn check_data_section(wasm_bytes: &[u8]) -> Result<(), String> {
+    validate_data_section(wasm_bytes).map_err(|e: DataSectionError| e.to_string())
+}
 
 /// Checks whether the current memory consumption exceeds the configured hard limit.
 ///
@@ -43,5 +78,36 @@ mod tests {
     fn test_check_memory_limit_exceeded_panics() {
         let result = std::panic::catch_unwind(|| check_memory_limit(1001, 1000));
         assert!(result.is_err(), "expected panic when memory exceeds limit");
+    }
+
+    #[test]
+    fn test_check_data_section_valid_module() {
+        let wasm = wat::parse_str("(module)").expect("wat parse failed");
+        assert!(check_data_section(&wasm).is_ok());
+    }
+
+    #[test]
+    fn test_check_data_section_oversized_returns_err_string() {
+        // Build a module whose single data segment is 1 byte over the limit.
+        let data_str = "\\00".repeat(MAX_DATA_SECTION_SIZE + 1);
+        let wat_src = format!(
+            r#"(module (memory 1) (data (i32.const 0) "{data_str}"))"#
+        );
+        let wasm = wat::parse_str(&wat_src).expect("wat parse failed");
+        let err = check_data_section(&wasm).unwrap_err();
+        assert!(
+            err.contains("memory exhaustion"),
+            "error string should mention memory exhaustion: {err}"
+        );
+    }
+
+    #[test]
+    fn test_max_data_section_size_is_positive() {
+        assert!(MAX_DATA_SECTION_SIZE > 0);
+    }
+
+    #[test]
+    fn test_max_data_segment_count_is_positive() {
+        assert!(MAX_DATA_SEGMENT_COUNT > 0);
     }
 }


### PR DESCRIPTION
A crafted WASM module with a massive declared data section can exhaust simulator memory before the Soroban execution budget fires, because wasmparser and the env-host allocate proportional to declared sizes.

Add decoder::validate_data_section which walks only the DataSection payload of the WASM binary without instantiating the module. It short-circuits on the first violation of two independent limits:

- MAX_DATA_SECTION_SIZE (128 KiB): combined initialiser byte count
- MAX_DATA_SEGMENT_COUNT (512): number of individual data segments

Wire the check into main.rs at the single choke point where untrusted contract_wasm bytes enter the pipeline, before vm::enforce_soroban_compatibility and before SourceMapper::new_with_options.

Add check_data_section convenience wrapper in memory.rs alongside the existing check_memory_limit helper, keeping all memory-safety thresholds in one module.

Closes: memory exhaustion via crafted WASM data section

## Description
<!-- Describe your changes in detail -->
<!-- Include motivation and context if resolving a specific issue -->

## Related Issues
<!-- Link to any related issues (e.g. "Fixes #123") -->

## Type of Change
<!-- Check all that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chore / Maintenance

## Checklist
- [ ] I have followed the guidelines in `CONTRIBUTING.md`.
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the documentation as needed.
- [ ] My code passes all local formatting and linting checks (`go fmt`, `golangci-lint`, `cargo fmt`, `cargo clippy`).

## Screenshots / Terminal Output (if applicable)
<!-- If your changes affect the CLI output or UI, please provide screenshots or copy-pasted terminal output here. -->


closes #1707