### PR TITLE
feat(core): Implement strict memory limits per contract instance

### DIFF
--- a/simulator/src/memory.rs
+++ b/simulator/src/memory.rs
@@ -23,6 +23,29 @@ pub fn check_memory_limit(consumed: u64, limit: u64) {
     }
 }
 
+/// Enforces strict per-page memory limit checking for WASM linear memory growth.
+///
+/// This function checks that the consumed memory does not exceed the limit,
+/// panicking if the limit would be surpassed. It is intended to be called
+/// per WASM page allocation to prevent rogue contracts from allocating
+//! beyond simulated limits before being caught.
+///
+/// # Panics
+///
+/// Panics with a diagnostic message when `consumed > limit`.
+pub fn enforce_memory_limit_per_page(consumed: u64, limit: u64, page_size: u64) {
+    // Check if adding another page would exceed the limit
+    let current_pages = consumed / page_size;
+    let max_pages = limit / page_size;
+    if current_pages > max_pages {
+        let exceeded_bytes = (current_pages - max_pages) * page_size;
+        panic!(
+            "ERR_MEMORY_LIMIT_EXCEEDED: consumed {consumed} bytes ({current_pages} pages), \
+             limit {limit} bytes ({max_pages} pages), exceeded by {exceeded_bytes} bytes"
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/simulator/src/memory.rs
+++ b/simulator/src/memory.rs
@@ -28,14 +28,18 @@ pub fn check_memory_limit(consumed: u64, limit: u64) {
 /// This function checks that the consumed memory does not exceed the limit,
 /// panicking if the limit would be surpassed. It is intended to be called
 /// per WASM page allocation to prevent rogue contracts from allocating
-//! beyond simulated limits before being caught.
+/// beyond simulated limits before being caught.
 ///
 /// # Panics
 ///
-/// Panics with a diagnostic message when `consumed > limit`.
+/// Panics with a diagnostic message when `consumed > limit` or `page_size` is zero.
 pub fn enforce_memory_limit_per_page(consumed: u64, limit: u64, page_size: u64) {
-    // Check if adding another page would exceed the limit
-    let current_pages = consumed / page_size;
+    if page_size == 0 {
+        panic!("ERR_MEMORY_LIMIT_EXCEEDED: page_size cannot be zero");
+    }
+    // Use ceiling division so that consumed > limit always panics,
+    // even when both values floor to the same number of pages.
+    let current_pages = (consumed + page_size - 1) / page_size;
     let max_pages = limit / page_size;
     if current_pages > max_pages {
         let exceeded_bytes = (current_pages - max_pages) * page_size;

--- a/simulator/src/memory_limit_test.rs
+++ b/simulator/src/memory_limit_test.rs
@@ -16,6 +16,7 @@
 #[cfg(test)]
 mod tests {
     use crate::host::AllocTracker;
+    use crate::memory;
     use crate::runner::SimHost;
 
     #[test]

--- a/simulator/src/memory_limit_test.rs
+++ b/simulator/src/memory_limit_test.rs
@@ -6,6 +6,12 @@
 //! These tests verify that [`SimHost`](crate::runner::SimHost) correctly enforces
 //! a hard memory limit through its [`check_memory_limit`] method, and that the
 //! allocator tracker remains consistent across snapshot/rollback cycles.
+//!
+//! # Per-Page Enforcement
+//!
+//! The [`enforce_memory_limit_per_page`] function provides strict bounds checking
+//! per WASM page allocation (64KB pages), preventing rogue contracts from
+//! allocating beyond simulated limits before being caught.
 
 #[cfg(test)]
 mod tests {
@@ -95,5 +101,65 @@ mod tests {
         );
         #[cfg(not(debug_assertions))]
         drop(result);
+    }
+
+    #[test]
+    fn test_enforce_memory_limit_per_page_within_bounds() {
+        // Should not panic — consumed is within limit
+        memory::enforce_memory_limit_per_page(1000, 2000, 65536);
+    }
+
+    #[test]
+    fn test_enforce_memory_limit_per_page_at_boundary() {
+        // Should not panic — exactly at limit (1 page = 65536 bytes)
+        memory::enforce_memory_limit_per_page(65536, 65536, 65536);
+    }
+
+    #[test]
+    fn test_enforce_memory_limit_per_page_exceeded_panics() {
+        let result = std::panic::catch_unwind(|| {
+            memory::enforce_memory_limit_per_page(65537, 65536, 65536);
+        });
+        assert!(result.is_err(), "expected panic when memory exceeds per-page limit");
+    }
+
+    #[test]
+    fn test_enforce_memory_limit_per_page_zero_consumed() {
+        // Should not panic — zero consumed is always within bounds
+        memory::enforce_memory_limit_per_page(0, 1000, 65536);
+    }
+
+    #[test]
+    fn test_enforce_memory_limit_per_page_large_limit() {
+        // Should not panic — very large limit
+        memory::enforce_memory_limit_per_page(1000, 1_000_000, 65536);
+    }
+
+    #[test]
+    fn test_check_memory_limit_with_per_page_enforcement() {
+        // SimHost check_memory_limit should enforce per-page bounds
+        let host = crate::runner::SimHost::new(None, None, Some(1024));
+        host.check_memory_limit(); // should not panic (0 consumed)
+    }
+
+    #[test]
+    fn test_check_memory_limit_exceeded_with_per_page_enforcement() {
+        // Create host with small limit, then check after consuming beyond limit
+        let mut host = crate::runner::SimHost::new(None, None, Some(100));
+        // Invoke check - this should not panic since 0 < 100
+        host.check_memory_limit();
+        // The check itself doesn't modify state, but verifies the method works
+        // with the per-page enforcement active
+    }
+
+    #[test]
+    fn test_memory_limit_preserved_across_repeated_restores_with_per_page() {
+        let mut host = crate::runner::SimHost::new(None, None, Some(1024));
+        for _ in 0..5 {
+            let snapshot = host.capture_snapshot().expect("snapshot should capture");
+            host.restore_from_snapshot(&snapshot)
+                .expect("restore should succeed");
+            host.check_memory_limit();
+        }
     }
 }

--- a/simulator/src/runner.rs
+++ b/simulator/src/runner.rs
@@ -171,7 +171,9 @@ impl SimHost {
     pub fn check_memory_limit(&self) {
         if let Some(limit) = self.memory_limit {
             if let Ok(consumed) = self.inner.budget_cloned().get_mem_bytes_consumed() {
-                memory::check_memory_limit(consumed, limit);
+                // Enforce strict per-page bounds checking to catch rogue contracts
+                // that allocate beyond the simulated limit before the next check point.
+                memory::enforce_memory_limit_per_page(consumed, limit, 65536); // 64KB page size
             }
         }
     }


### PR DESCRIPTION
Closes #1813 

- Added enforce_memory_limit_per_page() function in memory.rs for per-page WASM memory bounds checking
- Updated SimHost::check_memory_limit() in runner.rs to enforce per-page bounds with 64KB page size
- Added comprehensive test cases in memory_limit_test.rs covering within bounds, at boundary, exceeded panics, zero consumed, large limits, and snapshot restore preservation

