### PR TITLE
feat(extension): implement DAP stepBack request for simulator snapsho…

### DIFF
--- a/erst_extension/src/dap/adapter.ts
+++ b/erst_extension/src/dap/adapter.ts
@@ -161,6 +161,9 @@ export class ERSTDebugSession implements vscode.DebugAdapter {
                 case 'stepOut':
                     this.handleStepOut(request);
                     break;
+                case 'stepBack':
+                    this.handleStepBack(request);
+                    break;
                 case 'pause':
                     this.handlePause(request);
                     break;
@@ -590,6 +593,36 @@ export class ERSTDebugSession implements vscode.DebugAdapter {
             success: true,
             command: 'stepOut',
         } as DebugProtocol.StepOutResponse);
+
+        this.sendStoppedEvent('step');
+    }
+
+    private handleStepBack(request: DebugProtocol.StepBackRequest): void {
+        if (!this.trace || this.currentStepIndex <= 0) {
+            this.sendMessage({
+                type: 'response',
+                request_seq: request.seq,
+                success: true,
+                command: 'stepBack',
+            } as DebugProtocol.StepBackResponse);
+            return;
+        }
+
+        this.currentStepIndex--;
+        const step = this.trace.states[this.currentStepIndex];
+
+        // Log step info
+        this.sendEventMessage(
+            'stdout',
+            `ERST: Stepped back to ${this.currentStepIndex + 1}/${this.trace.states.length}: ${step.operation}${step.function ? ` (${step.function})` : ''}\n`
+        );
+
+        this.sendMessage({
+            type: 'response',
+            request_seq: request.seq,
+            success: true,
+            command: 'stepBack',
+        } as DebugProtocol.StepBackResponse);
 
         this.sendStoppedEvent('step');
     }


### PR DESCRIPTION
Closes #1815 

This PR implements the DAP `stepBack` request in the debug adapter, exposing the time-travel debugging capabilities of the simulator to the VS Code UI.

**Changes:**
- Plumbed the `stepBack` command through the debug adapter protocol's `handleMessage` router.
- Added `handleStepBack` which safely decrements the internal step index and coordinates snapshot restoration without re-fetching from the backend since the trace already contains discrete memory and host state snapshots.
- Sends the proper `step` event backward so VS Code updates its variable/scopes UI to reflect the previous snapshot in the trace array.
