### PR TITLE
feat: add CLI command erst debug --step-back for time-travel (issue #…

### DIFF
--- a/internal/cmd/debug.go
+++ b/internal/cmd/debug.go
@@ -81,6 +81,7 @@ var (
 	saveSnapshotsFlag    string
 	wasmBase64           string
 	assetSafetyFlag      bool
+	stepBackFlag         int
 )
 
 // DebugCommand holds dependencies for the debug command
@@ -685,6 +686,34 @@ Local WASM Replay Mode:
 
 		if lastSimResp == nil {
 			return errors.WrapSimulationLogicError("no simulation results generated")
+		}
+
+		// Time-travel: Step back N steps from the end of execution trace
+		if stepBackFlag > 0 {
+			originalEventCount := len(lastSimResp.Events)
+			originalLogCount := len(lastSimResp.Logs)
+
+			if stepBackFlag >= originalEventCount {
+				fmt.Printf("%s Cannot step back %d steps: only %d events in trace\n", visualizer.Error(), stepBackFlag, originalEventCount)
+				return errors.WrapSimulationLogicError("step-back value exceeds trace length")
+			}
+
+			// Truncate events and logs to step back from the end
+			newEventCount := originalEventCount - stepBackFlag
+			lastSimResp.Events = lastSimResp.Events[:newEventCount]
+
+			// Also truncate logs proportionally
+			if originalLogCount > 0 {
+				newLogCount := originalLogCount - stepBackFlag
+				if newLogCount < 0 {
+					newLogCount = 0
+				}
+				lastSimResp.Logs = lastSimResp.Logs[:newLogCount]
+			}
+
+			fmt.Printf("%s Time-travel: Stepped back %d steps from end of trace\n", visualizer.Symbol("clock"), stepBackFlag)
+			fmt.Printf("  Events: %d → %d\n", originalEventCount, len(lastSimResp.Events))
+			fmt.Printf("  Logs: %d → %d\n", originalLogCount, len(lastSimResp.Logs))
 		}
 
 		// Persist snapshot registry to disk when --save-snapshots is set.
@@ -1710,6 +1739,7 @@ func init() {
 	debugCmd.Flags().StringVar(&loadSnapshotsFlag, "load-snapshots", "", "Load simulation from a snapshot registry")
 	debugCmd.Flags().StringVar(&saveSnapshotsFlag, "save-snapshots", "", "Save simulation results to a snapshot registry")
 	debugCmd.Flags().BoolVar(&assetSafetyFlag, "asset-safety", true, "Enable Move-level Asset Safety tracing (on by default for debug)")
+	debugCmd.Flags().IntVar(&stepBackFlag, "step-back", 0, "Step back N steps from the end of execution trace (time-travel)")
 	rootCmd.AddCommand(debugCmd)
 }
 


### PR DESCRIPTION
## Linked Issue

Closes #1696

## Description

**What changed?**

* Added the `--step-back` CLI flag to `erst debug` to enable time-travel debugging through execution traces.
* Implemented trace-truncation logic that bounds-checks the requested step count and slices `lastSimResp.Events` and `lastSimResp.Logs` from the end of the trace.
* Added visualizer output reporting the stepped-back state and remaining trace length.

**Why was it changed?**
To expose the time-travel capability directly in the CLI, allowing developers to inspect prior execution states by stepping backwards through simulation events and logs.

**How was it implemented?**

* In `internal/cmd/debug.go`:
* Added `stepBackFlag int` to the flag declaration block.
* Registered `--step-back` on `debugCmd` via `debugCmd.Flags().IntVar(&stepBackFlag, "step-back", 0, "Step back N steps from the end of execution trace (time-travel)")`.
* Added the truncation block following the `lastSimResp` evaluation to slice both `Events` and `Logs` slices safely and print a formatted summary using the visualizer helpers.



## Type of Change

* [x] New feature (non-breaking change which adds functionality)
* [ ] Bug fix (non-breaking change that fixes an issue)
* [ ] Refactor
* [ ] Breaking change
* [ ] Documentation update
* [ ] Configuration / Tooling

## Test Evidence

### Local Verification

* [x] Code formatting passes (`go fmt`)
* [x] Static analysis passes (`go vet ./internal/cmd/...`)
* [x] CLI binary builds successfully (`go build ./cmd/erst/`)
* [x] Unit tests pass (`go test ./internal/cmd/`)

```text
$ go vet ./internal/cmd/...
$ go build ./cmd/erst/
$ go test ./internal/cmd/
PASS
ok  	github.com/dotandev/hintents/internal/cmd	0.412s

```

## Additional Notes for Reviewer

* **File Path Resolution:** The issue suggested `cmd/erst/main.go` and `internal/cli/debug.go`. `cmd/erst/main.go` serves as a thin entry point needing no changes, and the command is implemented directly in `internal/cmd/debug.go`.
* **Zero External Dependencies:** Uses existing standard slice operations on `SimulationResponse.Events` and `SimulationResponse.Logs` with bounds checks to prevent index-out-of-range errors when `step-back` exceeds trace length.