### PR TITLE
test(extension): Add DAP debug-session test against a mocked simulator

### DIFF
--- a/erst_extension/package-lock.json
+++ b/erst_extension/package-lock.json
@@ -16,6 +16,7 @@
         "@types/vscode": "^1.90.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
+        "@vscode/debugprotocol": "^1.68.0",
         "@vscode/test-electron": "^2.4.0",
         "eslint": "^8.0.0",
         "mocha": "^10.4.0",
@@ -435,6 +436,13 @@
       "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@vscode/debugprotocol": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.68.0.tgz",
+      "integrity": "sha512-2J27dysaXmvnfuhFGhfeuxfHRXunqNPxtBoR3koiTOA9rdxWNDTa1zIFLCFMSHJ9MPTPKFcBeblsyaCJCIlQxg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vscode/test-electron": {
       "version": "2.5.2",

--- a/erst_extension/package.json
+++ b/erst_extension/package.json
@@ -83,7 +83,6 @@
           "name": "Traces"
         }
       ]
-    }
     },
     "debuggers": [
       {
@@ -176,7 +175,7 @@
     "vscode-jsonrpc": "^8.2.1"
   },
   "devDependencies": {
-    "@vscode/debugprotocol": "^1.73.0",
+    "@vscode/debugprotocol": "^1.68.0",
     "@types/vscode": "^1.90.0",
     "@types/node": "^20.0.0",
     "@types/mocha": "^10.0.0",

--- a/erst_extension/src/dap/adapter.ts
+++ b/erst_extension/src/dap/adapter.ts
@@ -98,8 +98,8 @@ const MAIN_THREAD_ID = 1;
  * simulator IPC layer. Each instance corresponds to one "launch" request.
  */
 export class ERSTDebugSession implements vscode.DebugAdapter {
-    private _onDidSendMessage = new vscode.EventEmitter<DebugProtocol.Message>();
-    readonly onDidSendMessage: vscode.Event<DebugProtocol.Message> = this._onDidSendMessage.event;
+    private _onDidSendMessage = new vscode.EventEmitter<vscode.DebugProtocolMessage>();
+    readonly onDidSendMessage: vscode.Event<vscode.DebugProtocolMessage> = this._onDidSendMessage.event;
 
     private client: ERSTClient;
     private trace: Trace | null = null;
@@ -118,7 +118,7 @@ export class ERSTDebugSession implements vscode.DebugAdapter {
     // DAP Request Handler
     // ------------------------------------------------------------------
 
-    handleMessage(message: DebugProtocol.ProtocolMessage): void {
+    handleMessage(message: any): void {
         if (message.type !== 'request') return;
 
         const request = message as DebugProtocol.Request;
@@ -126,64 +126,64 @@ export class ERSTDebugSession implements vscode.DebugAdapter {
         try {
             switch (request.command) {
                 case 'initialize':
-                    this.handleInitialize(request);
+                    this.handleInitialize(request as DebugProtocol.InitializeRequest);
                     break;
                 case 'launch':
-                    this.handleLaunch(request);
+                    this.handleLaunch(request as DebugProtocol.LaunchRequest);
                     break;
                 case 'attach':
-                    this.handleAttach(request);
+                    this.handleAttach(request as DebugProtocol.AttachRequest);
                     break;
                 case 'disconnect':
-                    this.handleDisconnect(request);
+                    this.handleDisconnect(request as DebugProtocol.DisconnectRequest);
                     break;
                 case 'terminate':
-                    this.handleTerminate(request);
+                    this.handleTerminate(request as DebugProtocol.TerminateRequest);
                     break;
                 case 'configurationDone':
-                    this.handleConfigurationDone(request);
+                    this.handleConfigurationDone(request as DebugProtocol.ConfigurationDoneRequest);
                     break;
                 case 'setBreakpoints':
-                    this.handleSetBreakpoints(request);
+                    this.handleSetBreakpoints(request as DebugProtocol.SetBreakpointsRequest);
                     break;
                 case 'setExceptionBreakpoints':
-                    this.handleSetExceptionBreakpoints(request);
+                    this.handleSetExceptionBreakpoints(request as DebugProtocol.SetExceptionBreakpointsRequest);
                     break;
                 case 'continue':
-                    this.handleContinue(request);
+                    this.handleContinue(request as DebugProtocol.ContinueRequest);
                     break;
                 case 'next':
-                    this.handleNext(request);
+                    this.handleNext(request as DebugProtocol.NextRequest);
                     break;
                 case 'stepIn':
-                    this.handleStepIn(request);
+                    this.handleStepIn(request as DebugProtocol.StepInRequest);
                     break;
                 case 'stepOut':
-                    this.handleStepOut(request);
+                    this.handleStepOut(request as DebugProtocol.StepOutRequest);
                     break;
                 case 'pause':
-                    this.handlePause(request);
+                    this.handlePause(request as DebugProtocol.PauseRequest);
                     break;
                 case 'stackTrace':
-                    this.handleStackTrace(request);
+                    this.handleStackTrace(request as DebugProtocol.StackTraceRequest);
                     break;
                 case 'scopes':
-                    this.handleScopes(request);
+                    this.handleScopes(request as DebugProtocol.ScopesRequest);
                     break;
                 case 'variables':
-                    this.handleVariables(request);
+                    this.handleVariables(request as DebugProtocol.VariablesRequest);
                     break;
                 case 'source':
-                    this.handleSource(request);
+                    this.handleSource(request as DebugProtocol.SourceRequest);
                     break;
                 case 'threads':
-                    this.handleThreads(request);
+                    this.handleThreads(request as DebugProtocol.ThreadsRequest);
                     break;
                 case 'evaluate':
-                    this.handleEvaluate(request);
+                    this.handleEvaluate(request as DebugProtocol.EvaluateRequest);
                     break;
                 case 'exceptionInfo':
-                    this.handleExceptionInfo(request);
+                    this.handleExceptionInfo(request as DebugProtocol.ExceptionInfoRequest);
                     break;
                 default:
                     this.sendErrorResponse(request, {
@@ -211,7 +211,7 @@ export class ERSTDebugSession implements vscode.DebugAdapter {
      * Handles the 'initialize' request. Advertises the adapter's capabilities.
      */
     private handleInitialize(request: DebugProtocol.InitializeRequest): void {
-        const response: DebugProtocol.InitializeResponse = {
+        const response = {
             type: 'response',
             request_seq: request.seq,
             success: true,
@@ -231,7 +231,7 @@ export class ERSTDebugSession implements vscode.DebugAdapter {
                 supportsDelayedStackTraceLoading: true,
                 supportsLogPoints: false,
                 supportsTerminateRequest: true,
-                supportsTerminateDebuggee: true,
+                supportTerminateDebuggee: true,
                 supportsRestartRequest: false,
                 supportsValueFormattingOptions: false,
                 supportsClipboardContext: false,
@@ -618,7 +618,7 @@ export class ERSTDebugSession implements vscode.DebugAdapter {
                 success: true,
                 command: 'stackTrace',
                 body: { stackFrames: [], totalFrames: 0 },
-            } as DebugProtocol.StackTraceResponse);
+            });
             return;
         }
 
@@ -634,7 +634,7 @@ export class ERSTDebugSession implements vscode.DebugAdapter {
                 success: true,
                 command: 'stackTrace',
                 body: { stackFrames: [], totalFrames: 0 },
-            } as DebugProtocol.StackTraceResponse);
+            });
             return;
         }
 
@@ -699,7 +699,7 @@ export class ERSTDebugSession implements vscode.DebugAdapter {
                 success: true,
                 command: 'scopes',
                 body: { scopes: [] },
-            } as DebugProtocol.ScopesResponse);
+            });
         }
 
         const frameId = request.arguments.frameId;
@@ -893,7 +893,7 @@ export class ERSTDebugSession implements vscode.DebugAdapter {
                     type: 'object',
                     presentationHint: 'normal',
                 },
-            } as DebugProtocol.EvaluateResponse);
+            });
         } else {
             this.sendMessage({
                 type: 'response',
@@ -1073,11 +1073,18 @@ export class ERSTDebugSession implements vscode.DebugAdapter {
         }
     }
 
+    /**
+     * Disposes the debug session, required by `vscode.DebugAdapter`.
+     */
+    dispose(): void {
+        this.cleanup();
+    }
+
     // ------------------------------------------------------------------
     // Message Sending Helpers
     // ------------------------------------------------------------------
 
-    private sendMessage(msg: DebugProtocol.Message): void {
+    private sendMessage(msg: any): void {
         this._onDidSendMessage.fire(msg);
     }
 
@@ -1186,7 +1193,7 @@ export class ERSTDebugAdapterFactory
     createDebugAdapterDescriptor(
         _session: vscode.DebugSession
     ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
-        return new vscode.DebugInlineAdapter(new ERSTDebugSession());
+        return new vscode.DebugAdapterInlineImplementation(new ERSTDebugSession());
     }
 }
 

--- a/erst_extension/src/extension.ts
+++ b/erst_extension/src/extension.ts
@@ -16,7 +16,7 @@ import { Worker } from 'worker_threads';
 import * as path from 'path';
 
 export function activate(context: vscode.ExtensionContext) {
-    const client = new ERSTClient*'127.0.0.1', 8080);
+    const client = new ERSTClient('127.0.0.1', 8080);
     let treeView: vscode.TreeView<vscode.TreeItem> | undefined;
     let traceDataProvider: TraceTreeDataProvider;
 
@@ -27,7 +27,7 @@ export function activate(context: vscode.ExtensionContext) {
     (traceDataProvider as any).treeView = treeView;
 
     // Load initial trace in background worker to avoid blocking activation
-    const workspaceRoot = vscode.workspace.workspaceFolders?[0]?.uri.fsPath;
+    const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     if (workspaceRoot) {
         const tracePath = path.join(workspaceRoot, '.erst', 'trace.json');
         const worker = new Worker(path.join(__dirname, 'worker.js'));
@@ -102,7 +102,7 @@ export function activate(context: vscode.ExtensionContext) {
             content: stepJson,
             language: 'json'
         }).then((doc: vscode.TextDocument) => {
-            vscode.window.showTextDocument(doc, vscode.ViewColumn.BeSide);
+            vscode.window.showTextDocument(doc, vscode.ViewColumn.Beside);
         });
     });
 
@@ -129,7 +129,7 @@ export function activate(context: vscode.ExtensionContext) {
 
         const defaultBase = `${trace.transaction_hash || 'trace'}-trace-tree.html`;
         const defaultDir =
-            vscode.workspace.workspaceFolders?[0]?.uri ?? context.globalStorageUri;
+            vscode.workspace.workspaceFolders?.[0]?.uri ?? context.globalStorageUri;
         const defaultUri = vscode.Uri.joinPath(defaultDir, defaultBase);
         const htmlTarget = await vscode.window.showSaveDialog({
             title: 'Export trace tree as standalone HTML',
@@ -161,7 +161,7 @@ export function activate(context: vscode.ExtensionContext) {
             content: xdr,
             language: 'text'
         }).then((doc: vscode.TextDocument) => {
-            vscode.window.showTextDocument(doc, vscode.ViewColumn.BeSide);
+            vscode.window.showTextDocument(doc, vscode.ViewColumn.Beside);
         });
     });
 
@@ -206,7 +206,7 @@ export function activate(context: vscode.ExtensionContext) {
     // This enables VS Code's native step-through debugging of Soroban
     // transaction traces via the Debug Adapter Protocol.
     const debugAdapterFactory = new ERSTDebugAdapterFactory();
-    const debugAdapterDisposable = vscode.debug.registerDebugAdapterDascriptorFactory(
+    const debugAdapterDisposable = vscode.debug.registerDebugAdapterDescriptorFactory(
         ERST_DEBUG_TYPE,
         debugAdapterFactory
     );

--- a/erst_extension/src/providers/hoverProvider.ts
+++ b/erst_extension/src/providers/hoverProvider.ts
@@ -49,7 +49,7 @@ export class TraceHoverProvider implements vscode.HoverProvider {
         }
 
         const markdown = new vscode.MarkdownString();
-        markdown.appendMarkdown(`**ERST value for** \\`${variableName}\\`\n\n`);
+        markdown.appendMarkdown(`**ERST value for** \`${variableName}\`\n\n`);
         markdown.appendCodeblock(JSON.stringify(matchedValue, null, 2), 'json');
         markdown.isTrusted = true;
 

--- a/erst_extension/src/test/suite/extension.test.ts
+++ b/erst_extension/src/test/suite/extension.test.ts
@@ -2,7 +2,78 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as assert from 'assert';
+import * as net from 'net';
 import * as vscode from 'vscode';
+import type { DebugProtocol } from '@vscode/debugprotocol';
+import {
+    createMessageConnection,
+    StreamMessageReader,
+    StreamMessageWriter,
+} from 'vscode-jsonrpc/node';
+import type { Trace } from '../../erstClient';
+import { ERSTDebugSession } from '../../dap/adapter';
+
+/**
+ * Starts a mock ERST simulator that speaks JSON-RPC over a TCP socket,
+ * matching the protocol used by `ERSTClient`. It answers the
+ * `DebugTransaction` and `GetTrace` requests without a real simulator.
+ */
+function startMockSimulator(): Promise<{
+    port: number;
+    close: () => Promise<void>;
+}> {
+    const trace: Trace = {
+        transaction_hash: 'mock-tx',
+        start_time: '2024-01-01T00:00:00Z',
+        states: [
+            {
+                step: 1,
+                timestamp: '2024-01-01T00:00:00.000Z',
+                operation: 'invoke',
+                function: 'increment',
+                cpu_delta: 10,
+                memory_delta: 5,
+            },
+            {
+                step: 2,
+                timestamp: '2024-01-01T00:00:00.100Z',
+                operation: 'store',
+                cpu_delta: 5,
+                memory_delta: 2,
+            },
+        ],
+    };
+
+    return new Promise((resolve, reject) => {
+        const sockets = new Set<net.Socket>();
+        const server = net.createServer((socket) => {
+            sockets.add(socket);
+            socket.on('close', () => sockets.delete(socket));
+            const connection = createMessageConnection(
+                new StreamMessageReader(socket),
+                new StreamMessageWriter(socket)
+            );
+            connection.onRequest('DebugTransaction', () => ({ ok: true }));
+            connection.onRequest('GetTrace', () => trace);
+            connection.listen();
+        });
+        server.on('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+            const address = server.address() as net.AddressInfo;
+            resolve({
+                port: address.port,
+                close: () =>
+                    new Promise<void>((res) => {
+                        for (const socket of sockets) {
+                            socket.destroy();
+                        }
+                        sockets.clear();
+                        server.close(() => res());
+                    }),
+            });
+        });
+    });
+}
 
 suite('ERST Extension', () => {
     const EXTENSION_ID = 'hintents.erst-vscode';
@@ -49,5 +120,139 @@ suite('ERST Extension', () => {
             erstViews.some((v: { id: string }) => v.id === 'erst-traces'),
             'erst-traces view should be registered in erst-explorer'
         );
+    });
+
+    test('ERST debug session drives the DAP protocol against a mocked simulator', async () => {
+        const mock = await startMockSimulator();
+
+        try {
+            // Instantiate the real inline debug adapter in the test runner and
+            // drive it through the Debug Adapter Protocol, while its ERSTClient
+            // talks to the mocked simulator over a real TCP JSON-RPC connection.
+            const session = new ERSTDebugSession();
+            const responses: DebugProtocol.Response[] = [];
+            const events: DebugProtocol.Event[] = [];
+            const subscription = session.onDidSendMessage((message: any) => {
+                if (message.request_seq !== undefined) {
+                    responses.push(message as DebugProtocol.Response);
+                } else {
+                    events.push(message as DebugProtocol.Event);
+                }
+            });
+
+            // Sends a DAP request and resolves with its matching response body.
+            let seqCounter = 1;
+            const send = (
+                command: string,
+                args?: unknown
+            ): Promise<DebugProtocol.Response['body']> =>
+                new Promise((resolve, reject) => {
+                    const requestSeq = seqCounter++;
+                    const timer = setTimeout(() => {
+                        reject(new Error(`Timed out waiting for response: ${command}`));
+                    }, 15000);
+                    session.handleMessage({
+                        type: 'request',
+                        seq: requestSeq,
+                        command,
+                        arguments: args,
+                    } as unknown as DebugProtocol.Request);
+
+                    const check = (): void => {
+                        const response = responses.find(
+                            (r) => r.request_seq === requestSeq
+                        );
+                        if (response) {
+                            clearTimeout(timer);
+                            if (response.success) {
+                                resolve(response.body);
+                            } else {
+                                reject(new Error(JSON.stringify(response.body?.error)));
+                            }
+                            return;
+                        }
+                        setTimeout(check, 25);
+                    };
+                    check();
+                });
+
+            try {
+                // initialize -> advertises adapter capabilities.
+                const init = await send('initialize', {
+                    clientID: 'test',
+                    columnsStartAt1: true,
+                    linesStartAt1: true,
+                });
+                assert.ok(
+                    (init as DebugProtocol.InitializeResponse['body'])!.supportsConfigurationDoneRequest,
+                    'initialize should advertise configurationDone support'
+                );
+
+                // launch -> connects to the mocked simulator.
+                await send('launch', {
+                    host: '127.0.0.1',
+                    port: mock.port,
+                    transactionHash: 'mock-tx',
+                });
+
+                // configurationDone -> loads the trace and pauses at first step.
+                await send('configurationDone', {});
+                assert.ok(
+                    events.some(
+                        (e) =>
+                            (e as DebugProtocol.StoppedEvent).event === 'stopped'
+                    ),
+                    'configurationDone should emit a stopped event at the first step'
+                );
+
+                // evaluate "step" -> exposes the current trace step.
+                const evalBody = await send('evaluate', {
+                    expression: 'step',
+                    frameId: 0,
+                });
+                const stepResult = (evalBody as DebugProtocol.EvaluateResponse['body']).result;
+                assert.ok(
+                    stepResult,
+                    'evaluate "step" should return a trace step result'
+                );
+                const step = JSON.parse(stepResult);
+                assert.strictEqual(
+                    step.operation,
+                    'invoke',
+                    'evaluate "step" should expose the first trace step'
+                );
+
+                // stackTrace -> the call stack reflects the current operation.
+                const framesBody = await send('stackTrace', { threadId: 1 });
+                const frames = (
+                    framesBody as DebugProtocol.StackTraceResponse['body']
+                ).stackFrames;
+                assert.ok(
+                    frames.length >= 1,
+                    'stackTrace should return at least one frame'
+                );
+                assert.ok(
+                    frames[0].name.includes('invoke'),
+                    'top frame should be the current operation'
+                );
+
+                // threads -> the single simulation thread.
+                const threadsBody = await send('threads');
+                assert.strictEqual(
+                    (
+                        threadsBody as DebugProtocol.ThreadsResponse['body']
+                    ).threads.length,
+                    1,
+                    'threads should return exactly one thread'
+                );
+
+                // disconnect -> clean shutdown.
+                await send('disconnect', {});
+            } finally {
+                subscription.dispose();
+            }
+        } finally {
+            await mock.close();
+        }
     });
 });

--- a/erst_extension/src/worker.ts
+++ b/erst_extension/src/worker.ts
@@ -5,13 +5,14 @@ import { parentPort } from 'worker_threads';
 import * as fs from 'fs';
 
 if (parentPort) {
-    parentPort.on('message', (msg: any) => {
+    const port = parentPort;
+    port.on('message', (msg: any) => {
         if (msg.type === 'loadTrace') {
             try {
-                const trace = JSON.parse(fs.readFileSync(msg.filePlth, 'utf8'));
-                parentPort.postMessage({ type: 'traceLoaded', trace });
+                const trace = JSON.parse(fs.readFileSync(msg.filePath, 'utf8'));
+                port.postMessage({ type: 'traceLoaded', trace });
             } catch (err: any) {
-                parentPort.postMessage({ type: 'traceLoadError', error: err.message });
+                port.postMessage({ type: 'traceLoadError', error: err.message });
             }
         }
     });


### PR DESCRIPTION
## Summary

Closes #1821

Adds automated testing for the VS Code extension's debugging experience. Previously the debug adapter had **no automated tests at all**. This PR uses the VS Code extension test runner to mock a debug session and drive the real inline debug adapter through the Debug Adapter Protocol (DAP), validating the full debugging flow in CI.

### New test — `erst_extension/src/test/suite/extension.test.ts`
`ERST debug session drives the DAP protocol against a mocked simulator`:
- Spins up a **mock ERST simulator** — a real TCP JSON-RPC server matching the protocol used by `ERSTClient` — answering `DebugTransaction` and `GetTrace` without a real simulator.
- Instantiates the real `ERSTDebugSession` adapter (imported from `src/dap/adapter.ts`) and drives it through the DAP request cycle:
  - `initialize` → verifies `configurationDone` is advertised
  - `launch` → connects to the mocked simulator
  - `configurationDone` → loads the trace and emits a `stopped` event at the first step
  - `evaluate "step"` → exposes the current trace step (`invoke`)
  - `stackTrace` → call stack reflects the current operation
  - `threads` → reports the single simulation thread
  - `disconnect` → clean shutdown
- Runs inside the extension host test runner, so it exercises the real adapter + `ERSTClient` socket communication, not a unit stub.

### Pre-existing blockers fixed so the tests can actually run
The extension has not compiled for a while, which blocked any test execution. This PR fixes the compile blockers (out of scope of the original issue but required to make the suite pass):

- **`package.json`**: removed a stray brace that pushed the `debuggers` contribution out of `contributes` (the file was invalid JSON), and bumped `@vscode/debugprotocol` to `^1.68.0` — the previously pinned `^1.73.0` does not exist on npm, so `npm install` failed and the debug adapter could not resolve types.
- **`src/dap/adapter.ts`**: aligned the adapter with the current `vscode` / `@vscode/debugprotocol` types (`DebugProtocolMessage` event, `DebugAdapterInlineImplementation`, `supportTerminateDebuggee`, typed request/response casts, empty `stackTrace`/`scopes`/`evaluate` responses) and added the required `dispose()`.
- **`src/extension.ts`** & **`src/providers/hoverProvider.ts`**: fixed corrupted syntax (`ERSTClient` constructor, optional-chain `workspaceFolders?.[0]`, `ViewColumn.Beside`, `registerDebugAdapterDescriptorFactory`, a broken markdown backtick escape).
- **`src/worker.ts`**: fixed a corrupted `filePath` field and `parentPort` null-safety.

### Verification
- `npm run compile` — passes (0 errors)
- `npm run lint` — passes (0 warnings/errors)
- `npm run test` — full integration suite via `@vscode/test-electron` (headless via `xvfb`) — **5/5 passing**
- `npm run test:unit` — **2/2 passing**

## Test plan
```
cd erst_extension
npm install
npm run compile
npm run lint
npm run test    # requires a display (e.g. xvfb-run) in headless CI
```
