### PR TITLE
perf(simulator): compile JSON schema once instead of per-request

### DIFF
--- a/simulator/src/ipc/validate.rs
+++ b/simulator/src/ipc/validate.rs
@@ -13,22 +13,27 @@
 //
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
+use once_cell::sync::Lazy;
 use serde_json::Value;
+
+/// The schema is embedded at compile time and parsed+compiled exactly once,
+/// on first use, instead of on every incoming request.
+static COMPILED_SCHEMA: Lazy<jsonschema::Validator> = Lazy::new(|| {
+    let schema_json = include_str!("../../../docs/schema/simulation-request.schema.json");
+    let schema: Value = serde_json::from_str(schema_json)
+        .unwrap_or_else(|e| panic!("invalid embedded schema JSON: {e}"));
+    jsonschema::validator_for(&schema)
+        .unwrap_or_else(|e| panic!("schema compilation failed: {e}"))
+});
 
 /// Validates JSON input against the simulation-request.schema.json
 #[allow(dead_code)]
 pub fn validate_request(input: &str) -> Result<Value, String> {
-    // include the schema at compile-time
-    let schema_json = include_str!("../../../docs/schema/simulation-request.schema.json");
-    let schema: Value =
-        serde_json::from_str(schema_json).map_err(|e| format!("invalid schema JSON: {}", e))?;
-    let compiled = jsonschema::validator_for(&schema)
-        .map_err(|e| format!("schema compilation failed: {}", e))?;
-
     // parse the incoming JSON
     let instance: Value = serde_json::from_str(input).map_err(|e| e.to_string())?;
 
-    // validate against the schema
+    // validate against the globally compiled schema (compiled once, lazily)
+    let compiled = &*COMPILED_SCHEMA;
     let errors: Vec<String> = compiled
         .iter_errors(&instance)
         .map(|e| e.to_string())


### PR DESCRIPTION
## Summary

Closes #1650

This PR eliminates a per-request performance bottleneck in the simulator's IPC validation layer: the JSON Schema was being **parsed and compiled on every single incoming request**, even though the schema is static (embedded at compile time via `include_str!` and never changes at runtime).

### The problem

In `simulator/src/ipc/validate.rs`, `validate_request()` performed the full pipeline on each call:

1. `include_str!` the schema source (cheap, compile-time)
2. `serde_json::from_str` — parse the schema JSON **every request**
3. `jsonschema::validator_for` — compile the schema into a validator **every request**

Schema compilation is by far the dominant cost here, and it was pure waste: the result is deterministic and identical for every request.

### The fix

The compiled validator is now stored in a process-global `static COMPILED_SCHEMA: Lazy<jsonschema::Validator>` (via `once_cell::sync::Lazy`):

- Compiled **exactly once**, lazily, on first use (thread-safe initialization on first access)
- Subsequent requests reuse the already-compiled validator
- `validate_request()` now only does the work that actually varies per request: parsing the incoming JSON and running `iter_errors` against the cached validator
- If the embedded schema were ever invalid, compilation failures panic at first use with a clear message (fail-fast, since it's a build-time-embedded invariant, not user input)

### Changes

- `simulator/src/ipc/validate.rs`
  - Added `static COMPILED_SCHEMA: Lazy<jsonschema::Validator>` with `include_str!` + `serde_json::from_str` + `jsonschema::validator_for`
  - Removed per-call schema parse/compile from `validate_request`
  - Public behavior and error format for instance validation are unchanged

### Why `once_cell` over `lazy_static`

The issue suggested either; `once_cell::sync::Lazy` was chosen because it's std-lib-adjacent (slated for std stabilization), has no macro machinery, and integrates cleanly as a plain `static`. If the crate already standardizes on `lazy_static` elsewhere, this is a trivial swap — happy to change it.

### Performance impact

- **Before:** 1 JSON parse + 1 schema compile per request (O(schema size) work every call)
- **After:** 1 JSON parse + 1 schema compile total per process, then O(1) lookup + validation per request

For high-throughput IPC traffic this removes the dominant fixed overhead per message; validation itself (`iter_errors`) is untouched.

## Test plan

- [x] Behavior-preserving refactor: same inputs → same `Result<Value, String>` outputs and error strings
- [x] Verified the branch builds with the existing `simulator` crate toolchain
- [ ] CI green on this PR

## Checklist

- [x] Scope limited to the file named in the issue (`simulator/src/ipc/validate.rs`)
- [x] Branch is up to date with `upstream/main`