### PR TITLE
feat: Expose fine-grained WASM execution metrics

### DIFF
--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -12,6 +12,7 @@ pub mod hsm;
 pub mod ipc;
 pub mod memory;
 pub mod metering;
+pub mod metrics;
 pub mod runner;
 pub mod snapshot;
 pub mod source_map_cache;

--- a/simulator/src/metrics.rs
+++ b/simulator/src/metrics.rs
@@ -1,0 +1,56 @@
+// Copyright 2026 Erst Users
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+use soroban_env_host::{budget::Budget, xdr::ContractCostType, HostError};
+use std::collections::HashMap;
+
+/// Detailed breakdown of execution costs by operation type
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CostMetrics {
+    /// Total CPU instructions consumed for this operation
+    pub cpu: u64,
+    /// Total memory bytes allocated for this operation
+    pub mem: u64,
+    /// Number of times this operation was invoked
+    pub iterations: u64,
+}
+
+/// A comprehensive collection of metrics for all recorded operations
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ExecutionMetrics {
+    /// Distribution of instructions and costs per component
+    pub cost_distribution: HashMap<String, CostMetrics>,
+
+    /// Total CPU instructions consumed globally
+    pub total_cpu_insns: u64,
+
+    /// Total memory bytes consumed globally
+    pub total_mem_bytes: u64,
+}
+
+pub fn extract_metrics(budget: &Budget) -> Result<ExecutionMetrics, HostError> {
+    let mut cost_distribution = HashMap::new();
+
+    for ct in ContractCostType::variants() {
+        if let Ok(tracker) = budget.get_tracker(ct) {
+            if tracker.iterations > 0 || tracker.cpu > 0 || tracker.mem > 0 {
+                let name = format!("{:?}", ct);
+                cost_distribution.insert(
+                    name,
+                    CostMetrics {
+                        cpu: tracker.cpu,
+                        mem: tracker.mem,
+                        iterations: tracker.iterations,
+                    },
+                );
+            }
+        }
+    }
+
+    Ok(ExecutionMetrics {
+        cost_distribution,
+        total_cpu_insns: budget.get_cpu_insns_consumed()?,
+        total_mem_bytes: budget.get_mem_bytes_consumed()?,
+    })
+}

--- a/simulator/src/runner.rs
+++ b/simulator/src/runner.rs
@@ -226,6 +226,14 @@ impl SimHost {
         Ok(self.inner.get_events()?)
     }
 
+    /// Returns the execution metrics (CPU/Memory distribution).
+    #[instrument(level = "debug", skip(self))]
+    pub fn execution_metrics(&self) -> Result<crate::metrics::ExecutionMetrics, SimHostError> {
+        debug!("fetching execution metrics");
+        crate::metrics::extract_metrics(&self.inner.budget_cloned())
+            .map_err(SimHostError::Host)
+    }
+
     /// Returns the host events as a cloned vector for external history tracking.
     #[instrument(level = "debug", skip(self))]
     pub fn event_log(&self) -> Result<Vec<HostEvent>, SimHostError> {


### PR DESCRIPTION
Closes #1657 

This PR adds observability into WASM instruction distribution by hooking into the `soroban-env-host` metrics to extract and expose instruction counts and other cost tracking information.

Files changed:
- `simulator/src/metrics.rs`: Added new definitions for `CostMetrics` and `ExecutionMetrics` to extract tracking metrics by iterating over `ContractCostType::variants()` from `soroban_env_host::budget::Budget`.
- `simulator/src/runner.rs`: Exposed a new method `execution_metrics` on `SimHost` that uses the new metrics module to return the detailed execution footprint.
- `simulator/src/lib.rs`: Exposed the `metrics` module.